### PR TITLE
(PE-5349) Lay down conf file with correct load path for jvm-puppet

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -19,7 +19,10 @@ ezbake: {
                preinst: ["usermod -a -G puppet {{user}}",
                          "find /var/lib/puppet -type d -name '*' -exec chmod 775 {} ';'",
                          "find /var/lib/puppet -type f -name '*' -exec chmod 664 {} ';'",
-                         "mkdir -p /etc/puppet/manifests"]
+                         "mkdir -p /etc/puppet/manifests"],
+               install: ["echo \\\"os-settings: {\\\"                         > %{buildroot}%{_sysconfdir}/%{realname}/conf.d/os-settings.conf",
+                         "echo \\\"    ruby-load-path: [%{puppet_libdir}]\\\" >> %{buildroot}%{_sysconfdir}/%{realname}/conf.d/os-settings.conf",
+                         "echo \\\"}\\\"                                      >> %{buildroot}%{_sysconfdir}/%{realname}/conf.d/os-settings.conf" ]
              }
 
       debian: { dependencies: ["puppet-common (= 3.6.1-1puppetlabs1)"
@@ -29,7 +32,10 @@ ezbake: {
                preinst: ["usermod -a -G puppet {{user}}",
                          "find /var/lib/puppet -type d -name '*' -exec chmod 775 {} ';'",
                          "find /var/lib/puppet -type f -name '*' -exec chmod 664 {} ';'",
-                         "mkdir -p /etc/puppet/manifests"]
+                         "mkdir -p /etc/puppet/manifests"],
+               install: ["echo \\\"os-settings: {\\\"                       > $(BUILD_ROOT)/$(confdir)/$(realname)/conf.d/os-settings.conf"
+                         "echo \\\"    ruby-load-path: [$(rubylibdir)]\\\"  >> $(BUILD_ROOT)/$(confdir)/$(realname)/conf.d/os-settings.conf",
+                         "echo \\\"}\\\"                                    >> $(BUILD_ROOT)/$(confdir)/$(realname)/conf.d/os-settings.conf"]
              }
    }
 }


### PR DESCRIPTION
In order for jvm-puppet to know where to look to find puppet's ruby
files, it needs to be laid down via a config file. This commit adds that
ability, by laying it down during packaging using already available
variables in the rules and spec files.
