### PR TITLE
(PE-5567) Update http-client to 0.2.5, add test

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/certificate-authority "0.4.0"]
-                 [puppetlabs/http-client "0.2.4"]
+                 [puppetlabs/http-client "0.2.5"]
                  [org.jruby/jruby-complete "1.7.13"]
                  [clj-time "0.5.1"]
                  [compojure "1.1.6" :exclusions [org.clojure/tools.macro]]

--- a/test/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -1,0 +1,21 @@
+(ns puppetlabs.puppetserver.ruby.http-client-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.trapperkeeper.testutils.webserver :as jetty9]
+            [puppetlabs.trapperkeeper.testutils.webserver.common :refer [http-get]]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet]))
+
+(defn ring-app
+  [req]
+  {:status 200
+   :body "hi"})
+
+(deftest test-ruby-http-client
+  (jetty9/with-test-webserver ring-app port
+    (let [sc (jruby-puppet/empty-scripting-container ["./ruby/puppet/lib" "./ruby/facter/lib"])]
+      (.runScriptlet sc "require 'puppet/server/http_client'")
+      (is (= "hi" (.runScriptlet
+                    sc
+                    (format
+                      (str "c = Puppet::Server::HttpClient.new('localhost', %d, {:use_ssl => false});\n"
+                           "c.get('/', {}).body")
+                      port)))))))


### PR DESCRIPTION
This commit updates the http-client library to 0.2.5, which
includes a constructor for `RequestOptions` that takes a String
as an argument.

It also adds an integration test which exercises the ruby
http_client code.
