### PR TITLE
(SERVER-218) Docs on SSL server cert change and virtual ips

### DIFF
--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -73,7 +73,7 @@ running. We will try to work with the JRuby team to see if they can get a fix
 in for this, and upgrade to a newer JRuby when a fix becomes available. It might
 also be possible to patch the Puppet Ruby code to work around this issue.
 
-## Puppet Server Master Fails to Make SSL Connection to Servers with Different Certificates
+## Puppet Server Master Fails to Connect to Load-Balanced Servers with Different SSL Certificates
 
 [SERVER-207](https://tickets.puppetlabs.com/browse/SERVER-207): Intermittent
 SSL connection failures have been seen when the Puppet Server master tries to

--- a/documentation/ssl_server_certificate_change_and_virtual_ips.markdown
+++ b/documentation/ssl_server_certificate_change_and_virtual_ips.markdown
@@ -1,6 +1,6 @@
 # SSL Server Certificate Change and Virtual IP Addresses
 
-[SERVER-207] (https://tickets.puppetlabs.com/browse/SERVER-207) documents an
+[SERVER-207](https://tickets.puppetlabs.com/browse/SERVER-207) documents an
 issue that has been seen with Puppet Server but is not present with the
 Ruby-based Puppet master.  When the Puppet Server master needs to make an SSL
 client connection and the connection target is a virtual ip address which is
@@ -60,16 +60,16 @@ optionally turn off SSL session caching for the Jetty server (when hosting
 Puppet Server and/or PuppetDB) and/or Puppet Server master client requests.
 Several JIRA tickets have been filed to cover this work:
 
-* [TK-124] (https://tickets.puppetlabs.com/browse/TK-124) - Disable SSL session
+* [TK-124](https://tickets.puppetlabs.com/browse/TK-124) - Disable SSL session
   caching in the Jetty server
-* [TK-125] (https://tickets.puppetlabs.com/browse/TK-125) - Disable SSL session
+* [TK-125](https://tickets.puppetlabs.com/browse/TK-125) - Disable SSL session
   caching in the clj-http-client library that Puppet Server uses to make its
   client requests
-* [SERVER-216] (https://tickets.puppetlabs.com/browse/SERVER-216) - Utilize work
+* [SERVER-216](https://tickets.puppetlabs.com/browse/SERVER-216) - Utilize work
   in TK-125 to allow SSL session caching to be disabled for Puppet Server client
   requests.
 
-While the ability to disable SSL session caching would provide mitigation 
+While the ability to disable SSL session caching would provide mitigation
 against the triple handshake attack, allow different certificates to be used on
 each PuppetDB server, and provide for more backward compatible behavior with the
 Ruby Puppet master, the approach would have performance trade-offs.  Not having


### PR DESCRIPTION
This commit includes some documentation related to the issue discovered
in SERVER-207 - the JDK assertion made that the server certificate does
not change following a session resumption attempt and a renegotiation
attempted from servers behind a virtual ip address.
