### PR TITLE
(PE-4271) Adjusted Ruby Puppet endpoint defs and response handling

### DIFF
--- a/src/clj/puppetlabs/master/services/handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/master/services/handler/request_handler_core.clj
@@ -22,12 +22,10 @@
   [response]
   { :pre [(instance? JRubyPuppetResponse response)]
     :post [(map? %)] }
-  (let [body (slurp (.getBody response))]
-    { :status   (.getStatus response)
-      :body     body
-      :headers  { "Content-Type"      (.getContentType response)
-                  "Content-Length"    (str (count body))
-                  "X-Puppet-Version"  (.getPuppetVersion response)} }))
+    { :status  (.getStatus response)
+      :body    (.getBody response)
+      :headers {"Content-Type"     (.getContentType response)
+                "X-Puppet-Version" (.getPuppetVersion response)}})
 
 (defn as-jruby-request
   "Given a ring HTTP request, return a new map that contains all of the data

--- a/src/clj/puppetlabs/master/services/master/master_core.clj
+++ b/src/clj/puppetlabs/master/services/master/master_core.clj
@@ -16,15 +16,17 @@
   (compojure/routes
     ; TODO there are a bunch more that we'll need to add here
     ; https://tickets.puppetlabs.com/browse/PE-3977
-    (compojure/GET "/node/:node-certificate-name" request
+    (compojure/GET "/node/*" request
                    (request-handler environment request))
-    (compojure/GET "/file_metadatas/:file" request
+    (compojure/GET "/file_content/*" request
                    (request-handler environment request))
-    (compojure/GET "/file_metadata/:file" request
+    (compojure/GET "/file_metadatas/*" request
                    (request-handler environment request))
-    (compojure/POST "/catalog/:node-certificate-name" request
+    (compojure/GET "/file_metadata/*" request
+                   (request-handler environment request))
+    (compojure/POST "/catalog/*" request
                     (request-handler environment request))
-    (compojure/PUT "/report/:node-certificate-name" request
+    (compojure/PUT "/report/*" request
                    (request-handler environment request))))
 
 (defn root-routes

--- a/src/java/com/puppetlabs/master/JRubyPuppetResponse.java
+++ b/src/java/com/puppetlabs/master/JRubyPuppetResponse.java
@@ -1,7 +1,5 @@
 package com.puppetlabs.master;
 
-import java.io.Reader;
-
 /**
  * This class is a simple data structure that contains the response to an
  * agent -> master HTTP request, including all information
@@ -14,13 +12,13 @@ import java.io.Reader;
  */
 public class JRubyPuppetResponse {
     private final Integer status;
-    private final Reader body;
+    private final Object body;
     private final String contentType;
     private final String puppetVersion;
 
     public JRubyPuppetResponse(
             Integer status,
-            Reader body,
+            Object body,
             String contentType,
             String puppetVersion) {
         this.status = status;
@@ -29,7 +27,7 @@ public class JRubyPuppetResponse {
         this.puppetVersion = puppetVersion;
     }
 
-    public Reader getBody() {
+    public Object getBody() {
         return body;
     }
 

--- a/src/ruby/jvm-puppet-lib/puppet/jvm/master.rb
+++ b/src/ruby/jvm-puppet-lib/puppet/jvm/master.rb
@@ -90,9 +90,9 @@ class Puppet::Jvm::Master
     body = response[:body]
     body_to_return =
         if body.is_a? String
-          java.io.StringReader.new(body)
+          body
         elsif body.is_a? IO
-          java.io.InputStreamReader.new(body.to_inputstream)
+          body.to_inputstream
         else
           raise "Don't know how to handle response body from puppet, which is a #{body.class}"
         end


### PR DESCRIPTION
This commit contains the following changes:
- For all of the `legacy-routes` that the master service routes into
  JRubyPuppet, removed the trailing destructuring keywords from the
  definition and replaced with wildcards.  The keywords were not
  necessary because nothing in the Clojure layer used them and core Ruby
  Puppet destructures the URL independently anyway.  Also, for some
  routes where the trailing portion represented a file name --
  file_metadatas and file_metadata -- the keyword prevented the route
  from being a match when the file name portion had more than one level
  e.g., .../file.txt would match but .../somedir or
  .../somedir/somesubdir/file.txt would fail to match.
- Added a route for the "file_content" endpoint so that requests to it
  can be forwarded down into JRubyPuppet.
- Removed the intermediate translation of the response from a
  JRubyPuppet request into a String placed into the response body.  In
  the translation to String from an InputStream, some of the raw bytes
  were inappropriately encoded into a form that the original content was
  lost.  By bypassing the String translation, the original bytes of the
  response are preserved all the way out to the HTTP client.
  
  Related to this, removed the setting of the `Content-Length` header
  in the response map.  This was unnecessary in that the
  `Content-Length` was already being set downstream in the response
  handling anyway and removing it allows the responder to not have to
  realize the full InputStream earlier on in order to calculate the
  length.
