### PR TITLE
(SERVER-253) Documentation for subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ Apache/Passenger Puppet master stack, there are a handful of differences
 due to changes in the underlying architecture. Please see [Puppet Server vs. Apache/Passenger Puppet Master](./documentation/puppetserver_vs_passenger.markdown) for details.
 
 ## Installing Puppet Server
- 
+
 Puppet Server depends on Puppet 3.7.3 or later, so if you install it on a system running an older version of Puppet, installation will also upgrade Puppet itself. Please see [Installing Puppet Server from Packages](./documentation/install_from_packages.markdown) for complete installation  requirements and instructions.
 
 ## Ruby and Puppet Server
 
 Puppet Server is compatible with Ruby 1.9. If you are installing
-Puppet Server on an existing system with Ruby 1.8, the behavior of some extensions, such as custom functions and custom resource types and providers, might change slightly. Generally speaking, this shouldn't affect core Puppet Ruby code, which is tested against both versions of Ruby. 
+Puppet Server on an existing system with Ruby 1.8, the behavior of some extensions, such as custom functions and custom resource types and providers, might change slightly. Generally speaking, this shouldn't affect core Puppet Ruby code, which is tested against both versions of Ruby.
 
-Puppet Server uses its own JRuby interpreter, which doesn't load gems or other code from your system Ruby. If you want Puppet Server to load any additional gems, use the Puppet Server-specific `gem` command to install them. See [Puppet Server and Gems](./documentation/gems.markdown) for more information about gems and Puppet Server. 
+Puppet Server uses its own JRuby interpreter, which doesn't load gems or other code from your system Ruby. If you want Puppet Server to load any additional gems, use the Puppet Server-specific `gem` command to install them. See [Puppet Server and Gems](./documentation/gems.markdown) for more information about gems and Puppet Server.
 
 ## Configuration
 
@@ -41,6 +41,15 @@ still applies to using an external Certificate Authority in conjunction with Pup
 
 In network configurations that require external SSL termination, you need to do a few things differently in Puppet Server. Please see the [External SSL Termination](./documentation/external_ssl_termination.markdown) page for details.
 
+## CLI Commands
+
+Puppet Server provides several command-line utilities useful for development
+and debugging purposes. These commands are all aware of `puppet-server.conf`
+and the gems & ruby code specific to Puppet Server and Puppet, while keeping
+them isolated from your system Ruby.
+
+For more information, see [Puppet Server Subcommands](./documentation/subcommands.markdown).
+
 ## Known Issues
 
 As this application is still in development, there are a few [known issues](./documentation/known_issues.markdown) that you should be aware of.
@@ -48,8 +57,9 @@ As this application is still in development, there are a few [known issues](./do
 ## Developer Documentation
 
 If you are a developer who wants to play with our code, these documents should prove useful:
-* [Running Puppet Server From Source](./documentation/dev_running_from_source.markdown) 
+* [Running Puppet Server From Source](./documentation/dev_running_from_source.markdown)
 * [Debugging](./documentation/dev_debugging.markdown)
+* [Pupppet Server Subcommands](./documentation/subcommands.markdown)
 
 ## Issue Tracker
 
@@ -82,4 +92,3 @@ grateful to the developers for building such a great product and for helping us
 work through a few bugs that we've discovered along the way.
 
 [leiningen]: https://github.com/technomancy/leiningen
-

--- a/documentation/gems.markdown
+++ b/documentation/gems.markdown
@@ -5,9 +5,10 @@ canonical: "/puppetserver/latest/gems.html"
 ---
 
 
-If you have server-side Ruby code in your modules, Puppet Server will run it via
-JRuby. Generally speaking, this only affects custom parser functions and report
-processors. For the vast majority of cases, this shouldn't pose any problems, as JRuby is highly compatible with vanilla Ruby.
+If you have server-side Ruby code in your modules, Puppet Server will run it
+via JRuby. Generally speaking, this only affects custom parser functions and
+report processors. For the vast majority of cases, this shouldn't pose any
+problems, as JRuby is highly compatible with vanilla Ruby.
 
 Puppet server will not load gems from user specified `GEM_HOME` and `GEM_PATH`
 environment variables because `puppetserver` unsets `GEM_PATH` and manages
@@ -44,11 +45,15 @@ re-populated the next time `rake spec` is run in your working copy.
 
 We isolate the Ruby load paths that are accessible to Puppet Server's
 JRuby interpreter, so that it doesn't load any gems or other code that
-you have installed on your system Ruby. If you want Puppet Server to load additional gems, use the Puppet Server-specific `gem` command to install them. For example, to install the foobar gem, use:
+you have installed on your system Ruby. If you want Puppet Server to load
+additional gems, use the Puppet Server-specific `gem` command to install them.
+For example, to install the foobar gem, use:
 
     $ sudo puppetserver gem install foobar --no-ri --no-rdoc
 
-The `puppetserver gem` command is simply a wrapper around the usual Ruby `gem` command, so all of the usual arguments and flags should work as expected. For example, to show your locally installed gems, run:
+The `puppetserver gem` command is simply a wrapper around the usual Ruby `gem`
+command, so all of the usual arguments and flags should work as expected.
+For example, to show your locally installed gems, run:
 
     $ puppetserver gem list
 
@@ -87,20 +92,25 @@ script.
 
 With the gem installed into the project tree `pry` can be invoked from inside
 Ruby code.  For more detailed information on `pry` see
-[Puppet Server: Debugging](./dev_debugging.markdown#pry)
+[Puppet Server: Debugging](./dev_debugging.markdown#pry).
 
 ## Gems with Native (C) Extensions
 
-If, in your custom parser functions or report processors, you're using Ruby gems
-that require native (C) extensions, you won't be able to install these gems under
-JRuby. In many cases, however, there are drop-in replacements implemented in Java.
-For example, the popular [Nokogiri](http://www.nokogiri.org/) gem for processing
-XML provides a completely compatible Java implementation that's automatically
-installed if you run `gem install` via JRuby or Puppet Server, so you shouldn't need
-to change your code at all.
+If, in your custom parser functions or report processors, you're using Ruby
+gems that require native (C) extensions, you won't be able to install these gems
+under JRuby. In many cases, however, there are drop-in replacements implemented
+in Java. For example, the popular [Nokogiri](http://www.nokogiri.org/) gem for
+processing XML provides a completely compatible Java implementation that's
+automatically installed if you run `gem install` via JRuby or Puppet Server,
+so you shouldn't need to change your code at all.
 
-In other cases, there may be a replacement gem available with a slightly different name;
-e.g., `jdbc-mysql` instead of `mysql`. The JRuby wiki [C Extension Alternatives](https://github.com/jruby/jruby/wiki/C-Extension-Alternatives)
+In other cases, there may be a replacement gem available with a slightly
+different name; e.g., `jdbc-mysql` instead of `mysql`. The JRuby wiki
+[C Extension Alternatives](https://github.com/jruby/jruby/wiki/C-Extension-Alternatives)
 page discusses this issue further.
 
-If you're using a gem that won't run on JRuby and you can't find a suitable replacement, please open a ticket on our [Issue Tracker](https://tickets.puppetlabs.com/browse/SERVER); we're definitely interested in helping provide solutions if there are common gems that are causing trouble for users!
+If you're using a gem that won't run on JRuby and you can't find a suitable
+replacement, please open a ticket on our
+[Issue Tracker](https://tickets.puppetlabs.com/browse/SERVER); we're definitely
+interested in helping provide solutions if there are common gems that are
+causing trouble for users!

--- a/documentation/subcommands.markdown
+++ b/documentation/subcommands.markdown
@@ -1,0 +1,111 @@
+---
+layout: default
+title: "Puppet Server: Subcommands"
+canonical: "/puppetserver/latest/subcommands.html"
+---
+
+
+There are several CLI commands that are provided to help with debugging and
+exploring Puppet Server. Most of the commands are the same ones you would use
+in a Ruby environment - such as `gem`, `ruby`, and `irb` - except they run
+against the JRuby installation & gems that Puppet Server uses instead of your
+system Ruby.
+
+The following subcommands are provided:
+* [gem](#gem)
+* [ruby](#ruby)
+* [irb](#irb)
+* [foreground](#foreground)
+
+The format for each subcommand is:
+
+```sh
+puppetserver <subcommand> [<args>]
+```
+
+When running from source, the format is:
+
+```sh
+lein <subcommand> -c /path/to/puppet-server.conf [--] [<args>]
+```
+
+Note that if one of the `<args>` begins with a `-` (like `--version` or `-e`)
+then the intermediate `--` above is required for the argument to be applied to
+the subcommand and not leiningen. This is not necessary when running from
+packages (i.e. `puppetserver <subcommand>`).
+
+## gem
+
+Manage gems that are isolated from system Ruby and only accessible to Puppet
+Server. This is a simple wrapper around the standard Ruby `gem` so all of the
+usual arguments and flags should work as expected.
+
+Examples:
+
+```sh
+$ puppetserver gem install pry --no-ri --no-rdoc
+```
+
+```sh
+$ lein gem -c /path/to/puppet-server.conf -- install pry --no-ri --no-rdoc
+```
+
+For more information, see [Puppet Server and Gems](./gems.markdown).
+
+## ruby
+
+Interpreter for the JRuby that Puppet Server uses. This is a simple wrapper
+around the standard Ruby `ruby` so all of the usual arguments and flags should
+work as expected.
+
+Useful when experimenting with gems installed via `puppetserver gem` and the
+Puppet and Puppet Server ruby source code.
+
+Examples:
+
+```sh
+$ puppetserver ruby -e "require 'puppet'; puts Puppet[:certname]"
+```
+
+```sh
+$ lein ruby -c /path/to/puppet-server.conf -- -e "require 'puppet'; puts Puppet[:certname]"
+```
+
+## irb
+
+Interactive REPL for the JRuby that Puppet Server uses. This is a simple wrapper
+around the standard Ruby `irb` so all of the usual arguments and flags should
+work as expected.
+
+Like the `ruby` subcommand, this is useful for experimenting in an interactive
+environment with any installed gems (via `puppetserver gem`) as well as the
+Puppet and Puppet Server ruby source code.
+
+Examples:
+
+```ruby
+$ puppetserver irb
+irb(main):001:0> require 'puppet'
+=> true
+irb(main):002:0> puts Puppet[:certname]
+centos6-64.localdomain
+=> nil
+```
+
+## foreground
+
+Start the Puppet Server but don't background it; similar to starting the service
+and then tailing the log.
+
+Accepts an optional `--debug` argument to raise the logging level to DEBUG.
+
+Examples:
+
+```java
+$ puppetserver foreground --debug
+2014-10-25 18:04:22,158 DEBUG [main] [p.t.logging] Debug logging enabled
+2014-10-25 18:04:22,160 DEBUG [main] [p.t.bootstrap] Loading bootstrap config from specified path: '/etc/puppetserver/bootstrap.cfg'
+2014-10-25 18:04:26,097 INFO  [main] [p.s.j.jruby-puppet-service] Initializing the JRuby service
+2014-10-25 18:04:26,101 INFO  [main] [p.t.s.w.jetty9-service] Initializing web server(s).
+2014-10-25 18:04:26,149 DEBUG [clojure-agent-send-pool-0] [p.s.j.jruby-puppet-agents] Initializing JRubyPuppet instances with the following settings:
+```


### PR DESCRIPTION
Considering that most of these commands are standard Ruby ones I didn't feel the need to go into much detail. This ended up being mostly about showing examples of each one and calling out the `--` when running from source.

Happy to go change any/all of this; I just wanted to get something up before the break!
