### PR TITLE
(maint) Add detailed docs on GEM_HOME and JRuby REPL's

### DIFF
--- a/documentation/dev_debugging.markdown
+++ b/documentation/dev_debugging.markdown
@@ -40,18 +40,38 @@ their capabilities (not unlike how you would debug Ruby code in the MRI interpre
 
 For more info on installing gems for Puppet Server, see [Puppet Server and Gems](./gems.markdown).
 
+## Ruby REPL incompatible with Lein REPL
+
+Please note that a REPL running in Ruby is incompatible with `lein repl`
+because JRuby will not receive data from standard input when running inside
+of `lein repl`.  To use a ruby REPL during development run `puppetserver` from
+source with `lein run` rather than `lein repl`:
+
+    $ lein run --config ~/.puppet-server/puppet-server.conf
+
+The `lein run` command will start the server in the foreground as normal.
+`pry` or `ruby-debug` will display an input prompt once the relevant statement
+is reached.  Expect to see the normal `lein run` output and then the Ruby REPL
+will present itself as compared to `lein repl` which presents a prompt early in
+the process lifecycle.  In this way the "ruby repl" is more of a breakpoint
+than a REPL in the Clojure sense.
+
 ## `ruby-debug`
+
+### Installation
 
 There are many gems available that provide various ways of debugging Ruby code
 depending on what version of Ruby and which Ruby interpreter you're running.
 One of the most common gems is `ruby-debug`, and there is a JRuby-compatible
 version available.  To install it for use in Puppet Server, run:
 
-    $ puppetserver gem install ruby-debug
+    $ sudo puppetserver gem install ruby-debug
 
 Or, if you're running puppetserver from source:
 
     $ lein gem -c /path/to/puppet-server.conf install ruby-debug
+
+### Usage
 
 After installing the gem, you can trigger the debugger by adding a line like this
 to any of the Ruby code that is run in Puppet Server (including the Puppet Ruby
@@ -61,14 +81,26 @@ code):
 
 ## `pry`
 
-Pry is another popular gem for introspecting Ruby code.  It is compatible with
-JRuby, so you can install it via:
+### Installation
 
-    $ puppetserver gem install pry
+Pry is another popular gem for introspecting Ruby code.  It is compatible with
+JRuby.  Install `pry` when running a packaged version of puppetserver using:
+
+    $ sudo puppetserver gem install pry --no-ri --no-rdoc
 
 Or, if you're running puppetserver from source:
 
-    $ lein gem -c /path/to/puppet-server.conf install pry
+    $ lein gem -c ~/puppet-server/puppet-server.conf -- install pry \
+      --no-ri --no-rdoc
+
+### Usage
+
+`puppetserver` should be run in the foreground to make use of the pry repl.
+This involves stopping the background service and starting the server in the
+foreground with the `puppet foreground` subcommand:
+
+    $ sudo service puppetserver stop
+    $ sudo puppetserver foreground
 
 After installing, you can add a line like this to the Ruby code:
 

--- a/documentation/dev_running_from_source.markdown
+++ b/documentation/dev_running_from_source.markdown
@@ -151,11 +151,14 @@ Other useful commands for developers:
 * `lein test` to run the clojure test suite
 * `rake spec` to run the jruby test suite
 
+Installing Ruby Gems for Development
+-----
+
+Please see the [Gems](./gems.markdown) document for detailed information on
+installing Ruby Gems for use in development and testing contexts.
+
 Debugging
 ------
 
-For more information about debugging, see our [Puppet Server: Debugging](./dev_debugging.markdown)
-documentation.
-
-
-
+For more information about debugging both Clojure and JRuby code, please see
+[Puppet Server: Debugging](./dev_debugging.markdown) documentation.


### PR DESCRIPTION
Without this patch the developer documentation does not inform the
reader how to install Ruby gem dependencies when running in development
mode, and how this process is subtly different from installing Gems for
use with JRuby spec tests and for use with a packaged `puppetserver`
install.  This is a problem because developers may need to install
support libraries such as `pry` in an effort to get a REPL much the same
way the lein repl is used and it is not clear how to accomplish this
given the three scenarios of from packages (production), development,
and testing.

This patch addresses the problem by providing detailed information about
how to install gem dependencies when running puppetserver from source
and how the process differs from installing gem dependencies for testing
and for production packages.

The change also addresses a known issue when running the pry repl from
within the lein repl where by STDIN is not shared between the two and
JRuby REPLs cannot read user input.

This patch also changes all occurrences of `$ puppetserver gem install`
to `$ sudo puppetserver gem install` because the former does not work as
expected as described in SERVER-263.
