### PR TITLE
(PE-4355) Fixed pluginsync for directory environments

### DIFF
--- a/src/ruby/jvm-puppet-lib/puppet/jvm/master.rb
+++ b/src/ruby/jvm-puppet-lib/puppet/jvm/master.rb
@@ -57,7 +57,7 @@ class Puppet::Jvm::Master
                :facts_terminus => 'yaml'})
     Puppet.settings.initialize_app_defaults(app_defaults)
 
-    self.class.reset_environment_context()
+    reset_environment_context()
 
     Puppet.settings.use :main, :master, :ssl, :metrics
 
@@ -171,35 +171,34 @@ class Puppet::Jvm::Master
     result
   end
 
-  class << self
-    def reset_environment_context
-      # The following lines were copied for the most part from the run() method
-      # in the Puppet::Application class from .../lib/puppet/application.rb
-      # in core Ruby Puppet code.  The logic in the Puppet::Application class is
-      # executed by the core Ruby Puppet master during its initialization.
-      #
-      # The call to Puppet.base_context is needed in order for the modulepath
-      # settings just implicitly reprocessed for master run mode to be
-      # reset onto the Environment objects that later Ruby Puppet requests
-      # will use (e.g., for agent pluginsyncs).
-      #
-      # It would be better for the logic below to be put in a location where
-      # both the core Ruby Puppet and JVM Puppet masters can use the same
-      # implementation.  A separate ticket, PE-4356, was filed to cover this
-      # follow-on work.
+  private
+  def reset_environment_context
+    # The following lines were copied for the most part from the run() method
+    # in the Puppet::Application class from .../lib/puppet/application.rb
+    # in core Ruby Puppet code.  The logic in the Puppet::Application class is
+    # executed by the core Ruby Puppet master during its initialization.
+    #
+    # The call to Puppet.base_context is needed in order for the modulepath
+    # settings just implicitly reprocessed for master run mode to be
+    # reset onto the Environment objects that later Ruby Puppet requests
+    # will use (e.g., for agent pluginsyncs).
+    #
+    # It would be better for the logic below to be put in a location where
+    # both the core Ruby Puppet and JVM Puppet masters can use the same
+    # implementation.  A separate ticket, PE-4356, was filed to cover this
+    # follow-on work.
 
-      Puppet.push_context(Puppet.base_context(Puppet.settings),
-          "Update for application settings JVM puppet master")
-      configured_environment = Puppet.lookup(:environments).get(
-                                   Puppet[:environment])
-      configured_environment = configured_environment.override_from_commandline(
-                                   Puppet.settings)
+    Puppet.push_context(Puppet.base_context(Puppet.settings),
+        "Update for application settings JVM puppet master")
+    configured_environment = Puppet.lookup(:environments).get(
+                                 Puppet[:environment])
+    configured_environment = configured_environment.override_from_commandline(
+                                 Puppet.settings)
 
-      Puppet.push_context({:current_environment => configured_environment},
-          "Update current environment from JVM puppet master's configuration")
+    Puppet.push_context({:current_environment => configured_environment},
+        "Update current environment from JVM puppet master's configuration")
 
-      require 'puppet/util/instrumentation'
-      Puppet::Util::Instrumentation.init
-    end
+    require 'puppet/util/instrumentation'
+    Puppet::Util::Instrumentation.init
   end
 end


### PR DESCRIPTION
This commit includes some additional initialization for a JRubyPuppet
container which allows the module path settings for directory
environments to be honored, e.g., resources from the module paths
properly included in responses to agent catalog requests.

The Ruby master makes a call to `Puppet.base_context` with the current
`Puppet.settings` after the settings have been initialized for the master
run mode.  This call was not being made from a JVM master after setting
up the environment for the master run mode.  The lack of this call
prevented the directory environment module paths in the master section
of the puppet.conf file from being used by Ruby Puppet Environment
objects during later agent requests.

This commit includes the Puppet.base_context call after the setup for
master run mode.  For parity, this commit also includes some other logic
that the Ruby master performs during initialization.  The new logic is
in the reset_environment_context method of the Puppet::JVM::Master
class.

This commit also removed the `pson_result` private method from the
Puppet::JVM::Master class as it was apparently not referenced anywhere.
