### PR TITLE
(SERVER-256) Fix failing FOSS upgrade smoke test.

### DIFF
--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -24,11 +24,16 @@ step "Install MRI Puppet Agents."
 step "Run puppet as puppet user to prevent permissions errors later."
   puppet_apply_as_puppet_user
 
-step "Install Puppet Server."
-  make_env = {
-    "prefix" => "/usr",
-    "confdir" => "/etc/",
-    "rundir" => "/var/run/puppetserver",
-    "initdir" => "/etc/init.d",
-  }
-  install_puppet_server master, 'puppetserver', make_env
+if (test_config[:puppetserver_install_mode] == :upgrade)
+  step "Upgrade Puppet Server."
+    upgrade_package(master, "puppetserver")
+else
+  step "Install Puppet Server."
+    make_env = {
+      "prefix" => "/usr",
+      "confdir" => "/etc/",
+      "rundir" => "/var/run/puppetserver",
+      "initdir" => "/etc/init.d",
+    }
+    install_puppet_server master, make_env
+end

--- a/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
@@ -6,18 +6,6 @@ step "Configure puppet.conf" do
   lay_down_new_puppet_conf( master,
                            {"main" => { "dns_alt_names" => "puppet,#{hostname},#{fqdn}",
                                        "verbose" => true }}, dir)
-
-  variant, _, _, _ = master['platform'].to_array
-
-  case variant
-  when /^(fedora|el|centos)$/
-    defaults_file = '/etc/sysconfig/puppetserver'
-  when /^(debian|ubuntu)$/
-    defaults_file = '/etc/default/puppetserver'
-  else
-    logger.notify("Not sure how to handle defaults for #{variant} yet...")
-  end
-  on master, "sed -i -e 's/\(SERVICE_NUM_RETRIES\)=[0-9]*/\1=60/' #{defaults_file}"
 end
 
 case test_config[:puppetserver_install_type]


### PR DESCRIPTION
- This adds a method, package_upgrade, which always upgrades the given package
  regardless of whether there are changes both to the new version of the config
  file and to the previously-installed version.
- Also removes the puppet_server_name parameter on install_puppet_server which
  is unnecessary since as it turns out there is only actually one package name
  for puppet_server.
- Also removes some completely dead code which attemptes to modify
  SERVICE_NUM_RETRIES in puppetserver's defaults file. This variable is no
  longer used.
