### PR TITLE
(SERVER-1273) Add back in info that is missing from log messages

### DIFF
--- a/src/ruby/puppet-server-lib/puppet/server/logger.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/logger.rb
@@ -5,7 +5,7 @@ java_import org.slf4j.LoggerFactory
 
 Puppet::Util::Log.newdesttype :logback do
   def handle(msg)
-    output = msg.message
+    output = msg.to_s
     if msg.source.size > 0
       output = "#{msg.source} #{output}"
     end


### PR DESCRIPTION
As of this commit in PUP:

https://github.com/puppetlabs/puppet/commit/6debe89bd935d56e2ec424900ad6f573bbf45552

It became critical that log destinations call `to_s` on the `Log` object
in order to ensure that they log all of the extra information (such as
backtraces).  Prior to this commit, the Puppet Server logback log
destination was calling `message` instead of `to_s`, so we were missing
all of the extra detailed information in our log messages.