### PR TITLE
(SERVER-211) Update JRuby to 1.7.17 and fix String::crypt

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,11 +17,11 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/certificate-authority "0.6.0"]
                  [puppetlabs/http-client "0.4.0"]
-                 [org.jruby/jruby-core "1.7.15" :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
+                 [org.jruby/jruby-core "1.7.17" :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
                  ;; NOTE: jruby-stdlib packages some unexpected things inside
                  ;; of its jar; please read the detailed notes above the
                  ;; 'uberjar-exclusions' example toward the end of this file.
-                 [org.jruby/jruby-stdlib "1.7.15"]
+                 [org.jruby/jruby-stdlib "1.7.17"]
                  [com.github.jnr/jffi "1.2.7"]
                  [com.github.jnr/jffi "1.2.7" :classifier "native"]
                  [com.github.jnr/jnr-x86asm "1.0.2"]


### PR DESCRIPTION
Versions of JRuby prior to 1.7.17 used an old, DES-only implementation of String::crypt. With 1.7.17, it switched to the native crypt(3) implementation, bringing it in line with MRI.
