### PR TITLE
(MAINT) Update `curl-retries` variable name.

### DIFF
--- a/acceptance/config/beaker/options.rb
+++ b/acceptance/config/beaker/options.rb
@@ -5,6 +5,6 @@
   "service-prefix" => 'service ',
   "service-num-retries" => 1500,
   "puppetservice" => 'jvm-puppet',
-  "curl-retries" => 200,
+  "master-start-curl-retries" => 200,
 }
 

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -94,8 +94,8 @@ module JVMPuppetExtensions
     end
 
     step "Master: Start Puppet Master"
-      old_retries = master['curl-retries']
-      master['curl-retries'] = 1500
+      old_retries = master['master-start-curl-retries']
+      master['master-start-curl-retries'] = 1500
       with_puppet_running_on(master, "main" => { "autosign" => true, "dns_alt_names" => "puppet,#{hostname},#{fqdn}", "verbose" => true, "daemonize" => true }) do
 
         hosts.each do |host|
@@ -106,7 +106,7 @@ module JVMPuppetExtensions
         end
 
       end
-      master['curl-retries'] = old_retries
+      master['master-start-curl-retries'] = old_retries
   end
 
   def jvm_puppet_collect_data(host, relative_path)


### PR DESCRIPTION
Must use `master-start-curl-retries` since Beaker 1.14.1 includes slightly
changed behavior from the old git ref versions.

Signed-off-by: Wayne wayne@puppetlabs.com
