### PR TITLE
(MAINT) add hyphen back to uberjar name

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -77,7 +77,7 @@
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]]
 
-  :uberjar-name "puppetserver-release.jar"
+  :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"
                        :group "puppet"
                        :build-type "foss"


### PR DESCRIPTION
This is currently blocked on a tk-j9 PR and release.

Because of how EZBake finds the pid on Cent6 (involves a pgrep for
the jar file name), upgrades on that distro will fail if we change
the jar name without changing the ezbake logic as well.  It seems
easier to just change the jar name back for now.