### PR TITLE
(SERVER-71) Fix broken specs from change to Master ctor

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -6,14 +6,14 @@ require 'puppet/server/jvm_profiler'
 describe Puppet::Server::Master do
   context "run mode" do
     it "is set to 'master'" do
-      master = Puppet::Server::Master.new({}, nil)
+      master = Puppet::Server::Master.new({}, {}, nil)
       master.run_mode.should == 'master'
     end
   end
 
   context "puppet version" do
     it "returns the correct puppet version number" do
-      master = Puppet::Server::Master.new({}, nil)
+      master = Puppet::Server::Master.new({}, {}, nil)
       master.puppetVersion.should == '3.7.1'
     end
   end
@@ -32,12 +32,12 @@ describe Puppet::Server::Master do
 
   context "profiler" do
     it "does not register a profiler if profiler is set to nil" do
-      master = Puppet::Server::Master.new({}, nil)
+      master = Puppet::Server::Master.new({}, {}, nil)
       Puppet::Util::Profiler.current.length.should == 0
     end
 
     it "registers a profiler if the profiler is not nil" do
-      master = Puppet::Server::Master.new({}, Puppet::Server::JvmProfiler.new(MasterTestProfiler.new))
+      master = Puppet::Server::Master.new({}, {}, Puppet::Server::JvmProfiler.new(MasterTestProfiler.new))
       Puppet::Util::Profiler.current.length.should == 1
     end
   end


### PR DESCRIPTION
Previous commit broke the ruby spec tests due to a change to
the signature of the constructor for `Puppet::Server::Master`.
This commit fixes those broken tests.
