### PR TITLE
(PE-4384) Implement routes for catalog and resource_type gets

### DIFF
--- a/src/clj/puppetlabs/master/services/master/master_core.clj
+++ b/src/clj/puppetlabs/master/services/master/master_core.clj
@@ -33,9 +33,13 @@
                    (request-handler environment request))
     (compojure/GET "/file_metadata/*" request
                    (request-handler environment request))
+    (compojure/GET "/catalog/*" request
+                   (request-handler environment request))
     (compojure/POST "/catalog/*" request
                     (request-handler environment request))
     (compojure/PUT "/report/*" request
+                   (request-handler environment request))
+    (compojure/GET "/resource_type/*" request
                    (request-handler environment request))))
 
 (defn root-routes

--- a/test/puppetlabs/master/services/master/master_core_test.clj
+++ b/test/puppetlabs/master/services/master/master_core_test.clj
@@ -14,14 +14,24 @@
     (is (nil? (request "/foo")))
     (is (nil? (request "/foo/bar")))
     (doseq [[method paths]
-            {:get ["node"
+            {:get ["catalog"
+                   "node"
                    "facts"
                    "file_content"
                    "file_metadatas"
-                   "file_metadata"]
+                   "file_metadata"
+                   "resource_type"]
              :post ["catalog"]
              :put ["report"]}
             path paths]
       (let [resp (request method (str "/foo/" path "/bar"))]
-        (is (= 200 (:status resp)))
-        (is (= "foo" (:environment resp)))))))
+        (is (= 200 (:status resp))
+            (str "Did not get 200 for method: "
+                 method
+                 ", path: "
+                 path))
+        (is (= "foo" (:environment resp))
+            (str "Did not get expected response for method: "
+                 method
+                 ", path: "
+                 path))))))


### PR DESCRIPTION
This commit implements Compojure GET routes for the "catalog" and
"resource_type" endpoints into JRubyPuppet from JVM-Puppet.  These
routes need to be functional for use with the
security/cve-2013-1652_improper_query_params.rb and
security/cve-2013-4761_resource_type.rb Puppet acceptance tests,
respectively.
