### PR TITLE
(MAINT) fixes a logic error in PR#1009

### DIFF
--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -25,24 +25,3 @@ if puppet_build_version
     end
   end
 end
-
-if puppetdb_supported_platforms.include?(master.platform) then
-  step "Install PuppetDB repository" do
-    install_puppetlabs_dev_repo(
-      master, 'puppetdb', test_config[:puppetdb_build_version],
-      repo_config_dir, install_opts)
-
-    # Internal packages on ubuntu/debian aren't authenticated and thus apt
-    # will fail to install PuppetDB on those platforms.
-    # This hack tells apt that we can trust the PuppetDB packages until RE-6014
-    # is resolved, at which point this [trusted=yes] will already be in the file
-    # and we can delete the on(master, "sed ...") block below.
-    # This should make the puppetlabs-puppetdb module happily install PuppetDB on
-    # ubuntu/debian.
-    on(master, <<TRUSTPACKAGES)
-if [ -e /etc/apt/sources.list.d/pl-puppetdb* ]; then
-  sed -i -e 's/deb/deb [trusted=yes]/1' /etc/apt/sources.list.d/pl-puppetdb*
-fi
-TRUSTPACKAGES
-  end
-end

--- a/acceptance/suites/pre_suite/foss/35_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/35_install_pdb.rb
@@ -1,0 +1,24 @@
+confine :to, :platform => puppetdb_supported_platforms
+
+install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
+repo_config_dir = 'tmp/repo_configs'
+
+step "Install PuppetDB repository" do
+  install_puppetlabs_dev_repo(
+    master, 'puppetdb', test_config[:puppetdb_build_version],
+    repo_config_dir, install_opts)
+
+  # Internal packages on ubuntu/debian aren't authenticated and thus apt
+  # will fail to install PuppetDB on those platforms.
+  # This hack tells apt that we can trust the PuppetDB packages until RE-6014
+  # is resolved, at which point this [trusted=yes] will already be in the file
+  # and we can delete the on(master, "sed ...") block below.
+  # This should make the puppetlabs-puppetdb module happily install PuppetDB on
+  # ubuntu/debian.
+  on(master, <<TRUSTPACKAGES)
+if [ -e /etc/apt/sources.list.d/pl-puppetdb* ]; then
+sed -i -e 's/deb/deb [trusted=yes]/1' /etc/apt/sources.list.d/pl-puppetdb*
+fi
+TRUSTPACKAGES
+end 
+


### PR DESCRIPTION
The previous PR treated puppetdb_supported_platforms as an array of strings.  It is actually an array of regexps.  See SERVER-1292