### PR TITLE
(PE-3238) More extensive testing on certs generated during startup 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/certificate-authority "0.2.0"]
+                 [puppetlabs/certificate-authority "0.2.1"]
                  [puppetlabs/http-client "0.1.7"]
                  [org.jruby/jruby-complete "1.7.10"]
                  [clj-time "0.5.1"]

--- a/test/puppetlabs/master/certificate_authority_test.clj
+++ b/test/puppetlabs/master/certificate_authority_test.clj
@@ -146,6 +146,11 @@
           (is (utils/private-key? key))
           (is (= 512 (utils/keylength key)))))
 
+      (testing "capub"
+        (let [key (-> cadir-contents :capub utils/pem->public-key)]
+          (is (utils/public-key? key))
+          (is (= 512 (utils/keylength key)))))
+
       (finally
         (fs/delete-dir cadir))))
 
@@ -176,6 +181,11 @@
       (testing "hostprivkey"
         (let [key (-> ssldir-contents :hostprivkey utils/pem->private-key)]
           (is (utils/private-key? key))
+          (is (= 512 (utils/keylength key)))))
+
+      (testing "hostpubkey"
+        (let [key (-> ssldir-contents :hostpubkey utils/pem->public-key)]
+          (is (utils/public-key? key))
           (is (= 512 (utils/keylength key)))))
 
       (finally
@@ -221,9 +231,13 @@
         (testing message
           (try
             (f)
-            (is (= expected (-> ca-settings :cakey
+            (is (= expected (-> cadir-contents :cakey
                                 utils/pem->private-key utils/keylength)))
+            (is (= expected (-> cadir-contents :capub
+                                utils/pem->public-key utils/keylength)))
             (is (= expected (-> ssldir-contents :hostprivkey
                                 utils/pem->private-key utils/keylength)))
+            (is (= expected (-> ssldir-contents :hostpubkey
+                                utils/pem->public-key utils/keylength)))
             (finally
               (fs/delete-dir ssldir))))))))


### PR DESCRIPTION
This commit adds file-specific tests for each of the SSL files
generated by the CA during initialization. The main goal here was
just to use the various predicates in jvm-ca to give us at least
some level of appropriate testing beyond simple file existence.

These are not meant to be exhaustive, and there is certainly more
we could be testing. ~~Also, this work has revealed a lack of support
for working with public key files, which when deserialized using
`jvm-ca/pem->objs` results in a BouncyCastle `SubjectPublicKeyInfo`
class that is not immediately useful.
Because of this, there is no testing for the public key files in here.~~
