### PR TITLE
(PE-3178) Don't return serialized Ruby YAML

### DIFF
--- a/src/clj/puppetlabs/master/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/master/services/ca/certificate_authority_core.clj
@@ -22,26 +22,14 @@
         (rr/not-found (str "Could not find certificate_request " subject)))
       (rr/content-type "text/plain")))
 
-(defn signed-csr-response-body
-  [expiration-date subject]
-  ;; TODO return something proper (PE-3178)
-  (str "---\n"
-       "  - !ruby/object:Puppet::SSL::CertificateRequest\n"
-       "name: " subject "\n"
-       "content: !ruby/object:OpenSSL::X509::Request {}\n"
-       "expiration: " expiration-date))
-
 (schema/defn handle-put-certificate-request!
   [subject
    certificate-request
    ca-settings :- ca/CaSettings]
   (if (ca/autosign-csr? (:autosign ca-settings))
-    (-> (ca/autosign-certificate-request! subject certificate-request ca-settings)
-        (signed-csr-response-body subject)
-        (rr/response)
-        (rr/content-type "text/yaml"))
-    (do (ca/save-certificate-request! subject certificate-request (:csrdir ca-settings))
-        (rr/content-type (rr/response nil) "text/plain"))))
+    (ca/autosign-certificate-request! subject certificate-request ca-settings)
+    (ca/save-certificate-request! subject certificate-request (:csrdir ca-settings)))
+  (rr/content-type (rr/response nil) "text/plain"))
 
 (defn handle-get-certificate-revocation-list
   [{:keys [cacrl]}]

--- a/src/clj/puppetlabs/master/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/master/services/jruby/jruby_puppet_core.clj
@@ -251,7 +251,7 @@
   "Sequentially fill each pool with new JRubyPuppet instances."
   [context :- PoolContext]
   (let [config (:config context)]
-    (log/debugf (str "Initializing JRubyPuppet instances with the following settings:"
+    (log/debugf (str "Initializing JRubyPuppet instances with the following settings:\n"
                      "\tload path: %s\n"
                      "\tmaster conf dir: %s")
                 (:load-path config)

--- a/test/puppetlabs/master/services/ca/certificate_authority_core_test.clj
+++ b/test/puppetlabs/master/services/ca/certificate_authority_core_test.clj
@@ -31,14 +31,14 @@
             expected-path (ca/path-to-cert signeddir "test-agent")]
 
         (testing "it signs the CSR, writes the certificate to disk, and
-                 returns a 200 response with the CSR as a Ruby YAML string"
+                 returns a 200 response with empty plaintext body"
           (try
             (is (false? (fs/exists? expected-path)))
             (let [response (handle-put-certificate-request! "test-agent" csr settings)]
               (is (true? (fs/exists? expected-path)))
               (is (= 200 (:status response)))
-              (is (= "text/yaml" (get-in response [:headers "Content-Type"])))
-              (is (string? (:body response))))
+              (is (= "text/plain" (get-in response [:headers "Content-Type"])))
+              (is (nil? (:body response))))
             (finally
               (fs/delete expected-path))))))
 


### PR DESCRIPTION
This commit changes the HTTP response for the PUT CSR request
to an empty plaintext body rather than the unused serialized Ruby YAML.

After these changes were made, the certificate expiration logic was exposed
as being incorrect, and no longer used right now. I deleted the unused code
and removed the relevant portion of the test and put a TODO comment in place
for when we properly support ca-ttl. I pasted the code in the JIRA ticket
(PE-3173) so we can reuse the logic if necessary when we return to it.
