### PR TITLE
(SERVER-203) Update to clj-http-client 0.4.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/certificate-authority "0.6.0"]
-                 [puppetlabs/http-client "0.3.1"]
+                 [puppetlabs/http-client "0.4.0"]
                  [org.jruby/jruby-core "1.7.15" :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
                  ;; NOTE: jruby-stdlib packages some unexpected things inside
                  ;; of its jar; please read the detailed notes above the

--- a/src/ruby/puppet-server-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/http_client.rb
@@ -5,8 +5,8 @@ require 'net/http'
 require 'base64'
 
 require 'java'
-java_import com.puppetlabs.http.client.SyncHttpClient
-java_import com.puppetlabs.http.client.RequestOptions
+SyncHttpClient = com.puppetlabs.http.client.Sync
+java_import com.puppetlabs.http.client.SimpleRequestOptions
 java_import com.puppetlabs.http.client.ResponseBodyType
 
 class Puppet::Server::HttpClient
@@ -51,7 +51,7 @@ class Puppet::Server::HttpClient
           "Basic #{Base64.strict_encode64 "#{credentials[:user]}:#{credentials[:password]}"}"
     end
 
-    request_options = RequestOptions.new(build_url(url))
+    request_options = SimpleRequestOptions.new(build_url(url))
     request_options.set_headers(headers)
     request_options.set_as(ResponseBodyType::TEXT)
     request_options.set_body(body)
@@ -61,7 +61,7 @@ class Puppet::Server::HttpClient
   end
 
   def get(url, headers)
-    request_options = RequestOptions.new(build_url(url))
+    request_options = SimpleRequestOptions.new(build_url(url))
     request_options.set_headers(headers)
     request_options.set_as(ResponseBodyType::TEXT)
     configure_ssl(request_options)


### PR DESCRIPTION
This commit updates Puppet Server to utilize puppetlabs/clj-http-client
version 0.4.0.
