### PR TITLE
(PDB-2329) Shared storage for terminii

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -12,7 +12,8 @@
             [clojure.tools.logging :as log])
   (:import (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance)
            (com.puppetlabs.puppetserver PuppetProfiler)
-           (clojure.lang IFn)))
+           (clojure.lang IFn)
+           (java.util.concurrent ConcurrentHashMap)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants
@@ -227,7 +228,8 @@
    ;; For an explanation of why we need a separate agent for the `flush-instance`,
    ;; see the comments in jruby-puppet-agents/send-flush-instance
    :flush-instance-agent  (jruby-agents/pool-agent agent-shutdown-fn)
-   :pool-state            (atom (jruby-internal/create-pool-from-config config))})
+   :pool-state            (atom (jruby-internal/create-pool-from-config config))
+   :shared-terminus-state (ConcurrentHashMap.)})
 
 (schema/defn ^:always-validate
   free-instance-count

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -190,7 +190,8 @@
    id       :- schema/Int
    config   :- jruby-schemas/JRubyPuppetConfig
    flush-instance-fn :- IFn
-   profiler :- (schema/maybe PuppetProfiler)]
+   profiler :- (schema/maybe PuppetProfiler)
+   shared-terminus-state :- (schema/maybe java.util.Map)]
   (let [{:keys [ruby-load-path gem-home compile-mode
                 http-client-ssl-protocols http-client-cipher-suites
                 http-client-connect-timeout-milliseconds
@@ -219,6 +220,7 @@
       (.put puppet-server-config "http_idle_timeout_milliseconds"
         http-client-idle-timeout-milliseconds)
       (.put puppet-server-config "use_legacy_auth_conf" use-legacy-auth-conf)
+      (.put puppet-server-config "shared_terminus_state" shared-terminus-state)
       (let [instance (jruby-schemas/map->JRubyPuppetInstance
                        {:pool                 pool
                         :id                   id

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -5,7 +5,8 @@
            (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet EnvironmentRegistry)
            (com.puppetlabs.puppetserver.pool LockablePool)
            (org.jruby Main Main$Status RubyInstanceConfig)
-           (com.puppetlabs.puppetserver.jruby ScriptingContainer)))
+           (com.puppetlabs.puppetserver.jruby ScriptingContainer)
+           (java.util Map)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
@@ -137,7 +138,8 @@
    :profiler              (schema/maybe PuppetProfiler)
    :pool-agent            JRubyPoolAgent
    :flush-instance-agent  JRubyPoolAgent
-   :pool-state            PoolStateContainer})
+   :pool-state            PoolStateContainer
+   :shared-terminus-state (schema/maybe Map)})
 
 (def JRubyInstanceState
   "State metadata for an individual JRubyPuppet instance"

--- a/src/ruby/puppet-server-lib/puppet/server/config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/config.rb
@@ -25,6 +25,15 @@ class Puppet::Server::Config
       Puppet::Util::Profiler.add_profiler(@profiler)
     end
 
+    if puppet_server_config["shared_terminus_state"]
+      begin
+        require 'puppet/util/puppetdb/shared_terminus_state'
+        Puppet::Util::Puppetdb::SharedTerminusState.shared_terminus_state = puppet_server_config["shared_terminus_state"]
+      rescue LoadError => e
+        Puppet.warning "Could not inject shared state map into PuppetDB terminus: #{e.message}"
+      end
+    end
+
     Puppet::Server::HttpClient.initialize_settings(puppet_server_config)
     Puppet::Network::HttpPool.http_client_class = Puppet::Server::HttpClient
 

--- a/test/integration/puppetlabs/services/jruby/class_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/class_info_test.clj
@@ -80,7 +80,7 @@
                    {:master-code-dir (.getAbsolutePath code-dir)
                     :master-conf-dir (.getAbsolutePath conf-dir)})
           instance (jruby-internal/create-pool-instance!
-                     pool 0 config #() nil)
+                     pool 0 config #() nil nil)
           jruby-puppet (:jruby-puppet instance)
           container (:scripting-container instance)
           env-registry (:environment-registry instance)

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_internal_test.clj
@@ -36,7 +36,7 @@
                                                "TLS_RSA_WITH_AES_256_CBC_SHA"]
                    :http-client-ssl-protocols ["TLSv1" "TLSv1.2"]
                    :compile-mode :jit})
-          instance (jruby-internal/create-pool-instance! pool 0 config #() nil)
+          instance (jruby-internal/create-pool-instance! pool 0 config #() nil nil)
           container (:scripting-container instance)]
       (= RubyInstanceConfig$CompileMode/JIT
          (.getCompileMode container))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -11,7 +11,8 @@
            (org.jruby.embed LocalContextScope)
            (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance)
            (clojure.lang IFn)
-           (com.puppetlabs.puppetserver.jruby ScriptingContainer)))
+           (com.puppetlabs.puppetserver.jruby ScriptingContainer)
+           (java.util Map)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
@@ -82,7 +83,7 @@
    (create-pool-instance (jruby-puppet-config {:max-active-instances 1})))
   ([config]
    (let [pool (jruby-internal/instantiate-free-pool 1)]
-     (jruby-internal/create-pool-instance! pool 1 config default-flush-fn default-profiler))))
+     (jruby-internal/create-pool-instance! pool 1 config default-flush-fn default-profiler nil))))
 
 (defn create-mock-jruby-instance
   "Creates a mock implementation of the JRubyPuppet interface."
@@ -101,19 +102,22 @@
     id :- schema/Int
     config :- jruby-schemas/JRubyPuppetConfig
     flush-instance-fn :- IFn
-    profiler :- (schema/maybe PuppetProfiler)]
+    profiler :- (schema/maybe PuppetProfiler)
+    shared-terminus-state :- (schema/maybe Map)]
    (create-mock-pool-instance create-mock-jruby-instance
                               pool
                               id
                               config
                               flush-instance-fn
-                              profiler))
+                              profiler
+                              shared-terminus-state))
   ([mock-jruby-instance-creator-fn :- IFn
     pool :- jruby-schemas/pool-queue-type
     id :- schema/Int
     config :- jruby-schemas/JRubyPuppetConfig
     flush-instance-fn :- IFn
-    _ :- (schema/maybe PuppetProfiler)]
+    _ :- (schema/maybe PuppetProfiler)
+    _ :- (schema/maybe Map)]
    (let [instance (jruby-schemas/map->JRubyPuppetInstance
                    {:pool pool
                     :id id


### PR DESCRIPTION
(This goes with https://github.com/puppetlabs/puppetdb/pull/1875)

In order to support high availability, the PuppetDB terminus needs
to implement sticky failover. That is, after failing over to another
PuppetDB instance, it should keep using that instance for future
requests as long as possible. This is tricky when running in
PuppetServer, since it hosts multiple JRuby instances.

This adds a shared java.util.concurrent.ConcurrentHashMap instance as
the :shared-terminus-state entry of the jruby pool context. It is passed
to each JRuby instance when it is constructed and passed into the ruby
code via the puppet_server_config map (in the shared_terminus_state
key). Finally, the Puppet::Server::Config initialize method probes for
the existence of well-known class from the PuppetDB
terminus (Puppet::Util::Puppetdb::SharedTerminusState). If this class
exists, the map is injected into via its shared_terminus_state property.

In a more perfect world, there would be a uniform terminus API by which
this map could be passed from puppet-server to the terminus.