### PR TITLE
(MAINT) Assign default values for all BEAKER_ vars 

### DIFF
--- a/acceptance/scripts/generic/testrun.sh
+++ b/acceptance/scripts/generic/testrun.sh
@@ -3,13 +3,13 @@ set -x
 
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
 export GENCONFIG_LAYOUT="${GENCONFIG_LAYOUT:-redhat6-64ma-ubuntu1404-64a-windows2008r2-64a}"
-export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-acceptance/suites/tests/}"
+export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-acceptance/suites/tests}"
 export BEAKER_PRESUITE="${BEAKER_PRESUITE:-acceptance/suites/pre_suite/foss}"
-export BEAKER_POSTSUITE="acceptance/suites/post_suite/"
-export BEAKER_OPTIONS="acceptance/config/beaker/options.rb"
-export BEAKER_CONFIG="acceptance/scripts/hosts.cfg"
-export BEAKER_KEYFILE="~/.ssh/id_rsa-acceptance"
-export BEAKER_HELPER="acceptance/lib/helper.rb"
+export BEAKER_POSTSUITE="${BEAKER_POSTSUITE:-acceptance/suites/post_suite}"
+export BEAKER_OPTIONS="${BEAKER_OPTIONS:-acceptance/config/beaker/options.rb}"
+export BEAKER_CONFIG="${BEAKER_CONFIG:-acceptance/scripts/hosts.cfg}"
+export BEAKER_KEYFILE="${BEAKER_KEYFILE:-~/.ssh/id_rsa-acceptance}"
+export BEAKER_HELPER="${BEAKER_HELPER:-acceptance/lib/helper.rb}"
 
 bundle install --path vendor/bundle
 


### PR DESCRIPTION
Use Bash's operator for assigning default values to unset env variables so that values set in the environment can trump defaults hardcoded in the script.