### PR TITLE
(MAINT) Bump up default borrow timeout for jruby-pool-int tests

### DIFF
--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -40,7 +40,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utilities
 
-(def default-borrow-timeout 180000)
+(def default-borrow-timeout 300000)
 
 (defn timed-deref
   [ref]


### PR DESCRIPTION
This commit bumps up the default timeout for jruby-pool-int test
borrows from 3 minutes to 5 minutes.  This compensates for sporadic
failures we've seen in Travis CI when it took more than 3 minutes for a
JRuby pool initialization to complete.