### PR TITLE
(QENG-1061) Don't set `certname` in pre_suite.

### DIFF
--- a/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
@@ -5,8 +5,7 @@ step "Configure puppet.conf" do
 
   lay_down_new_puppet_conf( master,
                            {"main" => { "dns_alt_names" => "puppet,#{hostname},#{fqdn}",
-                                       "verbose" => true,
-                                       "certname" => "#{master}" }}, dir)
+                                       "verbose" => true }}, dir)
 
   variant, _, _, _ = master['platform'].to_array
 


### PR DESCRIPTION
This fix comes about as a result of dnsAltNames being properly implemented in
jvm-puppet.

Signed-off-by: Wayne wayne@puppetlabs.com
