### PR TITLE
Remove jvmpuppet repo config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,69 +2,17 @@ PROJECT_ROOT = File.dirname(__FILE__)
 ACCEPTANCE_ROOT = File.join(PROJECT_ROOT, 'acceptance')
 SPEC_TEST_GEMS = 'vendor/spec_test_gems'
 
-def get_platform_map ()
-  platform = ENV['PLATFORM']
-  arch = ENV['ARCH']
-
-  if platform =~ /(el-|fedora-)(.*)/
-    package_type = "rpm"
-    config_suffix = "repo"
-    platform_name = "#{platform}-#{arch}"
-  elsif platform =~ /(debian|ubuntu)(.*)/
-    package_type = "deb"
-    config_suffix = "list"
-    case platform
-    when "ubuntu-1004"
-      platform_name = "lucid"
-    when "ubuntu-1204"
-      platform_name = "precise"
-    when "debian-6"
-      platform_name = "squeeze"
-    when "debian-7"
-      platform_name = "wheezy"
-    else
-      abort "Unsupported debian-based platform!"
-    end
-  end
-
-  {:name => platform_name || nil,
-   :platform => platform || nil,
-   :arch => arch || nil,
-   :package_type => package_type || nil,
-   :config_suffix => config_suffix || nil
-  }
-end
-
-def assemble_default_jvmpuppet_repo_config (platform)
-  if ENV["JVMPUPPET_REPO_CONFIG"]
-    return ENV["JVMPUPPET_REPO_CONFIG"]
-  end
-
-  package_build_name = ENV["PACKAGE_BUILD_NAME"]
-  package_build_version = ENV["PACKAGE_BUILD_VERSION"]
-
-  if package_build_name and package_build_version and
-    platform[:name] and platform[:config_suffix]
-    repo_config = "http://builds.puppetlabs.lan/"
-    repo_config += "#{package_build_name}/#{package_build_version}/"
-    repo_config += "repo_configs/#{platform[:package_type]}/"
-    repo_config += "pl-#{package_build_name}-#{package_build_version}-"
-    repo_config += "#{platform[:name]}.#{platform[:config_suffix]}"
-  else
-    abort "Must specify an appropriate value for JVMPUPPET_REPO_CONFIG. See acceptance/README.md"
-  end
-
-  return repo_config
-end
-
-def assemble_default_beaker_config (platform)
+def assemble_default_beaker_config 
   if ENV["BEAKER_CONFIG"]
     return ENV["BEAKER_CONFIG"]
   end
 
-  if platform[:name] and platform[:arch]
+  platform = ENV['PLATFORM']
+  layout = ENV['LAYOUT']
+
+  if platform and layout
     beaker_config = "#{ACCEPTANCE_ROOT}/config/beaker/jenkins/"
-    beaker_config += "#{platform[:platform]}-#{platform[:arch]}.cfg"
+    beaker_config += "#{platform}-#{layout}.cfg"
   else
     abort "Must specify an appropriate value for BEAKER_CONFIG. See acceptance/README.md"
   end
@@ -116,10 +64,7 @@ namespace :test do
       loadpath = ENV["BEAKER_LOADPATH"] || ""
 
       # variables requiring some assembly
-      platform = get_platform_map
-      ENV['PLATFORM_NAME'] = platform[:name]
-      ENV['JVMPUPPET_REPO_CONFIG'] = assemble_default_jvmpuppet_repo_config(platform)
-      config = assemble_default_beaker_config(platform)
+      config = assemble_default_beaker_config
 
       # variables that take a limited set of acceptable strings
       type = ENV["BEAKER_TYPE"] || "pe"

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -99,7 +99,7 @@ through the command line:
 The Rakefile in jvm-puppet top-level directory is used during acceptance testing
 in the Jenkins CI pipeline to run various types of acceptance test in a
 consistent and reliable fashion. There are at least two expected workflows, one
-where BEAKER_CONFIG and JVMPUPPET_REPO_CONFIG are set manually prior to running the
+where BEAKER_CONFIG and PACKAGE_BUILD_VERSION are set manually prior to running the
 acceptance rake task, and another where values for those variables are
 calculated based on the values of other variables (see Workflow b below).
 
@@ -110,7 +110,7 @@ laptop.
 
     bundle install --path vendor/bundle
     export BEAKER_CONFIG=./acceptance/config/beaker/jenkins/debian-7-i386.cfg
-    export JVMPUPPET_REPO_CONFIG=http://builds.puppetlabs.lan/jvm-puppet/0.1.2.SNAPSHOT.2014.05.12T1408/repo_configs/deb/pl-jvm-puppet-0.1.2.SNAPSHOT.2014.05.12T1408-wheezy.list
+    export PACKAGE_BUILD_VERSION=0.1.2.SNAPSHOT.2014.05.12T1408
     export BEAKER_OPTS="--keyfile /home/username/downloads/id_rsa-acceptance"
     bundle exec rake test:acceptance:beaker 
 
@@ -121,8 +121,8 @@ repeated connection refused errors in Beaker's output.
 #### Rakefile Workflow b: "Jenkins" vSphere Hypervisor
 
 The following is a workflow that duplicates what happens in 'Workflow a' above
-by using PACKAGE_BUILD_NAME, PACKAGE_BUILD_VERSION, PLATFORM, and ARCH to
-produce the same values of BEAKER_CONFIG and JVMPUPPET_REPO_CONFIG as seen above
+by using PACKAGE_BUILD_NAME, PACKAGE_BUILD_VERSION, PLATFORM, and LAYOUT to
+produce the same values of BEAKER_CONFIG and PACKAGE_BUILD_VERSION as seen above
 in a ruby function. It is primarily intended for use in Jenkins
 acceptance/integration test jobs.
 
@@ -130,14 +130,14 @@ acceptance/integration test jobs.
     export PACKAGE_BUILD_NAME=jvm-puppet
     export PACKAGE_BUILD_VERSION=0.1.2.SNAPSHOT.2014.05.12T1408
     export PLATFORM=debian-7
-    export ARCH=i386
+    export LAYOUT=i386
     export BEAKER_OPTS="--keyfile /home/username/downloads/id_rsa-acceptance"
     bundle exec rake test:acceptance:beaker 
 
 PACKAGE_BUILD_NAME and PACKAGE_BUILD_VERSION are build parameters available as
 environment variables in the Jenkins 'execute shell script' build step.
 
-PLATFORM and ARCH are matrix parameters set for acceptance test Jenkins jobs.
+PLATFORM and LAYOUT are matrix parameters set for acceptance test Jenkins jobs.
 They are also available within the 'execute shell script' build step as
 environment variables.
 
@@ -147,15 +147,18 @@ The following workflow is intended to demonstrate running on a local machine
 using a vagrant hypervisor.
 
     bundle install --path vendor/bundle
-    export BEAKER_CONFIG=./acceptance/config/beaker/jenkins/debian-7-i386.cfg
-    export JVMPUPPET_REPO_CONFIG=http://builds.puppetlabs.lan/jvm-puppet/0.1.2.SNAPSHOT.2014.05.12T1408/repo_configs/deb/pl-jvm-puppet-0.1.2.SNAPSHOT.2014.05.12T1408-wheezy.list
+    export BEAKER_CONFIG=./acceptance/config/beaker/vbox/el6/64/1host.cfg
+    export PACKAGE_BUILD_VERSION=0.1.2.SNAPSHOT.2014.05.12T1408
+	bundle exec rake test:acceptance:beaker
 
 ### Environment Variables
 The following is a list of environment variables are supported by the
 test:acceptance:beaker Rake task and descriptions of the effect each has.
 
-* $JVMPUPPET_REPO_CONFIG 
-  * Default: None, fail loudly if no JVMPUPPET_REPO_CONFIG available.
+* $PACKAGE_BUILD_VERSION
+  * Default: None, fail loudly if no PACKAGE_BUILD_VERSION available.
+  * Example: 0.1.2.SNAPSHOT.2014.05.12T1408
+    export PACKAGE_BUILD_VERSION=0.1.2.SNAPSHOT.2014.05.12T1408
   * Description: This variable is used by the Beaker pre_suite to obtain a
   package repository configuration file used by yum or apt on the System Under
   Test. It is expected that this url will become available for a particular

--- a/acceptance/suites/pre_suite/05_standard_repos.rb
+++ b/acceptance/suites/pre_suite/05_standard_repos.rb
@@ -1,6 +1,11 @@
 step "Setup JVM Puppet repositories." do
   hosts.each do |host|
-    install_jvmpuppet_repos_on host
+    package_build_version = ENV['PACKAGE_BUILD_VERSION']
+    if package_build_version
+      install_dev_repos_on 'jvm-puppet', host, package_build_version, "repo_configs"
+    else
+      abort("Missing required PACKAGE_BUILD_VERSION!")
+    end
   end
 end
 

--- a/acceptance/suites/pre_suite/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/70_install_puppet.rb
@@ -5,4 +5,4 @@ step "Install MRI Puppet Agents."
   end
 
 step "Install JVM Puppet Master."
-  custom_install_puppet_package master, 'jvm-puppet' 
+  custom_install_puppet_package master, 'jvm-puppet'


### PR DESCRIPTION
@cprice404 You expressed some doubt about parsing for jvmpuppt_repo_config in an earlier PR and I think you were right. After reviewing Classifier and Puppet acceptance testing more closely, I see that the "platform" parameter in the Beaker config file can be used to the same effect in the pre_suite.
