### PR TITLE
(SERVER-76) Update puppet dependency

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -7,7 +7,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["puppet = 3.7.1"
+      redhat: { dependencies: ["puppet >= 3.7.1"
                                "java-1.7.0-openjdk"],
                # This is terrible, but we need write access to puppet's
                # var/conf dirs, so we need to add ourselves to the group.
@@ -23,8 +23,8 @@ ezbake: {
                          "echo \\\"}\\\"                                      >> %{buildroot}%{_sysconfdir}/%{realname}/conf.d/os-settings.conf" ]
              }
 
-      debian: { dependencies: ["puppet-common (= 3.7.1-1puppetlabs1)"
-                               "puppet (= 3.7.1-1puppetlabs1)"
+      debian: { dependencies: ["puppet-common (>= 3.7.1-1puppetlabs1)"
+                               "puppet (>= 3.7.1-1puppetlabs1)"
                                "openjdk-7-jre-headless"],
                # see redhat comments on why this is terrible
                preinst: ["install --group={{user}} --owner={{user}} -d /var/lib/puppet/jruby-gems",


### PR DESCRIPTION
Update puppet dependency to be >= 3.7.1, rather than tying it
directly to 3.7.1.
