### PR TITLE
(PE-5670) Add resource-types endpoint

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -39,6 +39,8 @@
     (compojure/PUT "/report/*" request
                    (request-handler environment request))
     (compojure/GET "/resource_type/*" request
+                   (request-handler environment request))
+    (compojure/GET "/resource_types/*" request
                    (request-handler environment request))))
 
 (defn root-routes


### PR DESCRIPTION
This commit adds the resource_types endpoint to our whitelist
of endpoints that we pass through to the Ruby Puppet code.

I've tested locally, but if we think we need additional
testing we can add some in a follow-up PR.
