### PR TITLE
(SERVER-1245) Pass OID shortnames to tk-auth

### DIFF
--- a/dev-resources/puppetlabs/puppetserver/auth_conf_test/csr_attributes.yaml
+++ b/dev-resources/puppetlabs/puppetserver/auth_conf_test/csr_attributes.yaml
@@ -1,0 +1,3 @@
+---
+extension_requests:
+  1.3.6.1.4.1.34380.1.2.2: 'Burning Finger'

--- a/dev-resources/puppetlabs/puppetserver/auth_conf_test/custom_trusted_oid_mapping.yaml
+++ b/dev-resources/puppetlabs/puppetserver/auth_conf_test/custom_trusted_oid_mapping.yaml
@@ -1,0 +1,5 @@
+---
+oid_mapping:
+  1.3.6.1.4.1.34380.1.2.2:
+    shortname: 'shiningfinger'
+    longname: 'Shining Finger'

--- a/dev-resources/puppetlabs/puppetserver/auth_conf_test/puppet.conf
+++ b/dev-resources/puppetlabs/puppetserver/auth_conf_test/puppet.conf
@@ -1,3 +1,5 @@
 [main]
 certname = localhost
 rest_authconfig = ./dev-resources/puppetlabs/puppetserver/auth_conf_test/auth.conf
+trusted_oid_mapping_file = ./dev-resources/puppetlabs/puppetserver/auth_conf_test/custom_trusted_oid_mapping.yaml
+csr_attributes = ./dev-resources/puppetlabs/puppetserver/auth_conf_test/csr_attributes.yaml

--- a/project.clj
+++ b/project.clj
@@ -55,7 +55,7 @@
 
 
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/trapperkeeper-authorization "0.5.0"]
+                 [puppetlabs/trapperkeeper-authorization "0.6.0"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
                  [puppetlabs/dujour-version-check "0.1.2" :exclusions [org.clojure/tools.logging]]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_disabled_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_disabled_service.clj
@@ -8,7 +8,7 @@
    This is required to maintain service loading order on installations
    which are not running a CA service."
   CaService
-  []
+  [[:AuthorizationService wrap-with-authorization-check]]
   (initialize-master-ssl!
     [this master-settings certname]
     (log/info "CA disabled; ignoring SSL initialization for Master"))
@@ -21,6 +21,6 @@
     [this localcacrl]
     (log/info "CA disabled; ignoring retrieval of CA CRL"))
 
-  (get-oid-mappings
+  (get-auth-handler
     [this]
-    {}))
+    wrap-with-authorization-check))

--- a/src/clj/puppetlabs/services/ca/certificate_authority_disabled_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_disabled_service.clj
@@ -19,4 +19,8 @@
 
   (retrieve-ca-crl!
     [this localcacrl]
-    (log/info "CA disabled; ignoring retrieval of CA CRL")))
+    (log/info "CA disabled; ignoring retrieval of CA CRL"))
+
+  (get-oid-mappings
+    [this]
+    {}))

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.services.ca.certificate-authority-service
   (:require [clojure.tools.logging :as log]
             [puppetlabs.trapperkeeper.core :as tk]
+            [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.puppetserver.certificate-authority :as ca]
             [puppetlabs.services.ca.certificate-authority-core :as core]
             [puppetlabs.services.protocols.ca :refer [CaService]]
@@ -13,9 +14,11 @@
    [:AuthorizationService wrap-with-authorization-check]]
   (init
    [this context]
-   (let [path           (get-route this)
-         settings       (ca/config->ca-settings (get-config))
-         puppet-version (get-in-config [:puppet-server :puppet-version])]
+   (let [path (get-route this)
+         settings (ca/config->ca-settings (get-config))
+         puppet-version (get-in-config [:puppet-server :puppet-version])
+         custom-oid-file (get-in-config [:puppet-server :trusted-oid-mapping-file])
+         oid-mappings (ca/get-oid-mappings custom-oid-file)]
      (ca/validate-settings! settings)
      (ca/initialize! settings)
      (log/info "CA Service adding a ring handler")
@@ -27,9 +30,9 @@
              comidi/routes->handler)
          settings
          path
-         wrap-with-authorization-check
-         puppet-version)))
-   context)
+         (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))
+         puppet-version))
+     (assoc context :oid-mappings oid-mappings)))
 
   (initialize-master-ssl!
    [this master-settings certname]
@@ -44,4 +47,8 @@
   (retrieve-ca-crl!
     [this localcacrl]
     (ca/retrieve-ca-crl! (get-in-config [:puppet-server :cacrl])
-                         localcacrl)))
+                         localcacrl))
+
+  (get-oid-mappings
+    [this]
+    (:oid-mappings (tk-services/service-context this))))

--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -43,7 +43,8 @@
     :serial
     :signeddir
     :ssl-client-header
-    :ssl-client-verify-header})
+    :ssl-client-verify-header
+    :trusted-oid-mapping-file})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; internal helpers

--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -14,7 +14,7 @@
    [:PuppetServerConfigService get-config]
    [:JRubyPuppetService]
    [:AuthorizationService wrap-with-authorization-check]
-   [:CaService get-oid-mappings]]
+   [:CaService get-auth-handler]]
   (init
     [this context]
     (let [ca-service (tk-services/get-service this :CaService)
@@ -37,13 +37,12 @@
                                                             false)
                                    ((partial comidi/context path))
                                    comidi/routes->handler)
-          oid-map (get-oid-mappings)
           master-handler-info {:mount       (master-core/get-master-mount
                                               master-ns
                                               master-route-config)
                                :handler     (master-core/get-wrapped-handler
                                               master-route-handler
-                                              (fn [request] (wrap-with-authorization-check request {:oid-map oid-map}))
+                                              (get-auth-handler)
                                               puppet-version
                                               use-legacy-auth-conf)
                                :api-version master-core/puppet-API-version}
@@ -62,7 +61,7 @@
                                               ca-route-handler
                                               ca-settings
                                               ca-mount
-                                              (fn [request] (wrap-with-authorization-check request {:oid-map oid-map}))
+                                              (get-auth-handler)
                                               puppet-version)
                                :api-version ca-core/puppet-ca-API-version}))
           ring-handler (legacy-routes-core/build-ring-handler

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -13,7 +13,7 @@
   [[:WebroutingService add-ring-handler get-route]
    [:PuppetServerConfigService get-config]
    [:RequestHandlerService handle-request]
-   [:CaService initialize-master-ssl! retrieve-ca-cert! retrieve-ca-crl! get-oid-mappings]
+   [:CaService initialize-master-ssl! retrieve-ca-cert! retrieve-ca-crl! get-auth-handler]
    [:JRubyPuppetService]
    [:AuthorizationService wrap-with-authorization-check]
    [:VersionedCodeService get-code-content]]
@@ -37,8 +37,7 @@
          environment-class-cache-enabled (get-in config
                                                  [:jruby-puppet
                                                   :environment-class-cache-enabled]
-                                                 false)
-         oid-map (get-oid-mappings)]
+                                                 false)]
      (version-check/check-for-updates! {:product-name product-name} update-server-url)
 
      (retrieve-ca-cert! localcacert)
@@ -54,7 +53,7 @@
                                                           jruby-service
                                                           get-code-content
                                                           handle-request
-                                                          (fn [request] (wrap-with-authorization-check request {:oid-map oid-map}))
+                                                          (get-auth-handler)
                                                           environment-class-cache-enabled)
                               ((partial comidi/context path))
                               comidi/routes->handler))]

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -13,7 +13,7 @@
   [[:WebroutingService add-ring-handler get-route]
    [:PuppetServerConfigService get-config]
    [:RequestHandlerService handle-request]
-   [:CaService initialize-master-ssl! retrieve-ca-cert! retrieve-ca-crl!]
+   [:CaService initialize-master-ssl! retrieve-ca-cert! retrieve-ca-crl! get-oid-mappings]
    [:JRubyPuppetService]
    [:AuthorizationService wrap-with-authorization-check]
    [:VersionedCodeService get-code-content]]
@@ -37,7 +37,8 @@
          environment-class-cache-enabled (get-in config
                                                  [:jruby-puppet
                                                   :environment-class-cache-enabled]
-                                                 false)]
+                                                 false)
+         oid-map (get-oid-mappings)]
      (version-check/check-for-updates! {:product-name product-name} update-server-url)
 
      (retrieve-ca-cert! localcacert)
@@ -53,7 +54,7 @@
                                                           jruby-service
                                                           get-code-content
                                                           handle-request
-                                                          wrap-with-authorization-check
+                                                          (fn [request] (wrap-with-authorization-check request {:oid-map oid-map}))
                                                           environment-class-cache-enabled)
                               ((partial comidi/context path))
                               comidi/routes->handler))]

--- a/src/clj/puppetlabs/services/protocols/ca.clj
+++ b/src/clj/puppetlabs/services/protocols/ca.clj
@@ -4,4 +4,5 @@
   "Describes the functionality of the CA service."
   (initialize-master-ssl! [this master-settings certname])
   (retrieve-ca-cert! [this localcacert])
-  (retrieve-ca-crl! [this localcacrl]))
+  (retrieve-ca-crl! [this localcacrl])
+  (get-oid-mappings [this]))

--- a/src/clj/puppetlabs/services/protocols/ca.clj
+++ b/src/clj/puppetlabs/services/protocols/ca.clj
@@ -5,4 +5,4 @@
   (initialize-master-ssl! [this master-settings certname])
   (retrieve-ca-cert! [this localcacert])
   (retrieve-ca-crl! [this localcacrl])
-  (get-oid-mappings [this]))
+  (get-auth-handler [this]))

--- a/src/clj/puppetlabs/services/puppet_admin/puppet_admin_service.clj
+++ b/src/clj/puppetlabs/services/puppet_admin/puppet_admin_service.clj
@@ -9,7 +9,7 @@
    [:WebroutingService add-ring-handler get-route]
    [:JRubyPuppetService]
    [:AuthorizationService wrap-with-authorization-check]
-   [:CaService get-oid-mappings]]
+   [:CaService get-auth-handler]]
   (init
     [this context]
     (log/info "Starting Puppet Admin web app")
@@ -18,8 +18,7 @@
           jruby-service (services/get-service this :JRubyPuppetService)
           whitelist-settings (core/puppet-admin-settings->whitelist-settings
                                settings)
-          client-whitelist (:client-whitelist whitelist-settings)
-          oid-map (get-oid-mappings)]
+          client-whitelist (:client-whitelist whitelist-settings)]
       (cond
         (or (false? (:authorization-required whitelist-settings))
             (not-empty client-whitelist))
@@ -44,5 +43,5 @@
         (core/build-ring-handler route
                                  whitelist-settings
                                  jruby-service
-                                 (fn [request] (wrap-with-authorization-check request {:oid-map oid-map})))))
+                                 (get-auth-handler))))
     context))

--- a/src/clj/puppetlabs/services/puppet_admin/puppet_admin_service.clj
+++ b/src/clj/puppetlabs/services/puppet_admin/puppet_admin_service.clj
@@ -8,7 +8,8 @@
   [[:ConfigService get-config]
    [:WebroutingService add-ring-handler get-route]
    [:JRubyPuppetService]
-   [:AuthorizationService wrap-with-authorization-check]]
+   [:AuthorizationService wrap-with-authorization-check]
+   [:CaService get-oid-mappings]]
   (init
     [this context]
     (log/info "Starting Puppet Admin web app")
@@ -17,7 +18,8 @@
           jruby-service (services/get-service this :JRubyPuppetService)
           whitelist-settings (core/puppet-admin-settings->whitelist-settings
                                settings)
-          client-whitelist (:client-whitelist whitelist-settings)]
+          client-whitelist (:client-whitelist whitelist-settings)
+          oid-map (get-oid-mappings)]
       (cond
         (or (false? (:authorization-required whitelist-settings))
             (not-empty client-whitelist))
@@ -42,5 +44,5 @@
         (core/build-ring-handler route
                                  whitelist-settings
                                  jruby-service
-                                 wrap-with-authorization-check)))
+                                 (fn [request] (wrap-with-authorization-check request {:oid-map oid-map})))))
     context))

--- a/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
+++ b/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
@@ -207,3 +207,80 @@
                         "modules/foo/files/bar?code_id=foobar&environment=test" false)]
           (is (= 403 (:status response)) (ks/pprint-to-string response))
           (is (re-find #"Forbidden request" (:body response)) (ks/pprint-to-string response))))))))
+
+(deftest ^:integration custom-oids-passed-to-tk-auth
+  (testing "puppet server successfully utilizes custom oid mappings and puppet short names for authorization"
+    (bootstrap/with-puppetserver-running
+      app
+      {:authorization {:version 1
+                       :allow-header-cert-info true
+                       :rules
+                       [{:match-request {:path "/"
+                                         :type "path"}
+                         :allow {:extensions {:shiningfinger "Burning Finger"}}
+                         :deny {:extensions {:pp_uuid "not a uuid"}}
+                         :sort-order 1
+                         :name "all endpoints"}]}
+       :webserver     {:host "localhost"
+                       :port 8080}}
+      (let [good-exts [{:oid      "1.3.6.1.4.1.34380.1.1.1"
+                        :critical false
+                        :value    "12345"}
+                       {:oid      "1.3.6.1.4.1.34380.1.2.2"
+                        :critical false
+                        :value    "Burning Finger"}]
+            bad-exts [{:oid      "1.3.6.1.4.1.34380.1.1.1"
+                       :critical false
+                       :value    "not a uuid"}
+                      {:oid      "1.3.6.1.4.1.34380.1.2.2"
+                       :critical false
+                       :value    "Burning Finger"}]
+            create-cert (fn [extensions]
+                          (:cert (ssl-simple/gen-self-signed-cert
+                                   "ssl-client"
+                                   1
+                                   {:keylength  512
+                                    :extensions extensions})))
+            allowable-cert (create-cert good-exts)
+            deniable-cert (create-cert bad-exts)
+            url-encode-cert (fn [cert]
+                              (let [cert-writer (StringWriter.)
+                                    _ (ssl-utils/cert->pem! cert cert-writer)]
+                                (ring-codec/url-encode cert-writer)))
+            url-encoded-allowable-cert (url-encode-cert allowable-cert)
+            url-encoded-deniable-cert (url-encode-cert deniable-cert)
+            http-get-no-ssl (fn [path cert]
+                              (http-client/get
+                                (str "http://localhost:8080/" path)
+                                {:headers {"Accept" "pson"
+                                           "X-Client-Cert" cert
+                                           "X-Client-DN" "CN=private"
+                                           "X-Client-Verify" "SUCCESS"}
+                                 :as :text}))]
+        (testing "ca endpoints use oid shortnames"
+          (let [path "/puppet-ca/v1/certificate_status/localhost"]
+            (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
+            (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
+
+        (testing "master endpoints use oid shortnames"
+          (let [path "puppet/v3/catalog/private?environment=production"]
+            (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
+            (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
+
+        (testing "legacy endpoints support oid shortnames"
+          (let [path "/v2.0/environments"]
+            (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
+            (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
+
+        (testing "puppet-admin endpoints support oid shortnames"
+          (let [path "/puppet-admin-api/v1/environment-cache?environment=production"
+                http-delete (fn [cert]
+                              (http-client/delete
+                                (str "http://localhost:8080/" path)
+                                {:headers {"Accept" "pson"
+                                           "X-Client-Cert" cert
+                                           "X-Client-DN" "CN=private"
+                                           "X-Client-Verify" "SUCCESS"}
+                                 :as :text}))]
+            (is (= 204 (:status (http-delete url-encoded-allowable-cert))))
+            (is (= 403 (:status (http-delete url-encoded-deniable-cert))))))))))

--- a/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
+++ b/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
@@ -210,77 +210,83 @@
 
 (deftest ^:integration custom-oids-passed-to-tk-auth
   (testing "puppet server successfully utilizes custom oid mappings and puppet short names for authorization"
-    (bootstrap/with-puppetserver-running
-      app
-      {:authorization {:version 1
-                       :allow-header-cert-info true
-                       :rules
-                       [{:match-request {:path "/"
-                                         :type "path"}
-                         :allow {:extensions {:shiningfinger "Burning Finger"}}
-                         :deny {:extensions {:pp_uuid "not a uuid"}}
-                         :sort-order 1
-                         :name "all endpoints"}]}
-       :webserver     {:host "localhost"
-                       :port 8080}}
-      (let [good-exts [{:oid      "1.3.6.1.4.1.34380.1.1.1"
-                        :critical false
-                        :value    "12345"}
-                       {:oid      "1.3.6.1.4.1.34380.1.2.2"
-                        :critical false
-                        :value    "Burning Finger"}]
-            bad-exts [{:oid      "1.3.6.1.4.1.34380.1.1.1"
-                       :critical false
-                       :value    "not a uuid"}
-                      {:oid      "1.3.6.1.4.1.34380.1.2.2"
-                       :critical false
-                       :value    "Burning Finger"}]
-            create-cert (fn [extensions]
-                          (:cert (ssl-simple/gen-self-signed-cert
-                                   "ssl-client"
-                                   1
-                                   {:keylength  512
-                                    :extensions extensions})))
-            allowable-cert (create-cert good-exts)
-            deniable-cert (create-cert bad-exts)
-            url-encode-cert (fn [cert]
-                              (let [cert-writer (StringWriter.)
-                                    _ (ssl-utils/cert->pem! cert cert-writer)]
-                                (ring-codec/url-encode cert-writer)))
-            url-encoded-allowable-cert (url-encode-cert allowable-cert)
-            url-encoded-deniable-cert (url-encode-cert deniable-cert)
-            http-get-no-ssl (fn [path cert]
-                              (http-client/get
-                                (str "http://localhost:8080/" path)
-                                {:headers {"Accept" "pson"
-                                           "X-Client-Cert" cert
-                                           "X-Client-DN" "CN=private"
-                                           "X-Client-Verify" "SUCCESS"}
-                                 :as :text}))]
-        (testing "ca endpoints use oid shortnames"
-          (let [path "/puppet-ca/v1/certificate_status/localhost"]
-            (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
-            (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
+    (logging/with-test-logging
+      (bootstrap/with-puppetserver-running
+        app
+        {:authorization {:version 1
+                         :allow-header-cert-info true
+                         :rules
+                         [{:match-request {:path "/"
+                                           :type "path"}
+                           :allow {:extensions {:shiningfinger "Burning Finger"}}
+                           :deny {:extensions {:pp_uuid "not a uuid"}}
+                           :sort-order 1
+                           :name "all endpoints"}]}
+         :webserver {:host "localhost"
+                     :port 8080}}
+        (let [good-exts [{:oid "1.3.6.1.4.1.34380.1.1.1"
+                          :critical false
+                          :value "12345"}
+                         {:oid "1.3.6.1.4.1.34380.1.2.2"
+                          :critical false
+                          :value "Burning Finger"}]
+              bad-exts [{:oid "1.3.6.1.4.1.34380.1.1.1"
+                         :critical false
+                         :value "not a uuid"}
+                        {:oid "1.3.6.1.4.1.34380.1.2.2"
+                         :critical false
+                         :value "Burning Finger"}]
+              create-cert (fn [extensions]
+                            (:cert (ssl-simple/gen-self-signed-cert
+                                     "ssl-client"
+                                     1
+                                     {:keylength 512
+                                      :extensions extensions})))
+              allowable-cert (create-cert good-exts)
+              deniable-cert (create-cert bad-exts)
+              url-encode-cert (fn [cert]
+                                (let [cert-writer (StringWriter.)
+                                      _ (ssl-utils/cert->pem! cert cert-writer)]
+                                  (ring-codec/url-encode cert-writer)))
+              url-encoded-allowable-cert (url-encode-cert allowable-cert)
+              url-encoded-deniable-cert (url-encode-cert deniable-cert)
+              http-get-no-ssl (fn [path cert]
+                                (http-client/get
+                                  (str "http://localhost:8080/" path)
+                                  {:headers {"Accept" "pson"
+                                             "X-Client-Cert" cert
+                                             "X-Client-DN" "CN=private"
+                                             "X-Client-Verify" "SUCCESS"}
+                                   :as :text}))]
+          (testing "ca endpoints use oid shortnames"
+            (let [path "/puppet-ca/v1/certificate_status/localhost"]
+              (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
+              (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
 
-        (testing "master endpoints use oid shortnames"
-          (let [path "puppet/v3/catalog/private?environment=production"]
-            (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
-            (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
+          (testing "master endpoints use oid shortnames"
+            (let [path "puppet/v3/catalog/private?environment=production"]
+              (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
+              (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
 
-        (testing "legacy endpoints support oid shortnames"
-          (let [path "/v2.0/environments"]
-            (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
-            (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
+          (testing "legacy endpoints support oid shortnames"
+            (let [path "/v2.0/environments"]
+              (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
+              (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
 
-        (testing "puppet-admin endpoints support oid shortnames"
-          (let [path "/puppet-admin-api/v1/environment-cache?environment=production"
-                http-delete (fn [cert]
-                              (http-client/delete
-                                (str "http://localhost:8080/" path)
-                                {:headers {"Accept" "pson"
-                                           "X-Client-Cert" cert
-                                           "X-Client-DN" "CN=private"
-                                           "X-Client-Verify" "SUCCESS"}
-                                 :as :text}))]
-            (is (= 204 (:status (http-delete url-encoded-allowable-cert))))
-            (is (= 403 (:status (http-delete url-encoded-deniable-cert))))))))))
+          (testing "legacy CA endpoints support oid shortnames"
+            (let [path "/production/certificate_statuses/all"]
+              (is (= 200 (:status (http-get-no-ssl path url-encoded-allowable-cert))))
+              (is (= 403 (:status (http-get-no-ssl path url-encoded-deniable-cert))))))
+
+          (testing "puppet-admin endpoints support oid shortnames"
+            (let [path "/puppet-admin-api/v1/environment-cache?environment=production"
+                  http-delete (fn [cert]
+                                (http-client/delete
+                                  (str "http://localhost:8080/" path)
+                                  {:headers {"Accept" "pson"
+                                             "X-Client-Cert" cert
+                                             "X-Client-DN" "CN=private"
+                                             "X-Client-Verify" "SUCCESS"}
+                                   :as :text}))]
+              (is (= 204 (:status (http-delete url-encoded-allowable-cert))))
+              (is (= 403 (:status (http-delete url-encoded-deniable-cert)))))))))))

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -12,6 +12,7 @@
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as webrouting]
             [puppetlabs.services.puppet-admin.puppet-admin-service :as puppet-admin]
+            [puppetlabs.services.ca.certificate-authority-disabled-service :as ca]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization]
             [puppetlabs.http.client.sync :as http-client]
             [me.raynes.fs :as fs]
@@ -278,7 +279,8 @@
            jetty9/jetty9-service
            webrouting/webrouting-service
            puppet-admin/puppet-admin-service
-           authorization/authorization-service]
+           authorization/authorization-service
+           ca/certificate-authority-disabled-service]
           (merge (jruby-testutils/jruby-puppet-tk-config
                    (jruby-testutils/jruby-puppet-config {:max-active-instances      4
                                                          :max-requests-per-instance 10

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -8,7 +8,8 @@
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
-            [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-testutils]))
+            [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-testutils]
+            [puppetlabs.trapperkeeper.services.authorization.authorization-service :as tk-auth]))
 
 
 
@@ -29,7 +30,8 @@
 
         [profiler/puppet-profiler-service
          jruby/jruby-puppet-pooled-service
-         disabled/certificate-authority-disabled-service]
+         disabled/certificate-authority-disabled-service
+         tk-auth/authorization-service]
 
         (-> (jruby-testutils/jruby-puppet-tk-config
               (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))


### PR DESCRIPTION
Ensure the puppet OID shortname mappings and the custom
oid mappings provided in the custom oid mappings file are passed
to tk-auth.

This will require a release of tk-auth before it can be merged.