### PR TITLE
(PUP-3165) Ensure agent run on master during pre_suite.

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -99,8 +99,6 @@ module PuppetServerExtensions
       with_puppet_running_on(master, "main" => { "autosign" => true, "dns_alt_names" => "puppet,#{hostname},#{fqdn}", "verbose" => true, "daemonize" => true }) do
 
         hosts.each do |host|
-          next if host['roles'].include? 'master'
-
           step "Agents: Run agent --test first time to gen CSR"
           on host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0]
         end


### PR DESCRIPTION
This will ensure that `/var/lib/puppet/reports/<master-fqdn>` gets created by
the master process running as the master user. This is necessary because
otherwise some early testcase may get a chance to run 'puppet apply' which will
create the same directory as root, thereby making it unavailable to the master
user.

Signed-off-by: Wayne wayne@puppetlabs.com
