### PR TITLE
(PUP-1680) Fix `incorrect header check` problem.

### DIFF
--- a/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
@@ -1,10 +1,17 @@
 step "Configure puppet.conf" do
   hostname = on(master, 'facter hostname').stdout.strip
   fqdn = on(master, 'facter fqdn').stdout.strip
-  dir = master.tmpdir(File.basename('/tmp'))
 
+  hosts.each do |host|
+    next if host == master
+    dir = host.tmpdir(File.basename('/tmp'))
+    lay_down_new_puppet_conf( host, {"main" => { "http_compression" => true }}, dir)
+  end
+
+  dir = master.tmpdir(File.basename('/tmp'))
   lay_down_new_puppet_conf( master,
                            {"main" => { "dns_alt_names" => "puppet,#{hostname},#{fqdn}",
+                                        "http_compression" => true,
                                        "verbose" => true }}, dir)
 
   variant, _, _, _ = master['platform'].to_array


### PR DESCRIPTION
This is a temporary fix until Puppet 3.7.1 is released, which will include the
patch that addresses PUP-1680.

Signed-off-by: Wayne wayne@puppetlabs.com
