### PR TITLE
(SERVER-13) Fix for file descriptor leak during report processing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/certificate-authority "0.6.0"]
-                 [puppetlabs/http-client "0.2.7"]
+                 [puppetlabs/http-client "0.2.8"]
                  [org.jruby/jruby-core "1.7.15" :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
                  [org.jruby/jruby-stdlib "1.7.15"]
                  [com.github.jnr/jffi "1.2.7"]


### PR DESCRIPTION
This commit bumps up the dependency that Puppet Server has on
puppetlabs/http-client to version 0.2.8.  The http-client 0.2.8 release
contains a fix for a file descriptor leak which previously occurred on
every HTTP client request.  Previously, this leak would be encountered
by Puppet Server for each client request it would make to a report
processor, e.g., PuppetDB.
