### PR TITLE
Take up ring-middleware helpers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,7 @@
                  [org.clojure/tools.macro "0.1.5"]
                  [org.clojure/tools.reader "1.0.0-alpha1"]
                  [org.clojure/tools.logging "0.3.1"]
+                 [ring/ring-servlet "1.4.0"]
                  [hiccup "1.0.5"]
                  ;; end version conflict resolution dependencies
 
@@ -59,6 +60,7 @@
                  [puppetlabs/trapperkeeper-authorization "0.6.1"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
+                 [puppetlabs/ring-middleware "0.3.0"]
                  [puppetlabs/dujour-version-check "0.1.2" :exclusions [org.clojure/tools.logging]]
                  [puppetlabs/http-client "0.5.0"]
                  [puppetlabs/comidi "0.3.1"]]

--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,7 @@
                  [puppetlabs/trapperkeeper-authorization "0.6.1"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/ring-middleware "0.3.0"]
+                 [puppetlabs/ring-middleware "0.3.1"]
                  [puppetlabs/dujour-version-check "0.1.2" :exclusions [org.clojure/tools.logging]]
                  [puppetlabs/http-client "0.5.0"]
                  [puppetlabs/comidi "0.3.1"]]

--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -57,7 +57,7 @@
 
 (defn wrap-with-environment-validation
   "Middleware function which validates the presence and syntactical content
-  of an environment in a ring request.  If validation fails, a ::bad-request
+  of an environment in a ring request.  If validation fails, a :bad-request
   slingshot exception is thrown."
   [handler]
   (fn [request]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.services.jruby.jruby-puppet-service
   (:require [clojure.tools.logging :as log]
+            [puppetlabs.ring-middleware.core :as mw]
             [puppetlabs.services.jruby.jruby-puppet-core :as core]
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
@@ -148,10 +149,9 @@
                         "jruby-puppet.max-active-instances.")}))
      (when (jruby-schemas/shutdown-poison-pill? pool-instance#)
        (jruby/return-instance ~jruby-service pool-instance# ~reason)
-       (sling/throw+
-        {:type    ::service-unavailable
-         :message (str "Attempted to borrow a JRuby instance from the pool "
-                       "during a shutdown. Please try again.")}))
+       (mw/throw-service-unavailable!
+         (str "Attempted to borrow a JRuby instance from the pool "
+              "during a shutdown. Please try again.")))
      (if (jruby-schemas/retry-poison-pill? pool-instance#)
        (do
          (jruby/return-instance ~jruby-service pool-instance# ~reason)

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -13,6 +13,7 @@
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.puppetserver.jruby-request :as jruby-request]
             [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.ring-middleware.core :as middleware]
             [cheshire.core :as cheshire]
             [clojure.string :as str]
             [bidi.schema :as bidi-schema]
@@ -296,7 +297,7 @@
           (not-modified-response parsed-tag)
           (-> (response-with-etag info-as-json parsed-tag)
               (rr/content-type "application/json"))))
-      (ringutils/json-response info-for-json))))
+      (middleware/json-response 200 info-for-json))))
 
 (schema/defn ^:always-validate
   environment-class-info-fn :- IFn
@@ -539,9 +540,9 @@
   [handler :- IFn
    puppet-version :- schema/Str]
   (-> handler
-      ringutils/wrap-exception-handling
-      ringutils/wrap-request-logging
-      ringutils/wrap-response-logging
+      (middleware/wrap-uncaught-errors :plain)
+      middleware/wrap-request-logging
+      middleware/wrap-response-logging
       (ringutils/wrap-with-puppet-version-header puppet-version)))
 
 (schema/defn ^:always-validate get-master-route-config

--- a/test/unit/puppetlabs/puppetserver/ringutils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ringutils_test.clj
@@ -40,18 +40,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Tests
-
-(deftest json-response-test
-  (testing "json response"
-    (let [source {"key1" "val1", "key2" "val2"}
-          response (json-response source)]
-      (testing "has 200 status code"
-        (is (= 200 (:status response))))
-      (testing "has json content-type"
-        (is (= "application/json" (get-in response [:headers "Content-Type"]))))
-      (testing "is properly converted to a json string"
-        (is (= (cheshire/parse-string (:body response)) source))))))
+;;; Test
 
 (deftest wrap-with-cert-whitelist-check-test
   (let [ring-handler (build-ring-handler

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -369,7 +369,7 @@
                           {:uri "/v1/certificate_statuses/"
                            :request-method :get})]
             (is (= 400 (:status response)))
-            (is (= "text/plain" (get-in response [:headers "Content-Type"])))
+            (is (re-matches #"text/plain.*" (get-in response [:headers "Content-Type"])))
             (is (= "Missing URL Segment" (:body response)))))
 
         (testing "allows special characters in ignored path segment"


### PR DESCRIPTION
Previously we copied and pasted (with slight changes) much of what made
up our ringutils.

As part of TK-214, the re-usable portions have moved to
puppetlabs/ring-middleware. This patch updates puppetserver to use those
common library functions and removes the outdated vendored functions.