### PR TITLE
(QE-1055) Decrease timeout for puppet-server to listen on port 8140.

### DIFF
--- a/acceptance/config/beaker/options.rb
+++ b/acceptance/config/beaker/options.rb
@@ -7,6 +7,6 @@
   "service-num-retries" => 1500,
   "puppetservice" => 'puppetserver',
   "use-service" => true,
-  "master-start-curl-retries" => 200,
+  "master-start-curl-retries" => 60,
 }
 


### PR DESCRIPTION
Signed-off-by: Wayne wayne@puppetlabs.com
