### PR TITLE
(PE-5437) Create `os-settings.conf` for install_from_ezbake.

### DIFF
--- a/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
@@ -19,3 +19,10 @@ step "Configure puppet.conf" do
   end
   on master, "sed -i -e 's/\(SERVICE_NUM_RETRIES\)=[0-9]*/\1=60/' #{defaults_file}"
 end
+
+case test_config[:puppetserver_install_type]
+when :git
+  step "Configure os-settings.conf" do
+    configure_puppet_server
+  end
+end


### PR DESCRIPTION
The way ezbake currently creates `os-settings.conf` for OS packages is
incompatible with installation using the Makefile as is done in
`Beaker::DSL::EZBakeUtils.install_from_ezbake`. This adds a helper method to
assist with this after installation of `puppet-server` but before ssl
initialization.

Signed-off-by: Wayne wayne@puppetlabs.com
