### PR TITLE
(SERVER-29) Set JARS_NO_REQUIRE='true' on scripting containers.

### DIFF
--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -18,7 +18,8 @@
   [config args]
   (doto (ScriptingContainer.)
     (.setArgv (into-array String args))
-    (.setEnvironment (hash-map "GEM_HOME" (get-in config [:jruby-puppet :gem-home])))
+    (.setEnvironment (hash-map "GEM_HOME" (get-in config [:jruby-puppet :gem-home])
+                               "JARS_NO_REQUIRE" "true"))
     (.runScriptlet "load 'META-INF/jruby.home/bin/gem'")))
 
 (defn load-tk-config

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -115,7 +115,8 @@
                          (map fs/absolute-path ruby-load-path)))
     (.setCompatVersion (CompatVersion/RUBY1_9))
     (.setCompileMode RubyInstanceConfig$CompileMode/OFF)
-    (.setEnvironment (merge {"GEM_HOME" gem-home} jruby-puppet-env))))
+    (.setEnvironment (merge {"GEM_HOME" gem-home "JARS_NO_REQUIRE" "true"}
+                            jruby-puppet-env))))
 
 (defn empty-scripting-container
   "Creates a clean instance of `org.jruby.embed.ScriptingContainer` with no code loaded."


### PR DESCRIPTION
JARS_NO_REQUIRE is an environment variable which, if set to `true`, will prevent
the loading of embedded jars using the `require_jar' method of the
`jar-dependencies` gem.

This is required to ensure that jruby-openssel, which is loaded by the JRuby
Kernel whenever ruby code requires 'openssl', does not attempt to load embedded
bouncy castle jars onto the classpath. The effect is to ensure that
jruby-openssl uses the bouncycastle included as a requirement of
jvm-certificate-authority rather than the version included with JRuby, as well
as preventing jvm-ceritificate-authority from using JRuby's bouncycastle.
