### PR TITLE
(SERVER-38) Store JRuby scripting containers in pool queue

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -85,6 +85,11 @@
    :profiler   (schema/maybe PuppetProfiler)
    :pool-state PoolStateContainer})
 
+(def PoolInstance
+  "A map with objects pertaining to an individual entry in the JRubyPuppet pool."
+  {:jruby-puppet JRubyPuppet
+   :scripting-container ScriptingContainer})
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
@@ -124,9 +129,8 @@
     (.runScriptlet "require 'puppet/server/master'")))
 
 (schema/defn ^:always-validate
-  create-jruby-instance :- JRubyPuppet
-  "Creates a new JRubyPuppet instance.  See the docs on `create-jruby-pool`
-  for the contents of `config`."
+  create-pool-instance :- PoolInstance
+  "Creates a new pool instance."
   [config   :- PoolConfig
    profiler :- (schema/maybe PuppetProfiler)]
   (let [{:keys [ruby-load-path gem-home master-conf-dir master-var-dir]} config]
@@ -140,9 +144,13 @@
         (.put jruby-config "confdir" (fs/absolute-path master-conf-dir)))
       (when master-var-dir
         (.put jruby-config "vardir" (fs/absolute-path master-var-dir)))
-
-      (.callMethod scripting-container ruby-puppet-class "new"
-                   (into-array Object [jruby-config profiler]) JRubyPuppet))))
+      {:jruby-puppet (.callMethod scripting-container
+                                  ruby-puppet-class
+                                  "new"
+                                  (into-array Object
+                                              [jruby-config profiler])
+                                              JRubyPuppet)
+       :scripting-container scripting-container})))
 
 (schema/defn ^:always-validate
   get-pool-state :- PoolState
@@ -185,7 +193,7 @@
   be available to other callers) and throws the poison pill's exception.
   Otherwise returns the instance that was passed in."
   [instance pool]
-  {:post [((some-fn nil? #(instance? JRubyPuppet %)) %)]}
+  {:post [((some-fn nil? #(nil? (schema/check PoolInstance %))) %)]}
   (when (instance? PoisonPill instance)
     (.put pool instance)
     (throw (IllegalStateException. "Unable to borrow JRuby instance from pool"
@@ -224,7 +232,7 @@
       (let [count (.remainingCapacity pool)]
         (dotimes [i count]
           (log/debugf "Priming JRubyPuppet instance %d of %d" (inc i) count)
-          (.put pool (create-jruby-instance config (:profiler context)))
+          (.put pool (create-pool-instance config (:profiler context)))
           (log/infof "Finished creating JRubyPuppet instance %d of %d"
                      (inc i) count))
         (mark-as-initialized! context))
@@ -241,7 +249,7 @@
   (.size (get-pool context)))
 
 (schema/defn ^:always-validate
-  borrow-from-pool :- JRubyPuppet
+  borrow-from-pool :- PoolInstance
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
   [context :- PoolContext]
@@ -250,7 +258,7 @@
     (validate-instance-from-pool! instance pool)))
 
 (schema/defn ^:always-validate
-  borrow-from-pool-with-timeout :- (schema/maybe JRubyPuppet)
+  borrow-from-pool-with-timeout :- (schema/maybe PoolInstance)
   "Borrows a JRubyPuppet interpreter from the pool, like borrow-from-pool but a
   blocking timeout is provided. If an instance is available then it will be
   immediately returned to the caller, if not then this function will block
@@ -266,8 +274,8 @@
 
 (schema/defn ^:always-validate
   return-to-pool
-  "Return a borrowed JRubyPuppet instance to its free pool."
+  "Return a borrowed pool instance to its free pool."
   [context :- PoolContext
-   instance :- JRubyPuppet]
+   instance :- PoolInstance]
   (let [pool (get-pool context)]
     (.put pool instance)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -60,8 +60,9 @@
       jruby-service
       (do-something-with-a-jruby-puppet-instance jruby-puppet)))"
   [jruby-puppet jruby-service & body]
-  `(let [~jruby-puppet (jruby/borrow-instance ~jruby-service)]
+  `(let [pool-instance# (jruby/borrow-instance ~jruby-service)
+         ~jruby-puppet  (:jruby-puppet pool-instance#)]
      (try
        ~@body
        (finally
-         (jruby/return-instance ~jruby-service ~jruby-puppet)))))
+         (jruby/return-instance ~jruby-service pool-instance#)))))

--- a/test/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -9,7 +9,8 @@
                 "./dev-resources/puppetlabs/services/config/puppet_server_config_core_test/puppet.conf"))
 
 (deftest test-puppet-config-values
-  (let [jruby-puppet (testutils/create-jruby-instance)]
+  (let [pool-instance (testutils/create-pool-instance)
+        jruby-puppet  (:jruby-puppet pool-instance)]
 
     (testing "usage of get-puppet-config-value"
       (is (= "0.0.0.0" (get-puppet-config-value jruby-puppet :bindaddress)))

--- a/test/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -85,8 +85,8 @@
              "Providing config values that should be read from Puppet results "
              "in an error that mentions all offending config keys.")
     (with-redefs
-      [jruby-puppet-core/create-jruby-instance
-         jruby-testutils/create-mock-jruby-instance]
+      [jruby-puppet-core/create-pool-instance
+         jruby-testutils/create-mock-pool-instance]
       (with-test-logging
         (is (thrown-with-msg?
               Exception

--- a/test/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -14,18 +14,20 @@
 (deftest create-jruby-instance-test
 
   (testing "Var dir is not required."
-    (let [config  {:ruby-load-path  testutils/ruby-load-path
-                   :gem-home        testutils/gem-home
-                   :master-conf-dir testutils/conf-dir}
-          jruby   (create-jruby-instance config testutils/default-profiler)
-          var-dir (.getSetting jruby "vardir")]
+    (let [config        {:ruby-load-path  testutils/ruby-load-path
+                         :gem-home        testutils/gem-home
+                         :master-conf-dir testutils/conf-dir}
+          pool-instance (create-pool-instance config testutils/default-profiler)
+          jruby-puppet  (:jruby-puppet pool-instance)
+          var-dir       (.getSetting jruby-puppet "vardir")]
       (is (not (nil? var-dir)))))
 
   (testing "Settings from Ruby Puppet are available"
     (let [temp-dir      (.getAbsolutePath (ks/temp-dir))
           config        (assoc (testutils/jruby-puppet-config)
                           :master-var-dir temp-dir)
-          jruby-puppet  (testutils/create-jruby-instance config)]
+          pool-instance (testutils/create-pool-instance config)
+          jruby-puppet  (:jruby-puppet pool-instance)]
       (is (= "0.0.0.0" (.getSetting jruby-puppet "bindaddress")))
       (is (= 8140 (.getSetting jruby-puppet "masterport")))
       (is (= false (.getSetting jruby-puppet "onetime")))

--- a/test/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -6,7 +6,7 @@
             [puppetlabs.services.jruby.testutils :as testutils]
             [puppetlabs.services.jruby.testutils :as jruby-testutils]))
 
-(use-fixtures :each testutils/mock-jruby-fixture)
+(use-fixtures :each testutils/mock-pool-instance-fixture)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Private
@@ -74,7 +74,7 @@
         config    (testutils/jruby-puppet-config pool-size)
         pool      (create-pool-context config testutils/default-profiler)
         err-msg   (re-pattern "Unable to borrow JRuby instance from pool")]
-    (with-redefs [core/create-jruby-instance (fn [_] (throw (IllegalStateException. "BORK!")))]
+    (with-redefs [core/create-pool-instance (fn [_] (throw (IllegalStateException. "BORK!")))]
                  (is (thrown? IllegalStateException (prime-pools! pool))))
     (testing "borrow and borrow-with-timeout both throw an exception if the pool failed to initialize"
       (is (thrown-with-msg? IllegalStateException

--- a/test/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -13,7 +13,7 @@
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]))
 
-(use-fixtures :each testutils/mock-jruby-fixture)
+(use-fixtures :each testutils/mock-pool-instance-fixture)
 
 (def jruby-service-test-config
   {:jruby-puppet (testutils/jruby-puppet-config 1)})
@@ -23,7 +23,7 @@
       (str "If there as an exception while putting a JRubyPuppet instance in "
            "the pool the application should shut down.")
     (logging/with-test-logging
-      (with-redefs [jruby-puppet-core/create-jruby-instance
+      (with-redefs [jruby-puppet-core/create-pool-instance
                     (fn [& _] (throw (Exception. "42")))]
                    (let [got-expected-exception (atom false)]
                      (try

--- a/test/puppetlabs/services/jruby/testutils.clj
+++ b/test/puppetlabs/services/jruby/testutils.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.services.jruby.testutils
-  (:import (com.puppetlabs.puppetserver JRubyPuppet JRubyPuppetResponse))
+  (:import (com.puppetlabs.puppetserver JRubyPuppet JRubyPuppetResponse)
+           (org.jruby.embed ScriptingContainer))
   (:require [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
             [puppetlabs.services.puppet-profiler.puppet-profiler-core :as profiler-core]
             [me.raynes.fs :as fs]))
@@ -62,25 +63,30 @@
 (def default-profiler
   nil)
 
-(defn create-jruby-instance
+(defn create-pool-instance
   ([]
-   (create-jruby-instance (jruby-puppet-config 1)))
+   (create-pool-instance (jruby-puppet-config 1)))
   ([config]
-   (jruby-core/create-jruby-instance config default-profiler)))
+   (jruby-core/create-pool-instance config default-profiler)))
 
 (defn create-mock-jruby-instance
   "Creates a mock implementation of the JRubyPuppet interface."
-  [& _]
+  []
   (reify JRubyPuppet
     (handleRequest [_ _]
       (JRubyPuppetResponse. 0 nil nil nil))
     (getSetting [_ _]
       (Object.))))
 
-(defn mock-jruby-fixture
+(defn create-mock-pool-instance
+  [_ _]
+  {:jruby-puppet        (create-mock-jruby-instance)
+   :scripting-container (ScriptingContainer.)})
+
+(defn mock-pool-instance-fixture
   "Test fixture which changes the behavior of the JRubyPool to create
   mock JRubyPuppet instances."
   [f]
   (with-redefs
-    [jruby-core/create-jruby-instance create-mock-jruby-instance]
+    [jruby-core/create-pool-instance create-mock-pool-instance]
     (f)))


### PR DESCRIPTION
This commit stores JRuby `ScriptingContainer` objects created during
JRubyPuppet pool initialization into a hash along with their associated
`JRubyPuppet` object and puts the result into the pool queue in the
service context.  The consumers of pool instances were updated to borrow
the `JRubyPuppet` object from the new hash instead of just being able to
access the `JRubyPuppet` object directly.

In the previous commit, the `ScriptingContainer` objects were not stored
in the service context and would fall out of scope when the
`create-jruby-instance` function returned.  The container objects could
then be garbage collected later on.  During garbage collection, the
terminate logic on the container would clean up -- decrement the ref
count for -- any open `ChannelDescriptor`s.  If the ref count for the
`ChannelDescriptor` had been bumped up because a file had been opened
during a JRubyPuppet request and the associated container was
terminated while the file was still open, the call that the JRubyPuppet
request would make to close the file handle would result in JRuby
throwing a `BadFileDescriptor` exception -- an assert fired because an
attempt was being made to decrement the ref count on the descriptor
below 0.  By always holding a reference to the `ScriptingContainer`s,
the containers will not be garbage collected and, therefore, the race
condition around closing descriptors would be eliminated.
