### PR TITLE
(SERVER-30) Copy cacert to localcacert and remove from master fail-fast

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_disabled_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_disabled_service.clj
@@ -10,5 +10,9 @@
   CaService
   []
   (initialize-master-ssl!
-   [this master-settings certname]
-   (log/info "CA disabled; ignoring SSL initialization for Master")))
+    [this master-settings certname]
+    (log/info "CA disabled; ignoring SSL initialization for Master"))
+
+  (retrieve-ca-cert!
+    [this localcacert]
+    (log/info "CA disabled; ignoring retrieval of CA cert")))

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -26,4 +26,9 @@
   (initialize-master-ssl!
    [this master-settings certname]
    (let [settings (ca/config->ca-settings (get-config))]
-     (ca/initialize-master-ssl! master-settings certname settings))))
+     (ca/initialize-master-ssl! master-settings certname settings)))
+
+  (retrieve-ca-cert!
+    [this localcacert]
+    (ca/retrieve-ca-cert! (get-in-config [:puppet-server :cacert])
+                          localcacert)))

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -9,15 +9,17 @@
   [[:WebserverService add-ring-handler]
    [:PuppetServerConfigService get-config]
    [:RequestHandlerService handle-request]
-   [:CaService initialize-master-ssl!]]
+   [:CaService initialize-master-ssl! retrieve-ca-cert!]]
   (init
    [this context]
    (core/validate-memory-requirements!)
-   (let [path     ""
-         config   (get-config)
-         certname (get-in config [:puppet-server :certname])
-         settings (ca/config->master-settings config)]
+   (let [path        ""
+         config      (get-config)
+         certname    (get-in config [:puppet-server :certname])
+         localcacert (get-in config [:puppet-server :localcacert])
+         settings    (ca/config->master-settings config)]
 
+     (retrieve-ca-cert! localcacert)
      (initialize-master-ssl! settings certname)
 
      (log/info "Master Service adding a ring handler")

--- a/src/clj/puppetlabs/services/protocols/ca.clj
+++ b/src/clj/puppetlabs/services/protocols/ca.clj
@@ -2,4 +2,5 @@
 
 (defprotocol CaService
   "Describes the functionality of the CA service."
-  (initialize-master-ssl! [this master-settings certname]))
+  (initialize-master-ssl! [this master-settings certname])
+  (retrieve-ca-cert! [this master-settings]))


### PR DESCRIPTION
This commit removes the check for localcacert from the master fail-fast
logic and replaces with a new CA protocol function,
`retrieve-ca-cert!`, which populates the localcacert from cacert.  The
new protocol function separates the certificate generation logic in
`initialize-master-ssl!` from the CA cert acquisition logic, allowing the
latter to be reused sometime in the future.

In the previous commit, master initialization would fail if the master cert
and private key were not present but the localcacert were present.  The
latter is valid, for example, if the master certname is changed sometime
after the server is initially booted.  The new logic more closely
matches the error handling in Ruby Puppet master initialization.
