### PR TITLE
(maint) Bump puppet version

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "043c6c30b29539bd89e1ab9dc2cc9843ffa13503", :string)
+                         "ab9e395ef55565a8e896bd847e90a1c3dfb225f5", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.4.2')
+      expect(subject).to eq('4.5.0')
     end
   end
 


### PR DESCRIPTION
This bump includes updates to the Xenial puppet-agent build that
compiles facter with JNI support.