### PR TITLE
(PE-3826) Implement naive autosign

### DIFF
--- a/src/clj/puppetlabs/master/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/master/services/ca/certificate_authority_core.clj
@@ -6,7 +6,7 @@
             [ring.util.response :as rr]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 'handler' functions for HTTP endpoints
+;;; 'Handler' functions for HTTP endpoints
 
 (defn handle-get-certificate
   [subject {:keys [cacert certdir]}]
@@ -22,27 +22,32 @@
         (rr/not-found (str "Could not find certificate_request " subject)))
       (rr/content-type "text/plain")))
 
+(defn signed-csr-response-body
+  [expiration-date subject]
+  ;; TODO return something proper (PE-3178)
+  (str "---\n"
+       "  - !ruby/object:Puppet::SSL::CertificateRequest\n"
+       "name: " subject "\n"
+       "content: !ruby/object:OpenSSL::X509::Request {}\n"
+       "expiration: " expiration-date))
+
 (schema/defn handle-put-certificate-request!
   [subject
    certificate-request
    ca-settings :- ca/CaSettings]
-  (let [expiration-date (ca/autosign-certificate-request!
-                          subject certificate-request ca-settings)]
-    ;; TODO return something proper (PE-3178)
-    (-> (str "---\n"
-             "  - !ruby/object:Puppet::SSL::CertificateRequest\n"
-             "name: " subject "\n"
-             "content: !ruby/object:OpenSSL::X509::Request {}\n"
-             "expiration: " expiration-date)
+  (if (ca/autosign-csr? (:autosign ca-settings))
+    (-> (ca/autosign-certificate-request! subject certificate-request ca-settings)
+        (signed-csr-response-body subject)
         (rr/response)
-        (rr/content-type "text/yaml"))))
+        (rr/content-type "text/yaml"))
+    (do (ca/save-certificate-request! subject certificate-request (:csrdir ca-settings))
+        (rr/content-type (rr/response nil) "text/plain"))))
 
 (defn handle-get-certificate-revocation-list
   [{:keys [cacrl]}]
   (-> (ca/get-certificate-revocation-list cacrl)
       (rr/response)
       (rr/content-type "text/plain")))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Compojure app
@@ -64,6 +69,5 @@
 (schema/defn ^:always-validate
   compojure-app
   [ca-settings :- ca/CaSettings]
-  (->
-    (routes ca-settings)
-    (ringutils/wrap-response-logging)))
+  (-> (routes ca-settings)
+      (ringutils/wrap-response-logging)))

--- a/test/puppetlabs/master/certificate_authority_test.clj
+++ b/test/puppetlabs/master/certificate_authority_test.clj
@@ -37,6 +37,27 @@
   (testing "returns nil when certificate request not found for subject"
     (is (nil? (get-certificate-request "not-there" csrdir)))))
 
+(deftest autosign-csr?-test
+  (testing "boolean values for 'autosign'"
+    (is (true? (autosign-csr? true)))
+    (is (true? (autosign-csr? "true")))
+    (is (false? (autosign-csr? false)))
+    (is (false? (autosign-csr? "false")))
+    (is (false? (autosign-csr? "/foo/bar/autosign.conf")))))
+
+(deftest save-certificate-request!-test
+  (testing "requests are saved to disk"
+    (let [csr-stream (io/input-stream (path-to-cert-request csrdir "test-agent"))
+          path       (path-to-cert-request csrdir "foo")]
+      (try
+        (is (false? (fs/exists? path)))
+        (save-certificate-request! "foo" csr-stream csrdir)
+        (is (true? (fs/exists? path)))
+        (is (= (get-certificate-request csrdir "foo")
+               (get-certificate-request csrdir "test-agent")))
+        (finally
+          (fs/delete path))))))
+
 (deftest autosign-certificate-request!-test
   (let [subject            "test-agent"
         request-stream     (-> csrdir

--- a/test/puppetlabs/master/services/ca/certificate_authority_core_test.clj
+++ b/test/puppetlabs/master/services/ca/certificate_authority_core_test.clj
@@ -1,6 +1,9 @@
 (ns puppetlabs.master.services.ca.certificate-authority-core-test
   (:require [puppetlabs.master.services.ca.certificate-authority-core :refer :all]
-            [clojure.test :refer :all]))
+            [puppetlabs.master.certificate-authority :as ca]
+            [me.raynes.fs :as fs]
+            [clojure.test :refer :all]
+            [clojure.java.io :as io]))
 
 (deftest crl-endpoint-test
   (testing "implementation of the CRL endpoint"
@@ -9,3 +12,50 @@
       (is (= 200 (:status response)))
       (is (= "text/plain" (get-in response [:headers "Content-Type"])))
       (is (string? (:body response))))))
+
+(deftest handle-put-certificate-request!-test
+  (let [ssldir   "./test-resources/config/master/conf/ssl"
+        certdir  (str ssldir "/certs")
+        csrdir   (str ssldir "/ca/requests")
+        settings {:ssl-dir ssldir
+                  :ca-name "some CA"
+                  :cakey   (str ssldir "/ca/ca_key.pem")
+                  :certdir certdir
+                  :csrdir  csrdir
+                  :ca-ttl  100}
+        csr-path (ca/path-to-cert-request csrdir "test-agent")]
+
+    (testing "when autosign is true"
+      (let [settings      (assoc settings :autosign true)
+            csr           (io/input-stream csr-path)
+            expected-path (ca/path-to-cert certdir "test-agent")]
+
+        (testing "it signs the CSR, writes the certificate to disk, and
+                 returns a 200 response with the CSR as a Ruby YAML string"
+          (try
+            (is (false? (fs/exists? expected-path)))
+            (let [response (handle-put-certificate-request! "test-agent" csr settings)]
+              (is (true? (fs/exists? expected-path)))
+              (is (= 200 (:status response)))
+              (is (= "text/yaml" (get-in response [:headers "Content-Type"])))
+              (is (string? (:body response))))
+            (finally
+              (fs/delete expected-path))))))
+
+    (testing "when autosign is false"
+      (let [settings      (assoc settings :autosign false)
+            csr           (io/input-stream csr-path)
+            expected-path (ca/path-to-cert-request csrdir "foo-agent")]
+
+        (testing "it writes the CSR to disk and returns a
+                 200 response with empty plaintext body"
+          (try
+            (is (false? (fs/exists? expected-path)))
+            (let [response (handle-put-certificate-request! "foo-agent" csr settings)]
+              (is (true? (fs/exists? expected-path)))
+              (is (false? (fs/exists? (ca/path-to-cert certdir "foo-agent"))))
+              (is (= 200 (:status response)))
+              (is (= "text/plain" (get-in response [:headers "Content-Type"])))
+              (is (nil? (:body response))))
+            (finally
+              (fs/delete expected-path))))))))


### PR DESCRIPTION
This commit modifies the CA service to honor Puppet's 'autosign' setting,
but only for boolean values (whitelist & executable files coming soon).
If the value of autosign is true, the CSR will be signed and the certificate written to disk.
Note this is the current behavior of our CA, which basically assumes autosign is always true.
If autosign is false, the CSR will be written to disk instead.
