### PR TITLE
(PE-5510) Honor the Puppet `ssl-server-ca-auth` setting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [com.github.jnr/jffi "1.2.7"]
                  [com.github.jnr/jffi "1.2.7" :classifier "native"]
                  [com.github.jnr/jnr-x86asm "1.0.2"]
-                 [clj-time "0.5.1"]
+                 [clj-time "0.5.1" :exclusions [joda-time]]
                  [compojure "1.1.8" :exclusions [org.clojure/tools.macro]]
                  [liberator "0.12.0"]
                  [ring/ring-json "0.3.1"]

--- a/test/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -20,7 +20,8 @@
         (is (map? puppet-config))
         (doseq [k puppet-config-keys]
           (is (contains? puppet-config k))
-          (is (not (nil? (get puppet-config k)))))))))
+          (if (contains? puppet-config-keys-which-require-a-non-nil-value k)
+            (is (not (nil? (get puppet-config k))))))))))
 
 (deftest test-schema-validation
   (testing "validating a data structure with a missing key"
@@ -32,3 +33,37 @@
   (testing "validating a map with a nil value"
     (let [config-with-nil-value (zipmap puppet-config-keys (repeat nil))]
       (is (not (nil? (schema/check Config config-with-nil-value)))))))
+
+(deftest test-init-webserver!
+  (let [settings-passed (atom nil)
+        override-fn     (fn [settings]
+                          (reset! settings-passed settings))]
+    (testing (str "expected settings when ssl-server-ca-auth non-nil passed "
+                  "through to override function")
+      (let [puppet-config   {:hostcert           "thehostcert"
+                             :cacert             "thecacert"
+                             :cacrl              "thecacrl"
+                             :hostprivkey        "thehostprivkey"
+                             :ssl-server-ca-auth "thesslservercaauth"}]
+        (init-webserver! override-fn puppet-config)
+        (is (= {:ssl-cert     "thehostcert"
+                :ssl-key      "thehostprivkey"
+                :ssl-ca-cert  "thesslservercaauth"
+                :ssl-crl-path "thecacrl"}
+               @settings-passed)
+            "Unexpected settings passed into the override function")))
+    (testing (str "expected settings when ssl-server-ca-auth nil passed "
+                  "through to override function")
+      (reset! settings-passed nil)
+      (let [puppet-config   {:hostcert           "thehostcert"
+                             :cacert             "thecacert"
+                             :cacrl              "thecacrl"
+                             :hostprivkey        "thehostprivkey"
+                             :ssl-server-ca-auth nil}]
+        (init-webserver! override-fn puppet-config)
+        (is (= {:ssl-cert     "thehostcert"
+                :ssl-key      "thehostprivkey"
+                :ssl-ca-cert  "thecacert"
+                :ssl-crl-path "thecacrl"}
+               @settings-passed)
+            "Unexpected settings passed into the override function")))))


### PR DESCRIPTION
This commit causes the webserver setting for `ssl-ca-cert` to be
overridden by the Puppet `ssl-server-ca-auth` setting if it is set in the
puppet.conf file.  If the `ssl-server-ca-auth` setting is not set, the
`ssl-ca-cert` value will be overridden by the Puppet `cacert` setting
instead.  This behavior is intended to match the behavior described for
the `ssl_server_ca_auth` setting at
https://docs.puppetlabs.com/references/latest/configuration.html#sslservercaauth.
The two settings allow the user to distinguish between a set of CA certs
to be used for authenticating clients vs. the CA cert used by the Puppet
Internal CA for signing certificates.

This commit also adds an exclusion of `joda-time` from `clj-time`.
Leiningen found that `clj-time` depended upon an older version of
`joda-time`, 2.2, than `jruby-core` depends upon, 2.3.
