### PR TITLE
(PE-4308) /certificate_status - return map as JSON

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -828,11 +828,14 @@
 
 ; TODO implement
 (defn get-certificate-status
-  ([] (get-certificate-status nil))
-  ([certname]
-   (if certname
-     (str "get-certificate-status on certname: " certname)
-     "get-certificate-statuses called")))
+  [certname]
+  {:msg "you called get-certificate-status.  hi!"
+   :certname certname})
+
+; TODO implement
+(defn get-certificate-statuses
+  []
+  {:msg "you called get-certificate-statuses.  hi!"})
 
 ; TODO implement
 (schema/defn set-certificate-status!

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -75,6 +75,8 @@
   [certname]
   :allowed-methods [:get :put :delete]
 
+  :available-media-types ["application/json"]
+
   :delete! (fn [context]
              (ca/delete-certificate! certname))
 
@@ -103,8 +105,14 @@
                            (ringutils/json-request? (get context :request))))
 
 (liberator/defresource certificate-statuses
+  :allowed-methods [:get]
+
+  :available-media-types ["application/json"]
+
+  :handle-exception utils/exception-handler
+
   :handle-ok (fn [context]
-               (ca/get-certificate-status)))
+               (ca/get-certificate-statuses)))
 
 (schema/defn routes
   [ca-settings :- ca/CaSettings]
@@ -113,7 +121,7 @@
       (ANY "/certificate_status/:certname" [certname]
         (certificate-status certname))
       (ANY "/certificate_statuses/:ignored-but-required" [do-not-use]
-           certificate-statuses)
+         certificate-statuses)
       (GET "/certificate/:subject" [subject]
         (handle-get-certificate subject ca-settings))
       (compojure/context "/certificate_request/:subject" [subject]

--- a/test/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -7,6 +7,7 @@
             [clojure.test :refer :all]
             [clojure.java.io :as io]
             [ring.mock.request :as mock]
+            [cheshire.core :as json]
             [schema.test :as schema-test]))
 
 (use-fixtures :once schema-test/validate-schemas)
@@ -185,9 +186,11 @@
       (let [request {:uri "/production/certificate_status/myagent"
                      :request-method :get
                      :content-type "application/json"}
-             response (test-compojure-app request)]
+             response (test-compojure-app request)
+             expected-response-body {:msg      "you called get-certificate-status.  hi!"
+                                     :certname "myagent"}]
         (is (= 200 (:status response)))
-        (is (= "get-certificate-status on certname: myagent" (:body response)))))
+        (is (= expected-response-body (json/parse-string (:body response) true)))))
 
     (testing "PUT"
       (testing "signing a cert"
@@ -248,7 +251,10 @@
 
   (testing "GET to /certificate_statuses"
       (let [response (test-compojure-app
-                       {:uri            "/production/certificate_statuses/thisisirrelevant"
-                        :request-method :get})]
-        (is (= 200 (:status response)))
-        (is (= "get-certificate-statuses called" (:body response))))))
+                       {:uri "/production/certificate_statuses/thisisirrelevant"
+                        :request-method :get
+                        :content-type "application/json"})
+            expected-response-body {:msg "you called get-certificate-statuses.  hi!"}]
+        (is (= 200 (:status response))
+            (str "response was: " response))
+        (is (= expected-response-body (json/parse-string (:body response) true))))))


### PR DESCRIPTION
The 'core' implementation functions for /certificate_status can now
return maps and the liberator resource will serialize them as JSON into
the response.

This commit also updates the certificate-statuses liberator resource to
include the exception-handler and explicitly call-out its
'allowed-methods' for clarity.
