### PR TITLE
(SERVER-116) Reuse client instances

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/certificate-authority "0.6.0"]
-                 [puppetlabs/http-client "0.3.1"]
+                 [puppetlabs/http-client "0.4.0"]
                  [org.jruby/jruby-core "1.7.15" :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
                  ;; NOTE: jruby-stdlib packages some unexpected things inside
                  ;; of its jar; please read the detailed notes above the


### PR DESCRIPTION
Reuse HTTP client instances in the ruby code rather than creating
a new one for every request.
