### PR TITLE
Fix broken acceptable_exit_codes.

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -19,7 +19,7 @@ module JVMPuppetExtensions
           next if host['roles'].include? 'master'
 
           step "Agents: Run agent --test first time to gen CSR"
-          on host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [1,0]
+          on host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0]
         end
 
       end


### PR DESCRIPTION
Matches that used by puppet acceptance ruby library.

Signed-off-by: Wayne wayne@puppetlabs.com
