### PR TITLE
(doc) Add comment on how to enable remote puppet agents

### DIFF
--- a/dev/sample-configs/puppet-server.sample.conf
+++ b/dev/sample-configs/puppet-server.sample.conf
@@ -9,6 +9,11 @@ product: {
 
 webserver: {
     client-auth: want
+    # ssl-host controls what networks the server will accept connections from.
+    # The default value below is 'localhost', so will only accept connections from
+    # processes on the same operating system instance, e.g. a local puppet agent.
+    # To support both local and remote puppet agents, use:
+    #ssl-host: 0.0.0.0
     ssl-host: localhost
     ssl-port: 8140
 }


### PR DESCRIPTION
I'm not sure if this is documented somewhere else or not, and the comment could probably use some wordsmithing, but something to this effect would have saved me 15 minutes of poking around.
