### PR TITLE
(MAINT) Reduce service restart timeout in initialize_ssl

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -95,7 +95,7 @@ module PuppetServerExtensions
 
     step "Server: Start Puppet Server"
       old_retries = master['master-start-curl-retries']
-      master['master-start-curl-retries'] = 1500
+      master['master-start-curl-retries'] = 300
       with_puppet_running_on(master, "main" => { "autosign" => true, "dns_alt_names" => "puppet,#{hostname},#{fqdn}", "verbose" => true, "daemonize" => true }) do
 
         hosts.each do |host|


### PR DESCRIPTION
1500 seconds is absurdly long and leads CI job failure detection on smoke tests
to take 25 minutes when it should take 5 minutes.

Signed-off-by: Wayne wayne@puppetlabs.com
