### PR TITLE
(MAINT) Corrects the assignment in the skip_test to a test.

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -1,6 +1,6 @@
 require 'json'
 
-skip_test 'SKIP: This test should only run in puppetserver FOSS.' if options[:type] = 'pe'
+skip_test 'SKIP: This test should only run in puppetserver FOSS.' if options[:type] == 'pe'
 
 test_name 'SERVER-1118: Validate code-id-command feature in FOSS'
 


### PR DESCRIPTION
Otherwise, this always skips.