### PR TITLE
(SERVER-87) Fix upgrade pre_suite for multi host configs.

### DIFF
--- a/acceptance/suites/pre_suite/foss/20_install_released_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/20_install_released_puppet.rb
@@ -1,7 +1,9 @@
 # skip this step entirely unless we are running in :upgrade mode
 if (test_config[:puppetserver_install_mode] == :upgrade)
   step "Install released MRI Puppet for upgrade test" do
-    install_package master, 'puppet'
+    hosts.each do |host|
+      install_package host, 'puppet'
+    end
   end
 
   step "Run puppet as puppet user to prevent permissions errors later." do


### PR DESCRIPTION
Previously in the `:upgrade` case the presuite would only install puppet on the
master which would lead to errors later in the presuite.
