### PR TITLE
(MAINT) Assign default values expansion for all BEAKER_*

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -206,13 +206,13 @@ knows which hosts to use.
 
 ## Using the handy shell script
 If all that seems like too much work, we have a script that should
-make things much simpler for you.
+make things much simpler for you. It relies on the built-in defaults
+for all arguments. All you provide is the two environment variables
+`PACKAGE_BUILD_VERSION` and `PUPPET_VERSION`. Thus:
 
 1. Set the environment variables `PUPPET_VERSION` and
    `PACKAGE_BUILD_VERSION` as described previously.
-2. Set the environment variable `GENCONFIG_LAYOUT` to a layout string
-   that `beaker-hostgenerator` understands.
-3. Execute `acceptance/scripts/generic/testrun.sh -p` to start a
+2. Execute `acceptance/scripts/generic/testrun.sh -p` to start a
    complete run of the tests and preserve the hosts. When the tests
    complete, the script makes a copy of the (modified) config file as
    `hosts_preserved.yml` at the top level of the repo.
@@ -220,9 +220,8 @@ make things much simpler for you.
 ```
    export PACKAGE_BUILD_VERSION='2.1.0.SNAPSHOT.2015.04.17T0057'
    export PUPPET_VERSION='1.0.0'
-   export GENCONFIG_LAYOUT=redhat7-64m-64a
    acceptance/scripts/generic/testrun.sh -p
 ```
    
-4. To reuse the hosts saved from a previous run, specify `-r` instead
+3. To reuse the hosts saved from a previous run, specify `-r` instead
    of `-p`, that is, `acceptance/scripts/generic/testrun.sh -r`.

--- a/acceptance/scripts/generic/testrun.sh
+++ b/acceptance/scripts/generic/testrun.sh
@@ -3,13 +3,13 @@ set -x
 
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
 export GENCONFIG_LAYOUT="${GENCONFIG_LAYOUT:-redhat6-64ma-ubuntu1404-64a-windows2008r2-64a}"
-export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-acceptance/suites/tests/}"
+export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-acceptance/suites/tests}"
 export BEAKER_PRESUITE="${BEAKER_PRESUITE:-acceptance/suites/pre_suite/foss}"
-export BEAKER_POSTSUITE="acceptance/suites/post_suite/"
-export BEAKER_OPTIONS="acceptance/config/beaker/options.rb"
-export BEAKER_CONFIG="acceptance/scripts/hosts.cfg"
-export BEAKER_KEYFILE="~/.ssh/id_rsa-acceptance"
-export BEAKER_HELPER="acceptance/lib/helper.rb"
+export BEAKER_POSTSUITE="${BEAKER_POSTSUITE:-acceptance/suites/post_suite}"
+export BEAKER_OPTIONS="${BEAKER_OPTIONS:-acceptance/config/beaker/options.rb}"
+export BEAKER_CONFIG="${BEAKER_CONFIG:-acceptance/scripts/hosts.cfg}"
+export BEAKER_KEYFILE="${BEAKER_KEYFILE:-~/.ssh/id_rsa-acceptance}"
+export BEAKER_HELPER="${BEAKER_HELPER:-acceptance/lib/helper.rb}"
 
 bundle install --path vendor/bundle
 


### PR DESCRIPTION
Use Bash's syntax for assigning default values to variables so that values set in the environment can trump defaults set in the script. Update README to reflect these changes.