### PR TITLE
(MAINT) Create puppet-server specific intialize_ssl.

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -83,7 +83,7 @@ module PuppetServerExtensions
     end
   end
 
-  def initialize_ssl
+  def puppetserver_initialize_ssl
     hostname = on(master, 'facter hostname').stdout.strip
     fqdn = on(master, 'facter fqdn').stdout.strip
 

--- a/acceptance/suites/pre_suite/foss/90_validate_sign_cert.rb
+++ b/acceptance/suites/pre_suite/foss/90_validate_sign_cert.rb
@@ -1,2 +1,2 @@
 step "Validate Sign Cert." 
-  initialize_ssl # from lib/helper.rb
+  puppetserver_initialize_ssl # from lib/helper.rb


### PR DESCRIPTION
When running FOSS/MRI puppet acceptance tests `initialize_ssl` is overridden by
a similar but passenger-specific method defined in the FOSS/MRI puppet
acceptance library.

Signed-off-by: Wayne wayne@puppetlabs.com
