### PR TITLE
(maint) Add cljfmt and pl-clojure-style guide

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "ruby/hiera"]
 	path = ruby/hiera
 	url = https://github.com/puppetlabs/hiera.git
+[submodule "ext/pl-clojure-style"]
+	path = ext/pl-clojure-style
+	url = git://github.com/puppetlabs/pl-clojure-style.git

--- a/project.clj
+++ b/project.clj
@@ -128,6 +128,10 @@
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}
+             :cljfmt {:plugins [[lein-cljfmt "0.5.0"]
+                                [lein-parent "0.2.1"]]
+                      :parent-project {:path "ext/pl-clojure-style/project.clj"
+                                       :inherit [:cljfmt]}}
              :voom {:plugins [[lein-voom "0.1.0-20150115_230705-gd96d771" :exclusions [org.clojure/clojure]]]}}
 
   :test-selectors {:integration :integration
@@ -135,7 +139,8 @@
 
   :aliases {"gem" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.gem"]
             "ruby" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.ruby"]
-            "irb" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.irb"]}
+            "irb" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.irb"]
+            "cljfmt" ["with-profile" "+cljfmt" "cljfmt"]}
 
   ; tests use a lot of PermGen (jruby instances)
   :jvm-opts ["-XX:MaxPermSize=256m" "-Xmx2g"]


### PR DESCRIPTION
This has been taken up by trapperkeeper. Thought it might be valuable to start the discussion on puppet-server?

_as in my editor isn't formatting quite correctly, I keep getting dinged for it in PRs and instead of mucking with it, if `cljfmt` is the future, I just want to use it_

This change in and of itself should be innocuous but the application of these styles needs to be somewhat coordinated with a lull in large PRs - it will cause a hellacious rebase for outstanding work.