### PR TITLE
(SERVER-73) Log message when puppetserver is ready

### DIFF
--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -26,4 +26,8 @@
      (add-ring-handler
       (compojure/context path [] (core/compojure-app handle-request))
       path))
-   context))
+   context)
+  (start
+    [this context]
+    (log/info "Puppet Server has successfully started and is now ready to handle requests")
+    context))


### PR DESCRIPTION
Log a message when puppet-server's jetty server has finished
starting up and is ready to receive requests.
