### PR TITLE
(maint) add hyphen back to uberjar name

### DIFF
--- a/acceptance/suites/tests/00_smoke/validate-excluded-bc-jars.rb
+++ b/acceptance/suites/tests/00_smoke/validate-excluded-bc-jars.rb
@@ -1,10 +1,10 @@
 
 test_name "Validate excluded BC jars are not in packaged uberjar."
 
-package_name = options['puppetserver-package'] 
+package_name = options['puppetserver-package']
 install_dir = get_defaults_var(master, "INSTALL_DIR")
 
-jarfile = File.join(install_dir, "puppetserver-release.jar")
+jarfile = File.join(install_dir, "puppet-server-release.jar")
 
 on(master, "test -e \"#{jarfile}\"")
 install_package(master, "unzip")

--- a/documentation/dev_trace_func.markdown
+++ b/documentation/dev_trace_func.markdown
@@ -47,7 +47,7 @@ Puppet Server from a package install, stdout should be routed to the
 Lines of output from `set_trace_func` look like the following:
 
 ~~~
- c-call /usr/share/puppetserver/puppetserver-release.jar!/META-INF/jruby.home/lib/ruby/shared/jopenssl19/openssl/ssl-internal.rb:30 initialize OpenSSL::X509::Store
+ c-call /usr/share/puppetserver/puppet-server-release.jar!/META-INF/jruby.home/lib/ruby/shared/jopenssl19/openssl/ssl-internal.rb:30 initialize OpenSSL::X509::Store
 ~~~
 
 You could use this technique to locate any references made to specific class

--- a/documentation/restarting.markdown
+++ b/documentation/restarting.markdown
@@ -15,7 +15,7 @@ Starting in version 2.3.0, you can restart Puppet Server by sending a hangup sig
 
 There are several ways to send a HUP signal to the Puppet Server process, but the most straightforward is to run the following [`kill`](http://linux.die.net/man/1/kill) command:
 
-    kill -HUP `pgrep -f puppetserver`
+    kill -HUP `pgrep -f puppet-server`
 
 ## Restarting Puppet Server to pick up changes
 

--- a/project.clj
+++ b/project.clj
@@ -77,7 +77,7 @@
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]]
 
-  :uberjar-name "puppetserver-release.jar"
+  :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"
                        :group "puppet"
                        :build-type "foss"


### PR DESCRIPTION
Because of how EZBake finds the pid on Cent6 (involves a pgrep for
the jar file name), upgrades on that distro will fail if we change
the jar name without changing the ezbake logic as well.  It seems
easier to just change the jar name back for now.