### PR TITLE
(PE-5722) Fix CA name used during generation of the master certificate

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -465,7 +465,6 @@
   Any existing files will be replaced."
   [settings :- MasterSettings
    master-certname :- schema/Str
-   ca-name :- schema/Str
    ca-private-key :- (schema/pred utils/private-key?)
    ca-public-key :- (schema/pred utils/public-key?)
    ca-cert :- (schema/pred utils/certificate?)
@@ -487,9 +486,9 @@
                                                settings)
         private-key  (utils/get-private-key keypair)
         x500-name    (utils/cn master-certname)
-        ca-x500-name (utils/cn ca-name)
         validity     (cert-validity-dates ca-ttl)
-        hostcert     (utils/sign-certificate ca-x500-name ca-private-key
+        hostcert     (utils/sign-certificate (get-subject ca-cert)
+                                             ca-private-key
                                              (next-serial-number! serial-file)
                                              (:not-before validity)
                                              (:not-after validity)
@@ -812,7 +811,6 @@
         (log/info "Master already initialized for SSL")
         (initialize-master! master-settings
                             master-certname
-                            (:ca-name ca-settings)
                             (utils/pem->private-key (:cakey ca-settings))
                             (utils/pem->public-key (:capub ca-settings))
                             (utils/pem->cert (:cacert ca-settings))

--- a/test/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -393,7 +393,7 @@
         signeddir       (str (ks/temp-dir))
         capubkey        (utils/pem->public-key capub)]
 
-    (initialize-master! master-settings "master" "Puppet CA: localhost"
+    (initialize-master! master-settings "master"
                         (utils/pem->private-key cakey)
                         capubkey
                         (utils/pem->cert cacert)


### PR DESCRIPTION
This commit changes the CA name applied to the master cert to be pulled
from the CA cert's subject name rather than being constructed from the
`ca_name` setting as derived from the puppet.conf file at the time the
service is started.
