### PR TITLE
Updates to beaker 2.38.1, and works around BKR-650

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.24.0')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.38.1')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
   gem 'uuidtools'
   gem 'httparty'

--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -26,7 +26,7 @@ if puppet_build_version
   end
 end
 
-confine_block(:to, {:platform => puppetdb_supported_platforms}, master) do
+if puppetdb_supported_platforms.include?(master.platform) then
   step "Install PuppetDB repository" do
     install_puppetlabs_dev_repo(
       master, 'puppetdb', test_config[:puppetdb_build_version],


### PR DESCRIPTION
In the recent past I attempted to update puppet-server to beaker 2.38.1.  The initial runs through CI were successful, but the nightly runs failed, because they use a larger set of test hosts, including some that do not have PuppetDB packages (fedora 21 and ubuntu 15).

Trying again.  This time, rather than relying on beakers broken confine_block (which modifies the global hosts list), I'm using a simple if statement to choose when we install PuppetDB packages.

I'll update this comment to list the layout flavors I've tested.  We shouldn't merge until I've tested on Fedora 21, Ubuntu 15, (the previously failing OSes) as well as at least one of the working ones.  Meanwhile I'd appreciate comments/review.

Tested on 
fedora21-64ma.
ubuntu1504-64ma-32a