### PR TITLE
Fix install_from_ezbake and preinst bug.

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -272,19 +272,6 @@ module JVMPuppetExtensions
     # install user
     group = ezbake[:group]
     user = ezbake[:user]
-    manifest = <<-EOS
-    group { '#{group}':
-      ensure => present,
-      system => true,
-    }
-    user { '#{user}':
-      ensure => present,
-      gid => '#{group}',
-      managehome => false,
-      system => true,
-    }
-    EOS
-    apply_manifest_on(host, manifest)
 
     # "make" on target
     cd_to_package_dir = "cd /root/" + dir_name + "; "

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -18,8 +18,7 @@ ezbake: {
                preinst: ["usermod -a -G puppet {{user}}",
                          "find /var/lib/puppet -type d -name '*' -exec chmod 775 {} ';'",
                          "find /var/lib/puppet -type f -name '*' -exec chmod 664 {} ';'",
-                         "mkdir -p /etc/puppet/manifests"
-                         "chown -R puppet:puppet /var/lib/puppet/{state,reports}"]
+                         "mkdir -p /etc/puppet/manifests"]
              }
 
       debian: { dependencies: ["puppet (= 3.6.1-puppetlabs1)"],
@@ -27,8 +26,7 @@ ezbake: {
                preinst: ["usermod -a -G puppet {{user}}",
                          "find /var/lib/puppet -type d -name '*' -exec chmod 775 {} ';'",
                          "find /var/lib/puppet -type f -name '*' -exec chmod 664 {} ';'",
-                         "mkdir -p /etc/puppet/manifests"
-                         "chown -R puppet:puppet /var/lib/puppet/{state,reports}"]
+                         "mkdir -p /etc/puppet/manifests"]
              }
    }
 }


### PR DESCRIPTION
This last postinst step was added as a workaround for install_from_ezbake since
install_from_ezbake calls "puppet apply ..." as root to apply a manifest which
adds a user and group.

After giving it some thought, however, in the context of jvm-puppet this
apply_manifest_on call doesn't make any sense since the MRI puppet dependency
should already install the correct user. Even if there are some edge cases where
this doesn't happen, the apply_manifest_on call really doesn't seem the right
way to do it and it probably should not happen within install_from_ezbake.

This fix removes the call to apply_manifest_on and the associated bogus preinst
steps.

Signed-off-by: Wayne wayne@puppetlabs.com
