### PR TITLE
(SERVER-77) Enable/disabled cert status access control

### DIFF
--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -88,6 +88,12 @@ certificate-authority: {
 
     # settings for the certificate_status HTTP endpoint
     certificate-status: {
+    
+        # (optional) Whether a client certificate is required to access
+        # the certificate status endpoints. A 'false' value will allow
+        # plaintext access and the client-whitelist will be ignored.
+        # Defaults to 'true'.
+        authorization-required: true
 
         # this setting contains a list of client certnames who are whitelisted to
         # have access to the certificate_status endpoint.  Any requests made to

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -37,7 +37,9 @@
   "Defines which clients are allowed access to the various CA endpoints.
    Each endpoint has a sub-section containing the client whitelist.
    Currently we only control access to the certificate_status(es) endpoints."
-  {:certificate-status {:client-whitelist [schema/Str]}})
+  {:certificate-status
+   {(schema/optional-key :authorization-required) schema/Bool
+    :client-whitelist                             [schema/Str]}})
 
 (def CaSettings
   "Settings from Puppet that are necessary for CA initialization

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -140,13 +140,16 @@
 
 (defn client-allowed-access?
   "Determines if the client in the request is allowed to access the
-   certificate_status(es) endpoint based on the client whitelist."
+   certificate_status(es) endpoint based on the client whitelist and
+   whether authorization is required."
   [settings context]
-  (if-let [client-cert (get-in context [:request :ssl-client-cert])]
-    (if (client-on-whitelist? settings client-cert)
-      true
-      (do (log-rejection client-cert) false))
-    (log/info "Access to certificate_status rejected; no client certificate found")))
+  (if (get-in settings [:access-control :certificate-status :authorization-required] true)
+    (if-let [client-cert (get-in context [:request :ssl-client-cert])]
+      (if (client-on-whitelist? settings client-cert)
+        true
+        (do (log-rejection client-cert) false))
+      (log/info "Access to certificate_status rejected; no client certificate found"))
+    true))
 
 (liberator/defresource certificate-status
   [subject settings]

--- a/test/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -588,4 +588,26 @@
                          :ssl-client-cert localhost-cert})]
           (is (= 200 (:status response)))
           (is (= #{test-agent-status revoked-agent-status localhost-status}
+                 (set (json/parse-string (:body response) true))))))))
+
+  (testing "access control can be disabled"
+    (let [settings (assoc (testutils/ca-settings cadir)
+                     :access-control {:certificate-status
+                                      {:authorization-required false
+                                       :client-whitelist []}})
+          test-app (compojure-app settings "1.2.3.4")]
+
+      (testing "certificate_status"
+        (let [response (test-app
+                        {:uri            "/production/certificate_status/test-agent"
+                         :request-method :get})]
+          (is (= 200 (:status response)))
+          (is (= test-agent-status (json/parse-string (:body response) true)))))
+
+      (testing "certificate_statuses"
+        (let [response (test-app
+                        {:uri            "/production/certificate_statuses/all"
+                         :request-method :get})]
+          (is (= 200 (:status response)))
+          (is (= #{test-agent-status revoked-agent-status localhost-status}
                  (set (json/parse-string (:body response) true)))))))))


### PR DESCRIPTION
This commit adds a new ca.conf setting to toggle on/off
access control to the certificate_status(es) endpoints.
The setting is optional, but defaults to true. When
false, the client-whitelist is ignored and plaintext
access is allowed.
