### PR TITLE
(MAINT) Add is_jvm_puppet and is_puppetserver to options.rb

### DIFF
--- a/acceptance/config/beaker/options.rb
+++ b/acceptance/config/beaker/options.rb
@@ -1,5 +1,7 @@
 {
   :forge_host => 'forge-aio01-petest.puppetlabs.com',
+  :is_puppetserver => true,
+  :is_jvm_puppet => true,
   "service-wait" => true,
   "service-prefix" => 'service ',
   "service-num-retries" => 1500,


### PR DESCRIPTION
Signed-off-by: Wayne wayne@puppetlabs.com
