### PR TITLE
(SERVER-250) Document jruby-pool Admin endpoint

### DIFF
--- a/documentation/admin-api/v1/jruby-pool.markdown
+++ b/documentation/admin-api/v1/jruby-pool.markdown
@@ -1,12 +1,31 @@
+---
+layout: default
+title: "Puppet Server: Admin API: JRuby Pool"
+canonical: "/puppetserver/latest/admin-api/v1/jruby-pool.html"
+---
 
-Puppet Server contains a pool of JRuby Instances.  Puppet Server adds a new
+Puppet Server contains a pool of JRuby instances.  Puppet Server adds a new, experimental
 endpoint to the master's HTTP API:
 
 
 ## `DELETE /puppet-admin-api/v1/jruby-pool`
 
-To flush the JRuby pool, make an HTTP
-request to this endpoint.
+This will remove all of the existing JRuby interpreters from the pool, allowing the memory occupied
+by these interpreters to be reclaimed by the JVM's garbage collector. The pool will then be refilled
+with new JRuby instances, each of which will load the latest Ruby code and related resources from disk.
+
+If you're developing new Ruby plugins that run on the Puppet master (functions, resource types, report handlers),
+you may need to force Puppet to re-load its plugins when a new version is ready to test. Killing the JRuby instances
+will do this, and it's faster than restarting the entire JVM process.
+
+Furthermore, if you are using multiple environments, this could be useful if you want to make
+sure that your JRuby instances are cleaned up and don't have conflicts based
+on common code that appears in multiple environments.
+
+This is an experimental feature, and as such the performance impact is unknown at this time. Also, please
+note that this operation is computationally-expensive, and as such Puppet Server will be unable to fulfill
+any incoming requests until the first of the new interpreters has been initialized, which may take several
+seconds.
 
 
 ### Response
@@ -16,16 +35,16 @@ The response body will be empty.
 
 
 ### Example
-```
+~~~
 $ curl -i -k -X DELETE https://localhost:8140/puppet-admin-api/v1/jruby-pool
 HTTP/1.1 204 No Content
-```
+~~~
 
 
-### Relevant Configuration
+## Relevant Configuration
 
 This endpoint is gated behind the security provisions in the `puppet-admin`
 part of the configuration data; see
-[this page](https://github.com/puppetlabs/puppet-server/blob/master/documentation/configuration.markdown)
+[this page](../../configuration.markdown)
 for more information.  In the example above, we have configured
 `authorization-required: false` for brevity.


### PR DESCRIPTION
Document the new jruby-pool endpoint that was recently added
to the HTTP Admin API.

This should be merged after https://github.com/puppetlabs/puppet-server/pull/317 (or the PR that will replace it once https://github.com/puppetlabs/puppet-server/pull/313 is merged).
