### PR TITLE
(MAINT) Bump puppet agent dep to da1e61e

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "8fd6efcae71d49291bbaef236f04bcb58a6feb72", :string)
+                         "da1e61eb7308be2617c3ebcee41785f49a5eac8c", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This commit bumps the puppet-agent dependency up to da1e61e and the
corresponding Ruby puppet submodule up to 57315f.