### PR TITLE
DO NOT MERGE: 

### DIFF
--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -10,7 +10,14 @@
 ## PuppetDB successfully received the agent's report sent from Puppet Server.
 ## We can just run the agent that's on the master for this.
 
-confine :to, {:platform => puppetdb_supported_platforms}, master
+# This confine was originally
+# confine :to, {:platform => puppetdb_supported_platforms}, master
+# With , master present, execution unexpectedly enters the body of the
+# test when we expect the test to be skipped.  BKR-650 maybe relavent.
+# Be aware that future modifications to this test might, especially
+# if there are test operations added that run against agents instead of just
+# masters.
+confine :to, {:platform => puppetdb_supported_platforms}
 
 require 'json'
 


### PR DESCRIPTION
(MAINT) Modifies the confine statement so that... ...the test body is not entered just because a master is present.  
  Tested with ubuntu 15 master.  The puppetdb integration test was skipped as expected.  
  Tested with redhat6 master; the puppetdb_integration test ran as expected.

However, I'm still concerned about this change.  I understand the documentation for "confine" to say that we ought to be able to pass ", master" in, as the host array.  We want the confine to only evaluate the master, not the entire host array.  By deleting ", master", I'm asking the confine to evaluate the entire host array in the beaker options hash.

Read https://github.com/puppetlabs/beaker/blob/master/lib/beaker/dsl/structure.rb#L135 for more...

For our case, I think beaker confine is broken here:
https://github.com/puppetlabs/beaker/blob/master/lib/beaker/dsl/structure.rb#L205