### PR TITLE
(MAINT) Make user repl config dynamic

### DIFF
--- a/dev/user.clj.sample
+++ b/dev/user.clj.sample
@@ -11,7 +11,7 @@
 ;; defaults.  You could just supply a map literal here, but I like to parse
 ;; the config from my config files on disk, so that I am using the same settings
 ;; that I would get if I ran the server via `lein run --config`.
-(defn jvm-puppet-conf
+(defn puppet-server-conf
   []
   (config/load-config "/Users/cprice/puppet-server/conf/puppet-server.conf"))
 

--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -17,7 +17,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Configuration
 
-(defn jvm-puppet-conf
+(defn puppet-server-conf
   "This function returns a map containing all of the config settings that
   will be used when running Puppet Server in the repl.  It provides some
   reasonable defaults, but if you'd like to use your own settings, you can
@@ -25,7 +25,7 @@
   will be used instead.  (If there is a `user.clj` on the classpath, lein
   will automatically load it when the REPL is started.)"
   []
-  (if-let [conf (resolve 'user/jvm-puppet-conf)]
+  (if-let [conf (resolve 'user/puppet-server-conf)]
     ((deref conf))
     {:global                {:logging-config "./dev/logback-dev.xml"}
      :os-settings           {:ruby-load-path jruby-testutils/ruby-load-path}
@@ -52,7 +52,7 @@
                request-handler-service
                puppet-server-config-service
                certificate-authority-service]
-              (jvm-puppet-conf))))
+              (puppet-server-conf))))
   (alter-var-root #'system tka/init)
   (tka/check-for-errors! system))
 


### PR DESCRIPTION
This commit modifies `user_repl.clj` and the sample `user.clj`
file to use a function instead of a var for the user-provided
config.

Prior to this, the config was read from disk as a var when the
REPL was first launched, and never re-loaded after that.  This
meant that doing a `reset` would not pick up changes you might
have made to the config files on disk; you needed to restart
the REPL to pick up those changes.

Now, the user config is acquired via a function call, which
means that your config files will be reloaded each time you
call `reset`.
