### PR TITLE
(TK-360) Fix acceptance tests testing denied response

### DIFF
--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -64,7 +64,7 @@ with_puppet_running_on(master, {}) do
     assert_allowed
 
     curl_unauthenticated('/puppet/v3/environments')
-    assert_denied(/denied by rule 'puppetlabs environments'/)
+    assert_denied(/\/puppet\/v3\/environments \(method :get\)/)
   end
 
   step 'catalog endpoint' do
@@ -72,10 +72,10 @@ with_puppet_running_on(master, {}) do
     assert_allowed
 
     curl_authenticated('/puppet/v3/catalog/notme?environment=production')
-    assert_denied(/denied by rule 'puppetlabs catalog'/)
+    assert_denied(/\/puppet\/v3\/catalog\/notme \(method :get\)/)
 
     curl_unauthenticated("/puppet/v3/catalog/#{masterfqdn}?environment=production")
-    assert_denied(/denied by rule 'puppetlabs catalog'/)
+    assert_denied(/\/puppet\/v3\/catalog\/#{masterfqdn} \(method :get\)/)
   end
 
   step 'node endpoint' do
@@ -83,10 +83,10 @@ with_puppet_running_on(master, {}) do
     assert_allowed
 
     curl_authenticated('/puppet/v3/node/notme?environment=production')
-    assert_denied(/denied by rule 'puppetlabs node'/)
+    assert_denied(/\/puppet\/v3\/node\/notme \(method :get\)/)
 
     curl_unauthenticated("/puppet/v3/node/#{masterfqdn}?environment=production")
-    assert_denied(/denied by rule 'puppetlabs node'/)
+    assert_denied(/\/puppet\/v3\/node\/#{masterfqdn} \(method :get\)/)
   end
 
   step 'report endpoint' do
@@ -94,10 +94,10 @@ with_puppet_running_on(master, {}) do
     assert_allowed
 
     curl_authenticated(report_query('notme'))
-    assert_denied(/denied by rule 'puppetlabs report'/)
+    assert_denied(/\/puppet\/v3\/report\/notme \(method :put\)/)
 
     curl_unauthenticated(report_query(masterfqdn))
-    assert_denied(/denied by rule 'puppetlabs report'/)
+    assert_denied(/\/puppet\/v3\/report\/#{masterfqdn} \(method :put\)/)
   end
 
   step 'file_metadata endpoint' do
@@ -107,7 +107,7 @@ with_puppet_running_on(master, {}) do
     assert_allowed(404)
 
     curl_unauthenticated('/puppet/v3/file_metadata/modules/foo?environment=production')
-    assert_denied(/denied by rule 'puppetlabs file'/)
+    assert_denied(/\/puppet\/v3\/file_metadata\/modules\/foo \(method :get\)/)
   end
 
   step 'file_content endpoint' do
@@ -117,7 +117,7 @@ with_puppet_running_on(master, {}) do
     assert_allowed(404)
 
     curl_unauthenticated('/puppet/v3/file_content/modules/foo?environment=production')
-    assert_denied(/denied by rule 'puppetlabs file'/)
+    assert_denied(/\/puppet\/v3\/file_content\/modules\/foo \(method :get\)/)
   end
 
   step 'file_bucket_file endpoint' do
@@ -127,7 +127,7 @@ with_puppet_running_on(master, {}) do
     assert_allowed(400)
 
     curl_unauthenticated('/puppet/v3/file_bucket_file/md5/123?environment=production')
-    assert_denied(/denied by rule 'puppetlabs file'/)
+    assert_denied(/\/puppet\/v3\/file_bucket_file\/md5\/123 \(method :get\)/)
   end
 
   step 'status endpoint' do
@@ -142,7 +142,7 @@ with_puppet_running_on(master, {}) do
     assert_allowed(400)
 
     curl_unauthenticated('/puppet/v3/static_file_content/foo/bar?environment=production')
-    assert_denied(/denied by rule 'puppetlabs static file content'/)
+    assert_denied(/\/puppet\/v3\/static_file_content\/foo\/bar \(method :get\)/)
   end
 
   step 'certificate_revocation_list endpoint' do


### PR DESCRIPTION
Previously, all the checks of requests being denied were matching against the
rule. However, for TK-360 the rule name was removed from the response. This
commit updates those assertions to match against the path and method (which
are in the response) instead.