### PR TITLE
Improvements for REPL-driven development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ log
 vendor
 .nrepl-port
 profiles.clj
+dev/user.clj
+.lein-repl-history

--- a/dev/user.clj.sample
+++ b/dev/user.clj.sample
@@ -1,0 +1,46 @@
+;; This file provides a sample `user` namespace that shows some things that
+;; can be useful during development; especially if you'd like to develop
+;; via the REPL.  To use this, simply make a copy of this file named `user.clj`
+;; and modify it to your liking.
+(ns user
+  (:require [puppetlabs.trapperkeeper.config :as config]))
+
+;; The `user_repl.clj` file has utility functions for starting, stopping, and
+;; loading Puppet Server from the REPL.  If you define a var here that contains
+;; configuration data for Puppet Server, it will use that config instead of the
+;; defaults.  You could just supply a map literal here, but I like to parse
+;; the config from my config files on disk, so that I am using the same settings
+;; that I would get if I ran the server via `lein run --config`.
+(def jvm-puppet-conf
+  (config/load-config "/Users/cprice/puppet-server/conf/puppet-server.conf"))
+
+;; The `go` function in the `user-repl` namespace  will start up an instance of
+;; Pupppet Server.  This function will load that namespace, switch to it, and call `go`.
+;; Here's an example REPL session:
+;;
+;;    $ lein repl
+;;    user=> (go)
+;;       2014-10-31 06:20:40,302 INFO  [p.s.j.jruby-puppet-service] Initializing the JRuby service
+;;       ...
+;;       2014-10-31 06:24:40,036 INFO  [p.s.m.master-service] Puppet Server has successfully started and is now ready to handle requests
+;;       ...
+;;    user-repl=> (reset)
+;;       2014-10-31 06:26:08,639 INFO  [p.t.internal] Beginning shutdown sequence
+;;       2014-10-31 06:26:08,640 INFO  [p.t.s.w.jetty9-service] Shutting down web server(s).
+;;       ...
+;;       2014-10-31 06:26:08,649 INFO  [p.t.internal] Finished shutdown sequence
+;;       :reloading (puppetlabs.puppetserver.ringutils puppetlabs.services.master.master-core
+;;       ...
+;;       2014-10-31 06:26:10,988 INFO  [p.s.j.jruby-puppet-service] Initializing the JRuby service
+;;       2014-10-31 06:26:10,990 INFO  [p.t.s.w.jetty9-service] Initializing web server(s).
+;;       ...
+;;    user-repl=> (stop)
+;;       2014-10-31 06:51:20,037 INFO  [p.t.internal] Beginning shutdown sequence
+;;       ...
+;;       2014-10-31 06:51:20,052 INFO  [p.t.internal] Finished shutdown sequence
+;;    user-repl=>
+(defn go
+  []
+  (load-file "./dev/user_repl.clj")
+  (ns user-repl)
+  ((-> 'user-repl/go resolve deref)))

--- a/project.clj
+++ b/project.clj
@@ -75,6 +75,8 @@
   ; tests use a lot of PermGen (jruby instances)
   :jvm-opts ["-XX:MaxPermSize=256m"]
 
+  :repl-options {:init-ns user}
+
   ;; NOTE: jruby-stdlib packages some unexpected things inside
   ;; of its jar.  e.g., it puts a pre-built copy of the bouncycastle
   ;; jar into its META-INF directory.  This is highly undesirable


### PR DESCRIPTION
This commit does the following:
- Adds a gitignore for `dev/user.clj` so that developers can create
  a file there w/o worrying about it getting tracked in VCS
- Modifies `dev/user-repl.clj` so that developers can override the
  default REPL Puppet Server config settings in their own `user`
  namespace.
- Provides an example `user.clj.sample` file, which can be copied
  to `user.clj`, which has an example of how to override the
  config settings plus a convenience function for loading the
  `user-repl` namespace and launching Puppet Server.
- Modify `project.clj` to define `user` as the default REPL
  namespace.
