### PR TITLE
(SERVER-151) Move environment fns from jruby-testutils to service

### DIFF
--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -12,7 +12,9 @@
             [puppetlabs.trapperkeeper.app :as tka]
             [clojure.tools.namespace.repl :refer (refresh)]
             [clojure.java.io :as io]
-            [clojure.pprint :as pprint]))
+            [clojure.pprint :as pprint]
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Configuration
@@ -96,7 +98,7 @@
 (defn jruby-pool
   "Returns a reference to the current pool of JRuby interpreters."
   []
-  (jruby-testutils/jruby-pool system))
+  (jruby-core/pool->vec (context [:JRubyPuppetService :pool-context])))
 
 (defn puppet-environment-state
   "Given a JRuby instance, return the state information about the environments
@@ -119,4 +121,5 @@
   "Mark all environments, on all JRuby instances, stale so that they will
   be flushed from the environment cache."
   []
-  (jruby-testutils/mark-all-environments-expired! system))
+  (jruby-protocol/mark-all-environments-expired!
+    (tka/get-service system :JRubyPuppetService)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -193,6 +193,14 @@
   [context :- PoolContext]
   (:pool (get-pool-state context)))
 
+(schema/defn ^:always-validate
+  pool->vec :- [JRubyPuppetInstance]
+  [context :- PoolContext]
+  (-> (get-pool context)
+      .iterator
+      iterator-seq
+      vec))
+
 (defn instantiate-free-pool
   "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
   [size]
@@ -277,6 +285,14 @@
   [context :- PoolContext]
   {:post [(>= % 0)]}
   (.size (get-pool context)))
+
+(schema/defn ^:always-validate
+  mark-all-environments-expired!
+  [context :- PoolContext]
+  (doseq [jruby-instance (pool->vec context)]
+    (-> jruby-instance
+        :environment-registry
+        puppet-env/mark-all-environments-expired!)))
 
 (schema/defn ^:always-validate
   borrow-from-pool :- JRubyPuppetInstance

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -52,7 +52,12 @@
   (free-instance-count
     [this]
     (let [pool-context (:pool-context (tk-services/service-context this))]
-      (core/free-instance-count pool-context))))
+      (core/free-instance-count pool-context)))
+
+  (mark-all-environments-expired!
+    [this]
+    (let [pool-context (:pool-context (tk-services/service-context this))]
+      (core/mark-all-environments-expired! pool-context))))
 
 (defmacro with-jruby-puppet
   "Encapsulates the behavior of borrowing and returning an instance of

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -19,4 +19,8 @@
 
   (free-instance-count
     [this]
-    "The number of free JRubyPuppet instances left in the pool."))
+    "The number of free JRubyPuppet instances left in the pool.")
+
+  (mark-all-environments-expired!
+    [this]
+    "Mark all cached environments expired, in all JRuby instances."))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -95,19 +95,3 @@
     [jruby-core/create-pool-instance create-mock-pool-instance]
     (f)))
 
-(defn jruby-pool
-  [app]
-  (-> (tk-app/app-context app)
-      deref
-      (get-in [:JRubyPuppetService :pool-context :pool-state])
-      deref
-      :pool
-      .iterator
-      iterator-seq))
-
-(defn mark-all-environments-expired!
-  [app]
-  (doseq [jruby-instance (jruby-pool app)]
-    (-> jruby-instance
-        :environment-registry
-        puppet-env/mark-all-environments-expired!)))


### PR DESCRIPTION
We originally defined some functions for interacting with the
environment cache state in jruby-testutils.  This commit moves
the logic into the `JRubyPuppetService` instead; this will be necessary
in order to wire up the HTTP endpoint, since we will only have
access to the service and not to the entire TK app.
