### PR TITLE
(SERVER-1258) Update puppet-agent version to greenify tests

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "192cd8fa98c5458d00b189787920a6f526cc736d", :string)
+                         "609a3b381fcdc2ff294fefbe2aeb3679ede3349a", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This commit updates the puppet-agent ref to a version that passes the
puppetdb smoke tests and also updates the puppet submodule commit to
match the puppet change.