### PR TITLE
(SERVER-259) Improve validate-memory-requirements! error message

### DIFF
--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -37,3 +37,34 @@
                  method
                  ", path: "
                  path))))))
+
+(defn assert-failure-msg
+  "Assert the message thrown by validate-memory-requirements! matches re"
+  [re behavior-msg]
+  (testing (str "the error " behavior-msg)
+    (is (thrown-with-msg? Error re (validate-memory-requirements!)))))
+
+(deftest validate-memory-requirements!-test
+  (testing "when /proc/meminfo does not exist"
+    (with-redefs [meminfo-content (constantly nil)
+                  max-heap-size 2097152]
+      (is (nil? (validate-memory-requirements!))
+          "nil when /proc/meminfo does not exist")))
+  (testing "when ram is > 1.1 times JVM max heap"
+    (with-redefs [meminfo-content #(str "MemTotal:        3878212 kB\n")
+                  max-heap-size 2097152]
+      (is (nil? (validate-memory-requirements!))
+          "nil when ram is > 1.1 times JVM max heap")))
+  (testing "when ram is < 1.1 times JVM max heap"
+    (with-redefs [meminfo-content #(str "MemTotal:        1878212 kB\n")
+                  max-heap-size 2097152]
+      (assert-failure-msg #"RAM (.*) JVM heap"
+                          "mentions RAM and JVM Heap size")
+      (assert-failure-msg #"JAVA_ARGS"
+                          "suggests the user configure JAVA_ARGS")
+      (assert-failure-msg #"computed as 1.1 *"
+                          "informs the user how required memory is calculated")
+      (assert-failure-msg #"/etc/sysconfig/puppetserver"
+                          "points the user to the EL config location")
+      (assert-failure-msg #"/etc/default/puppetserver"
+                          "points the user to the debian config location"))))


### PR DESCRIPTION
Without this patch the fatal error message given to the user when RAM is less
than 1.1 \* JVM heap size is the following following:

```
Not enough RAM. Puppet Server requires at least 2181MB of RAM.
```

This is a problem because it leads the user to believe they don't have enough
RAM.  They may conclude their only recourse is to add more memory when another
recourse is to decrease the configured maximum JVM heap size.

This patch addresses the problem by augmenting the error message to
specifically call out the JVM heap setting as a possible recourse.  The message
further tries to help the user by directing them to the JAVA_ARGS, -Xms, -Xmx
options, and the locations of the configuration files on Debian and Enterprise
Linux, the most common platforms.
