### PR TITLE
(maint) Bump puppet-agent to a more recent sha

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "ab9e395ef55565a8e896bd847e90a1c3dfb225f5", :string)
+                         "3200ce85a656330f6bfee7cce5d5817e0f38ce03", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
Previously, we were running puppetserver tests against a sha of
puppet-agent that hadn't been fully built out. This commit updates the
sha to use for acceptance tests to default to a sha with a full
complement of packages available to test against.