### PR TITLE
(PE-3992) Remove 'not-found' route (again)

### DIFF
--- a/src/clj/puppetlabs/master/services/master/master_core.clj
+++ b/src/clj/puppetlabs/master/services/master/master_core.clj
@@ -34,8 +34,7 @@
     (compojure/context "/v2.0" request
                        (request-handler request))
     (compojure/context "/:environment" [environment]
-                       (legacy-routes request-handler environment))
-    (route/not-found "Not Found")))
+                       (legacy-routes request-handler environment))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public


### PR DESCRIPTION
Remove the 'not-found' route / 404 handler from the compojure app.  This
was already deleted once, but resurrected accidentally (by me) in a
botched merge conflict resolution.

Replaces https://github.com/puppetlabs/pe-jvm-puppet-extensions/pull/87
