### PR TITLE
(SERVER-262) Fix `puppetserver gem env` subcommand

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -28,6 +28,7 @@ end
 gem_uninstall = "#{cli} gem uninstall"
 gem_list = "#{cli} gem list"
 gem_cleanup = "#{cli} gem cleanup"
+gem_env = "#{cli} gem env"
 
 # teardown
 teardown do
@@ -69,7 +70,7 @@ step "Clean up gems that are not required to meet a dependency."
 
 on(master, "#{gem_cleanup}")
 
-step "Verify that current list matchs initial list."
+step "Verify that current list matches initial list."
 
 final_installed_gems = get_gem_list(master, "#{gem_list}")
 
@@ -77,3 +78,10 @@ initial_installed_gems.each do |gem_info|
   assert_send([final_installed_gems, :include?, gem_info])
 end
 
+step "(SERVER-262) Verify the gem env command returns expected information"
+
+on(master, gem_env) do
+  assert_no_match(/ERROR:  While executing gem/, stdout, "gem env blew up!")
+  assert_match(/SHELL PATH:/, stdout, "PATH expected but not present")
+  assert_match(/INSTALLATION DIRECTORY:/, stdout, "GEM_HOME not present")
+end

--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -2,14 +2,28 @@
   (:import (org.jruby.embed ScriptingContainer))
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]))
 
+(defn cli-gem-environment
+  "Return a map representing the environment.  Environment variables
+  puppetserver needs are enforced while all other variables are preserved.
+  By design this function only modifies environment variables puppetserver
+  cares about.  The underlying principle is that a process should preserve as
+  much of the environment as possible in an effort to get out of the end users
+  way.  This includes PATH which should be fully managed elsewhere, e.g. the
+  service management framework."
+  [config initial-env]
+  (let [clojure-map-env (into {} initial-env)]
+    (assoc clojure-map-env
+           "GEM_HOME" (get-in config [:jruby-puppet :gem-home])
+           "JARS_NO_REQUIRE" "true")))
+
 (defn run!
   [config args]
-  (doto (ScriptingContainer.)
-    (.setArgv (into-array String args))
-    (.setEnvironment (hash-map "GEM_HOME"
-                               (get-in config [:jruby-puppet :gem-home])
-                               "JARS_NO_REQUIRE" "true"))
-    (.runScriptlet "load 'META-INF/jruby.home/bin/gem'")))
+  (let [container (new ScriptingContainer)
+        initial-env (.getEnvironment container)]
+    (doto container
+      (.setArgv (into-array String args))
+      (.setEnvironment (cli-gem-environment config initial-env))
+      (.runScriptlet "load 'META-INF/jruby.home/bin/gem'"))))
 
 (defn -main
   [& args]

--- a/test/unit/puppetlabs/puppetserver/cli/gem_test.clj
+++ b/test/unit/puppetlabs/puppetserver/cli/gem_test.clj
@@ -1,0 +1,22 @@
+(ns puppetlabs.puppetserver.cli.gem-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.puppetserver.cli.gem :refer :all]))
+
+(deftest cli-gem-environment-test
+  (let [fake-config {:jruby-puppet {:gem-home "/fake/path"}}
+        fake-env {"PATH" "/bin:/usr/bin", "FOO_DEBUG" "1"}]
+    (testing "The environment intended for the gem subcommand"
+      (is (not (empty? ((cli-gem-environment fake-config fake-env) "PATH")))
+          "has a non-empty PATH originating from the System")
+      (is (= "/bin:/usr/bin" ((cli-gem-environment fake-config fake-env)
+                               "PATH"))
+          "does not modify the PATH environment variable")
+      (is (= "/fake/path" ((cli-gem-environment fake-config fake-env)
+                            "GEM_HOME"))
+          "has GEM_HOME set to /fake/path from the provided config")
+      (is (= "true" ((cli-gem-environment fake-config fake-env)
+                      "JARS_NO_REQUIRE"))
+          "has JARS_NO_REQUIRE set to true")
+      (is (= "1" ((cli-gem-environment fake-config fake-env)
+                      "FOO_DEBUG"))
+          "preserves arbitrary environment vars for the end user"))))


### PR DESCRIPTION
Without this patch the `puppetserver gem env` subcommand bombs out with the
following error:

```
ERROR:  While executing gem ... (NoMethodError)
    undefined method `split' for nil:NilClass
```

The problem is a result of clearing the entire system environment resulting in
`ENV['PATH']` being `nil`.  This patch addresses the problem by associating
GEM_HOME and other variables into the system environment rather than clearing
it.
