### PR TITLE
(MAINT) Update `.travis.yml` with encrypted hipchat credentials.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ruby/puppet"]
 	path = ruby/puppet
-	url = git@github.com:puppetlabs/puppet.git
+	url = https://github.com/puppetlabs/puppet.git
 [submodule "ruby/facter"]
 	path = ruby/facter
-	url = git@github.com:puppetlabs/facter.git
+	url = https://github.com/puppetlabs/facter.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: clojure
 lein: lein2
 jdk:
-  - oraclejdk7
-  - openjdk7
-script: ./ext/travisci/test.sh
+- oraclejdk7
+- openjdk7
+script: "./ext/travisci/test.sh"
 notifications:
   email: false
-
+  hipchat:
+    rooms:
+      secure: ASvt1XwEYbgkKuYZjZHytwg/6Y53Tg4T7QhohiDB4Xb1dmJueqPFpV2ko/VjHCa18JjLiUq0nWcDpRjsqaGGvJ5FSxTyyWDKtZsg1sUf4F+7aZ5vq0Dzg8Uzvdu7m9X1Uszvs9zf6wJ+Jobq4xck1xpPYxFT/+ei2Q2STrJ9xwQ=
+    template:
+    - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"


### PR DESCRIPTION
Also updates `.gitmodules` to enable travis-ci to recursively clone the
repository without ssh credential errors.

Signed-off-by: Wayne wayne@puppetlabs.com
