### PR TITLE
(PE-4966) CA initialization fails on partial state

### DIFF
--- a/test/puppetlabs/master/certificate_authority_test.clj
+++ b/test/puppetlabs/master/certificate_authority_test.clj
@@ -427,6 +427,23 @@
           (finally
             (fs/delete-dir ssldir)))))
 
+    (testing "Throws an exception if only some of the files exist"
+      (try
+        ;; Create all the files and directories, then delete some
+        (initialize! ca-settings master-settings "master" 512)
+        (fs/delete-dir (:signeddir ca-settings))
+        (fs/delete (:capub ca-settings))
+
+        ;; Verify exception is thrown with message that contains
+        ;; the paths for both the missing and found files
+        (initialize! ca-settings master-settings "master" 512)
+        (catch IllegalStateException e
+          (doseq [file (vals (settings->cadir-paths ca-settings))]
+            (is (true? (.contains (.getMessage e) file)))))
+
+        (finally
+          (fs/delete-dir ssldir))))
+
     (testing "Keylength"
       (doseq [[message f expected]
               [["can be configured"


### PR DESCRIPTION
MERGE AFTER #85

Prior to this commit, the CA initialization would overwrite
existing files in the case when other required files were missing.
This commit changes this behavior to prevent the CA from starting
by throwing an exception with a message containing the missing and
found files.
