### PR TITLE
(PE-4300) Adds pre_suite testcase to scp log files

### DIFF
--- a/acceptance/suites/pre_suite/99_scp_logs.rb
+++ b/acceptance/suites/pre_suite/99_scp_logs.rb
@@ -1,0 +1,3 @@
+step "Preserve JVM Puppet Log Files"
+  scp_from master, "/var/log/jvm-puppet/jvm-puppet.log", "./"
+  scp_from master, "/var/log/jvm-puppet/jvm-puppet-daemon.log", "./"


### PR DESCRIPTION
This will help reduce the effort necessary to analyze problems that occur during
pre_suite by making log files available in the working directory independent of
whether or not "--preserve-hosts" is enabled.

This has to be put at the end of the pre_suite because that is the only way to
get the log files if the pre_suite fails; if the pre_suite failes, neither the
tests suite nor the post_suite will get run.

Signed-off-by: Wayne wayne@puppetlabs.com
