### PR TITLE
(PE-5904) handle responses that don't have a body

### DIFF
--- a/src/ruby/puppet-server-lib/puppet/server/master.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/master.rb
@@ -99,7 +99,7 @@ class Puppet::Server::Master
 
     body = response[:body]
     body_to_return =
-        if body.is_a? String
+        if body.is_a? String or body.nil?
           body
         elsif body.is_a? IO
           body.to_inputstream


### PR DESCRIPTION
Handle responses from Puppet's HTTP layer that have a nil body.  This is
correct in certain cases, like a HEAD request.

I did a bit of manual testing on this in the REPL.  I wanted to write a test case for this but it seems like much more work; we don't have any similar test cases in the codebase ATM.  And this is urgent.
