### PR TITLE
(DOC) Add init-scratch script to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ puppet-server
   * Update the git submodules located in `./ruby`
     * `git submodule init`
     * `git submodule update`
+  * Create the required scratch directories in `./scratch`
+    * `bin/init-scratch.sh`
   * in the REPL:
     * load the namespace `puppetlabs.puppet-server.testutils.repl`
     * `(go)`


### PR DESCRIPTION
The dev-resources/puppet-server.conf config points to a directory that
doesn't exist, unless you run the handy init-scratch.sh script. But the
documention didn't mention the script. Without the directory the run
command fails.
