### PR TITLE
(PE-6073) Fix rspec tests

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -14,7 +14,7 @@ describe Puppet::Server::Master do
   context "puppet version" do
     it "returns the correct puppet version number" do
       master = Puppet::Server::Master.new({}, nil)
-      master.puppetVersion.should == '3.7.0'
+      master.puppetVersion.should == '3.7.1'
     end
   end
 

--- a/spec/run_specs.rb
+++ b/spec/run_specs.rb
@@ -2,4 +2,4 @@ require "bundler/setup"
 require "rspec"
 require "spec_helper"
 
-RSpec::Core::Runner.run(%w[./spec], $stderr, $stdout)
+exit RSpec::Core::Runner.run(%w[./spec], $stderr, $stdout)


### PR DESCRIPTION
This commit changes the expected version in the puppet version spec test
to 3.7.1 so that the test is sync with current puppet submodule being
selected by the project.

This commit also wraps the `RSpec::Core::Runner.run` call that
run_specs.rb makes in an exit call so that the return code from the
`run` call is propagated out.  Previously, the result from the `run`
call was swallowed, causing the calling application to always have an
exit code of 0 even if tests had failed.
