### PR TITLE
(SERVER-29) exclude BouncyCastle jars from uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -71,4 +71,9 @@
 
   ; tests use a lot of PermGen (jruby instances)
   :jvm-opts ["-XX:MaxPermSize=256m"]
+
+  ;; JRuby bundles the (un-exploded) BouncyCastle .jars.
+  ;; We don't want them in our uberjar,
+  ;; since we define our own dependency on BouncyCastle.
+  :uberjar-exclusions [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"]
   )


### PR DESCRIPTION
Yo dawg, JRuby bundles the BouncyCastle .jars in its .jar.  Avoid using these,
since this project defines its own dependency on BouncyCastle directly.

I tested this by building an uberjar (that includes jetty) and doing an agent run against it.  It worked fine, with no obvious problems.
