### PR TITLE
(MAINT) Update TK and Kitchensink dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def tk-version "0.5.1")
+(def tk-version "1.0.1")
 (def tk-jetty-version "0.9.0")
-(def ks-version "0.7.2")
+(def ks-version "1.0.0")
 
 (defn deploy-info
   [url]

--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -28,7 +28,7 @@
   [app config-overrides & body]
   (let [tmp-conf (ks/temp-file "puppet-server" ".conf")]
     (fs/copy dev-config-file tmp-conf)
-    (let [config (-> (tk-config/load-config tmp-conf)
+    (let [config (-> (tk-config/load-config (.getPath tmp-conf))
                      (assoc-in [:global :logging-config] logging-test-conf-file)
                      (assoc-in [:jruby-puppet :master-conf-dir] master-conf-dir)
                      (assoc-in [:jruby-puppet :master-var-dir] master-var-dir)


### PR DESCRIPTION
This is required for the forthcoming `puppetserver foreground` cli command to work.
