### PR TITLE
(maint) bump version to 0.5.0-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
     :password :env/nexus_jenkins_password
     :sign-releases false })
 
-(defproject puppetlabs/puppet-server "0.4.1-SNAPSHOT"
+(defproject puppetlabs/puppet-server "0.5.0-SNAPSHOT"
   :description "Puppet Server"
 
   :dependencies [[org.clojure/clojure "1.5.1"]


### PR DESCRIPTION
While we're not yet 100% decided on what the next version from this branch will be, it will definitely be at least `0.5.0`.
