### PR TITLE
(PE-4982) Change acceptance tests to new package name

### DIFF
--- a/acceptance/config/beaker/local/el6/1host.cfg
+++ b/acceptance/config/beaker/local/el6/1host.cfg
@@ -9,7 +9,7 @@ HOSTS:
     ip: 192.168.56.4
     service-wait: true
     service-prefix: 'service '
-    puppetservice: puppet-server
+    puppetservice: puppetserver
     puppetpath: /etc/puppet
     group: puppet
     puppetbin: /usr/bin/puppet

--- a/acceptance/config/beaker/options.rb
+++ b/acceptance/config/beaker/options.rb
@@ -3,7 +3,7 @@
   "service-wait" => true,
   "service-prefix" => 'service ',
   "service-num-retries" => 1500,
-  "puppetservice" => 'puppet-server',
+  "puppetservice" => 'puppetserver',
   "master-start-curl-retries" => 200,
 }
 

--- a/acceptance/config/beaker/vbox/el6/64/1host.cfg
+++ b/acceptance/config/beaker/vbox/el6/64/1host.cfg
@@ -11,7 +11,7 @@ HOSTS:
     box_url: https://vagrantcloud.com/puppetlabs/centos-6.5-64-nocm/version/2/provider/virtualbox.box
     service-wait: true
     service-prefix: 'service '
-    puppetservice: puppet-server
+    puppetservice: puppetserver
     puppetpath: /etc/puppet
     group: puppet
     puppetbin: /usr/bin/puppet

--- a/acceptance/config/beaker/vbox/el6/64/2hosts.cfg
+++ b/acceptance/config/beaker/vbox/el6/64/2hosts.cfg
@@ -11,7 +11,7 @@ HOSTS:
     box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
     service-wait: true
     service-prefix: 'service '
-    puppetservice: puppet-server
+    puppetservice: puppetserver
     puppetpath: /etc/puppet
     group: puppet
     puppetbin: /usr/bin/puppet

--- a/acceptance/config/beaker/vcenter_dual.cfg
+++ b/acceptance/config/beaker/vcenter_dual.cfg
@@ -10,7 +10,7 @@ HOSTS:
     hypervisor: vcloud
     service-wait: true
     service-prefix: 'service '
-    puppetservice: puppet-server
+    puppetservice: puppetserver
     puppetpath: /etc/puppet
     group: puppet
     puppetbin: /usr/bin/puppet

--- a/acceptance/config/beaker/vcenter_mono.cfg
+++ b/acceptance/config/beaker/vcenter_mono.cfg
@@ -10,7 +10,7 @@ HOSTS:
     hypervisor: vcloud
     service-wait: true
     service-prefix: 'service '
-    puppetservice: puppet-server
+    puppetservice: puppetserver
     puppetpath: /etc/puppet
     group: puppet
     puppetbin: /usr/bin/puppet

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -110,13 +110,13 @@ module PuppetServerExtensions
   end
 
   def puppet_server_collect_data(host, relative_path)
-    destination = File.join("./log/latest/puppet-server/", relative_path)
+    destination = File.join("./log/latest/puppetserver/", relative_path)
     FileUtils.mkdir_p(destination)
-    scp_from master, "/var/log/puppet-server/puppet-server.log", destination
-    scp_from master, "/var/log/puppet-server/puppet-server-daemon.log", destination
+    scp_from master, "/var/log/puppetserver/puppetserver.log", destination
+    scp_from master, "/var/log/puppetserver/puppetserver-daemon.log", destination
   end
 
-  def install_puppet_server (host, puppet_server_name='puppet-server', make_env={})
+  def install_puppet_server (host, puppet_server_name='puppetserver', make_env={})
     case test_config[:puppetserver_install_type]
     when :package
       install_package host, puppet_server_name

--- a/acceptance/suites/pre_suite/foss/30_install_release_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_release_repos.rb
@@ -3,7 +3,7 @@ when :package
   step "Setup Puppet Server repositories." do
     package_build_version = ENV['PACKAGE_BUILD_VERSION']
     if package_build_version
-      install_puppetlabs_dev_repo master, 'puppet-server', package_build_version
+      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version
     else
       abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
     end

--- a/acceptance/suites/pre_suite/foss/40_install_jvmpuppet_deps.rb
+++ b/acceptance/suites/pre_suite/foss/40_install_jvmpuppet_deps.rb
@@ -4,7 +4,7 @@ when :git # only if installing from source
     `lein install`
     project_version = test_config[:puppetserver_version] ||
       `lein with-profile ci pprint :version | tail -n 1 | cut -d\\" -f2`
-    ezbake_stage 'puppet-server', project_version
+    ezbake_stage 'puppetserver', project_version
 
     install_ezbake_deps master
 end

--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -25,7 +25,7 @@ step "Install Puppet Server."
   make_env = {
     "prefix" => "/usr",
     "confdir" => "/etc/",
-    "rundir" => "/var/run/puppet-server",
+    "rundir" => "/var/run/puppetserver",
     "initdir" => "/etc/init.d",
   }
-  install_puppet_server master, 'puppet-server', make_env
+  install_puppet_server master, 'puppetserver', make_env

--- a/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
@@ -12,9 +12,9 @@ step "Configure puppet.conf" do
 
   case variant
   when /^(fedora|el|centos)$/
-    defaults_file = '/etc/sysconfig/puppet-server'
+    defaults_file = '/etc/sysconfig/puppetserver'
   when /^(debian|ubuntu)$/
-    defaults_file = '/etc/default/puppet-server'
+    defaults_file = '/etc/default/puppetserver'
   else
     logger.notify("Not sure how to handle defaults for #{variant} yet...")
   end

--- a/acceptance/suites/pre_suite/optional/setup_jvmpuppet.rb
+++ b/acceptance/suites/pre_suite/optional/setup_jvmpuppet.rb
@@ -1,6 +1,6 @@
 step "Configure Puppet Server ." 
   if master['platform'].include? 'el-6'
-    on master, "sed -i.bak -e 's/localhost/#{master}/' /etc/puppet-server/conf.d/puppet-server.ini"
-    on master, "sed -i.bak -e 's/localhost/#{master}/' /etc/puppet-server/conf.d/webserver.ini"
+    on master, "sed -i.bak -e 's/localhost/#{master}/' /etc/puppetserver/conf.d/puppet-server.ini"
+    on master, "sed -i.bak -e 's/localhost/#{master}/' /etc/puppetserver/conf.d/webserver.ini"
   end
 


### PR DESCRIPTION
Because of naming conflicts with legacy packages, we
are forced to name our package `puppetserver` rather than
`puppet-server`.

This affects directory names as well.  This commit changes
it in all of the acceptance tests.
