### PR TITLE
(SERVER-245) Avoid Puppet 4 being used as a dependency

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -8,6 +8,7 @@ ezbake: {
    pe: {}
    foss: {
       redhat: { dependencies: ["puppet >= 3.7.3"
+                               "puppet < 4.0.0"
                                "java-1.7.0-openjdk"],
                # This is terrible, but we need write access to puppet's
                # var/conf dirs, so we need to add ourselves to the group.
@@ -24,7 +25,9 @@ ezbake: {
              }
 
       debian: { dependencies: ["puppet-common (>= 3.7.3-1puppetlabs1)"
+                               "puppet-common (< 4.0.0-1puppetlabs1)"
                                "puppet (>= 3.7.3-1puppetlabs1)"
+                               "puppet (< 4.0.0-1puppetlabs1)"
                                "openjdk-7-jre-headless"],
                # see redhat comments on why this is terrible
                preinst: ["install --group={{user}} --owner={{user}} -d /var/lib/puppet/jruby-gems",


### PR DESCRIPTION
Without this patch puppet-server allows any version of Puppet >= 3.7.3.  This
is a problem because Puppet 4 is on the horizon and will introduce changes in
behavior incompatible with behaviors we depend on.

This patch addresses the problem by specifying that RedHat and Debian style
packages should only use puppet packages >= 3.7.3 and < 4.0.0 to satisfy the
dependencies for puppet-server.

I smoke tested this by building the packages and then installing the snapshot
RPM onto a RHEL 7 system.  This involved:

```
# in puppet-server project root
$ lein deploy
$ cd ../ezbake
$ lein run build puppetserver puppet-server-version=0.4.2-SNAPSHOT
```

On my RHEL test box:

```
$ sudo yum install http://builds.puppetlabs.lan/puppetserver/0.4.2.SNAPSHOT.2014.12.12T1450/artifacts/el/6/products/x86_64/puppetserver-0.4.2.SNAPSHOT.2014.12.12T1450-1.el6.noarch.rpm
```

This installation proceeded without problem while using our public yum
repositories.  The version specification appears to be correct when querying
the package:

```
$ rpm -q --requires -p puppetserver-0.4.2.SNAPSHOT.2014.12.12T1450-1.el6.noarch.rpm
/bin/bash
/bin/sh
/bin/sh
/bin/sh
/bin/sh
/usr/bin/env
chkconfig
config(puppetserver) = 0.4.2.SNAPSHOT.2014.12.12T1450-1.el6
java-1.7.0-openjdk
puppet >= 3.7.3
puppet < 4.0.0
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
```
