### PR TITLE
(PE-5567) Return string rather than stream from http requests

### DIFF
--- a/src/ruby/puppet-server-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/http_client.rb
@@ -6,6 +6,7 @@ require 'net/http'
 require 'java'
 java_import com.puppetlabs.http.client.SyncHttpClient
 java_import com.puppetlabs.http.client.RequestOptions
+java_import com.puppetlabs.http.client.ResponseBodyType
 
 class Puppet::Server::HttpClient
 
@@ -27,6 +28,7 @@ class Puppet::Server::HttpClient
   def post(url, body, headers)
     request_options = RequestOptions.new(build_url(url))
     request_options.set_headers(headers)
+    request_options.set_as(ResponseBodyType::TEXT)
     request_options.set_body(body)
     configure_ssl(request_options)
     response = SyncHttpClient.post(request_options)
@@ -36,6 +38,7 @@ class Puppet::Server::HttpClient
   def get(url, headers)
     request_options = RequestOptions.new(build_url(url))
     request_options.set_headers(headers)
+    request_options.set_as(ResponseBodyType::TEXT)
     configure_ssl(request_options)
     response = SyncHttpClient.get(request_options)
     ruby_response(response)


### PR DESCRIPTION
The HTTP client we're registering with Puppet was returning an
InputStream for the body, but the rest of the Ruby code is
expecting a String.

In the future it might be nice to make this more flexible, and
consume it as a stream in some cases when possible, but for now
we may as well read it in to a String since that's what is
required by all of the callers.
