### PR TITLE
(SERVER-208) Improve error message for missing `puppet-admin` section

### DIFF
--- a/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
+++ b/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
@@ -72,7 +72,11 @@
   "Given the full Puppet Server config map, extract and return the settings for
   the Puppet Admin web service."
   [config]
-  (:puppet-admin config))
+  (if-let [settings (:puppet-admin config)]
+    settings
+    (throw (IllegalArgumentException.
+             (str "'puppet admin' section required but not found in "
+                  "configuration settings")))))
 
 (schema/defn ^:always-validate build-ring-handler :- IFn
   "Returns the ring handler for the Puppet Admin API."


### PR DESCRIPTION
This commit improves the error message for a missing `puppet-admin` section in the Trapperkeeper configuration at startup.
