### PR TITLE
(MAINT) Added explicit ring-servlet 1.4.0 pin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -123,6 +123,7 @@
                                                [org.clojure/clojure ~clj-version]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
+                                               [ring/ring-servlet "1.4.0"]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :plugins [[puppetlabs/lein-ezbake "0.3.25"]]
                       :name "puppetserver"}


### PR DESCRIPTION
This commit adds an explicit ezbake packaging pin to ring/ring-servlet
1.4.0.  In prior commits, the ezbake-time dependency on
puppetlabs/trapperkeeper-webserver-jetty9 1.5.6 would try to bring in
ring/ring-servlet 1.1.8 whereas the recently added dependency on
puppetlabs/trapperkeeper-authorization 0.6.1 would try to bring in
ring/ring-servlet 1.4.0.  This commit resolves the conflict in favor of
the later ring/ring-servlet version.