### PR TITLE
(SERVER-1258) Update puppet-agent ref to greenify tests

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "609a3b381fcdc2ff294fefbe2aeb3679ede3349a", :string)
+                         "043c6c30b29539bd89e1ab9dc2cc9843ffa13503", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This commit updates the puppet-agent ref to fix PUP-6176, which had been
causing puppetdb module failures on ubuntu-14.04.