### PR TITLE
(PE-5635) Revert removal of call to `override-webserver-settings`

### DIFF
--- a/dev-resources/puppet-server.conf
+++ b/dev-resources/puppet-server.conf
@@ -6,10 +6,6 @@ webserver: {
     client-auth: want
     ssl-host: localhost
     ssl-port: 8140
-    ssl-cert: ./scratch/master/conf/ssl/certs/localhost.pem
-    ssl-key: ./scratch/master/conf/ssl/private_keys/localhost.pem
-    ssl-ca-cert: ./scratch/master/conf/ssl/certs/ca.pem
-    ssl-crl-path: ./scratch/master/conf/ssl/ca/ca_crl.pem
 }
 
 os-settings: {

--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -98,3 +98,13 @@
     jruby-puppet jruby-service pool-descriptor
     (let [config (get-puppet-config* jruby-puppet)]
       (assoc config :puppet-version (.puppetVersion jruby-puppet)))))
+
+(defn init-webserver!
+  "Initialize Jetty with paths to the master's SSL certs."
+  [override-webserver-settings! puppet-config]
+  (let [{:keys [hostcert cacert cacrl hostprivkey] :as settings} puppet-config]
+    (log/info "Initializing webserver settings: " settings)
+    (override-webserver-settings! {:ssl-cert     hostcert
+                                   :ssl-key      hostprivkey
+                                   :ssl-ca-cert  cacert
+                                   :ssl-crl-path cacrl})))

--- a/src/clj/puppetlabs/services/config/puppet_server_config_service.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_service.clj
@@ -11,7 +11,8 @@
 (tk/defservice puppet-server-config-service
   PuppetServerConfigService
   [[:ConfigService get-config get-in-config]
-   [:JRubyPuppetService get-default-pool-descriptor]]
+   [:JRubyPuppetService get-default-pool-descriptor]
+   [:WebserverService override-webserver-settings!]]
 
   (init
     [this context]
@@ -23,6 +24,8 @@
           puppet-config (core/get-puppet-config
                           jruby-service
                           pool-descriptor)]
+      (core/init-webserver! override-webserver-settings!
+                            puppet-config)
       (assoc context :puppet-config
                      {:puppet-server puppet-config})))
 

--- a/test/puppetlabs/services/bootstrap_test.clj
+++ b/test/puppetlabs/services/bootstrap_test.clj
@@ -71,10 +71,6 @@
       (merge {:webserver
                {:ssl-host     "0.0.0.0"
                 :ssl-port     port
-                :ssl-cert     "./dev-resources/config/master/conf/ssl/certs/localhost.pem"
-                :ssl-key      "./dev-resources/config/master/conf/ssl/private_keys/localhost.pem"
-                :ssl-ca-cert  "./dev-resources/config/master/conf/ssl/certs/ca.pem"
-                :ssl-crl-path "./dev-resources/config/master/conf/ssl/crl.pem"
                 :client-auth  "need"}}
              (jruby-testutils/jruby-puppet-tk-config-with-prod-env 1))
       (testing (str "Simple request to puppet server succeeds when the client "


### PR DESCRIPTION
This commit reverts all of the previous work done to initially remove
the call to `override-webserver-settings` for PE-5635.  The previous
work would have introduced the need for all of the SSL-related settings
to be added to the `webserver.conf` file in packaging and the logistics
of getting that right for the initial release seemed too difficult to
work out.
