### PR TITLE
(PE-3845) Support autosign whitelist

### DIFF
--- a/src/clj/puppetlabs/master/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/master/services/ca/certificate_authority_core.clj
@@ -26,7 +26,7 @@
   [subject
    certificate-request
    ca-settings :- ca/CaSettings]
-  (if (ca/autosign-csr? (:autosign ca-settings))
+  (if (ca/autosign-csr? (:autosign ca-settings) subject)
     (ca/autosign-certificate-request! subject certificate-request ca-settings)
     (ca/save-certificate-request! subject certificate-request (:csrdir ca-settings)))
   (rr/content-type (rr/response nil) "text/plain"))

--- a/test-resources/config/master/conf/autosign-whitelist.conf
+++ b/test-resources/config/master/conf/autosign-whitelist.conf
@@ -1,0 +1,13 @@
+# This is an autosign.conf whitelist (non-executable) for testing.
+# This file is a list of certnames and domain-name globs.
+# Blank lines and comment lines are allowed.
+# aaa
+bbb123
+    
+*.red
+
+*.blACk.6
+#*.white
+#
+coffee#tea
+qux


### PR DESCRIPTION
There are 2 differences between this and existing Ruby CA:
- This does not return an error response to the agent when an invalid pattern is found in the whitelist.
- Invalid patterns are not fatal - the pattern will be logged, ignored, and evaluation of the list continues.
