### PR TITLE
(maint) Add in support for the packaging repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor
 profiles.clj
 dev/user.clj
 .lein-repl-history
+ext/packaging

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,8 @@ PUPPET_SERVER_RUBY_SRC = File.join(PROJECT_ROOT, 'src', 'ruby', 'puppet-server-l
 TEST_GEMS_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_gems')
 TEST_BUNDLE_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_bundle')
 
+RAKE_ROOT = File.expand_path(File.dirname(__FILE__))
+
 def assemble_default_beaker_config
   if ENV["BEAKER_CONFIG"]
     return ENV["BEAKER_CONFIG"]
@@ -116,4 +118,41 @@ namespace :test do
       sh beaker
     end
   end
+end
+
+build_defs_file = File.join(RAKE_ROOT, 'ext', 'build_defaults.yaml')
+if File.exist?(build_defs_file)
+  begin
+    require 'yaml'
+    @build_defaults ||= YAML.load_file(build_defs_file)
+  rescue Exception => e
+    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
+    raise e
+  end
+  @packaging_url  = @build_defaults['packaging_url']
+  @packaging_repo = @build_defaults['packaging_repo']
+  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
+  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
+
+  namespace :package do
+    desc "Bootstrap packaging automation, e.g. clone into packaging repo"
+    task :bootstrap do
+      if File.exist?(File.join(RAKE_ROOT, "ext", @packaging_repo))
+        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
+      else
+        cd File.join(RAKE_ROOT, 'ext') do
+          %x{git clone #{@packaging_url}}
+        end
+      end
+    end
+    desc "Remove all cloned packaging automation"
+    task :implode do
+      rm_rf File.join(RAKE_ROOT, "ext", @packaging_repo)
+    end
+  end
+end
+
+begin
+  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
+rescue LoadError
 end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,0 +1,4 @@
+---
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_repo: 'packaging'
+project: 'puppetserver'


### PR DESCRIPTION
Since puppet-server is built with ezbake, this addition is not
necessary. However, we do want to be able to create release tickets for
the puppet-server project when the time comes for a release. It does
seem a little silly to add in support for the entire packaging repo just
to create release tickets, but ultimately that funcionality will be good
to have easy access to.

In order to create tickets, in the puppet server project, run the
following:

`rake package:implode package:bootstrap`
`rake pl:tickets BUILDER=melissa DEVELOPER=$you WRITER=jean
RELEASE=1.0.0 DATE=2014-12-15 JIRA_USER=$you PROJECT=SERVER`

The DEVELOPER corresponds to the persion who is going to coordinate the
release. The BUILDER is the Release Engineer working on the release, and
the JIRA_USER is the person who is creating the tickets. It is important
that the names all correspond to actual jira usernames.

More documentation is available at
https://github.com/puppetlabs/packaging/blob/master/tasks/tickets.rake#L408
