### PR TITLE
(SERVER-1245) Add trusted oid mapping to env classes int test

### DIFF
--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -643,7 +643,9 @@
           :ssl-client-verify-header
           "X_ssl-client-verify-header-FOO"
           :puppet-version
-          "1.2.3"}))
+          "1.2.3"
+          :trusted-oid-mapping-file
+          (str bootstrap/master-conf-dir "/custom_trusted_oid_mapping.yaml")}))
 
 (deftest ^:integration class-info-updated-after-cache-flush-during-prior-request
   (let [puppet-server-settings (default-puppet-server-settings)


### PR DESCRIPTION
This commit adds a `trusted-oid-mapping-file` setting value that the
mock pupppetserver config service in the test uses.  This was added in
order for the newly added code which handles the trusted oid mapping
file to work without any problems - although it isn't directly related
to anything that the specific test validates.