### PR TITLE
(PE-4358) Implement the Compojure route for the facts endpoint

### DIFF
--- a/src/clj/puppetlabs/master/services/master/master_core.clj
+++ b/src/clj/puppetlabs/master/services/master/master_core.clj
@@ -25,6 +25,8 @@
     ; https://tickets.puppetlabs.com/browse/PE-3977
     (compojure/GET "/node/*" request
                    (request-handler environment request))
+    (compojure/GET "/facts/*" request
+                   (request-handler environment request))
     (compojure/GET "/file_content/*" request
                    (request-handler environment request))
     (compojure/GET "/file_metadatas/*" request

--- a/test/puppetlabs/master/services/master/master_core_test.clj
+++ b/test/puppetlabs/master/services/master/master_core_test.clj
@@ -14,7 +14,11 @@
     (is (nil? (request "/foo")))
     (is (nil? (request "/foo/bar")))
     (doseq [[method paths]
-            {:get ["node" "file_content" "file_metadatas" "file_metadata"]
+            {:get ["node"
+                   "facts"
+                   "file_content"
+                   "file_metadatas"
+                   "file_metadata"]
              :post ["catalog"]
              :put ["report"]}
             path paths]


### PR DESCRIPTION
This commit adds a Compojure route to the list of Master `legacy-routes`
for the "/facts" endpoint.
