### PR TITLE
(MAINT) updates GEM_SOURCE default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+source ENV['GEM_SOURCE'] || "http://rubygems.delivery.puppetlabs.net"
 
 def location_for(place, fake_version = nil)
   if place =~ /^(git[:@][^#]*)#(.*)/


### PR DESCRIPTION
In most test scripts, and all the CI pipelines I've looked at, we set our GEM_SOURCE to http://rubygems.delivery.puppetlabs.net.  Performing bundle operations while inadvertently having to failed EXPORT GEM_SOURCE=http://rubygems.delivery.puppetlabs.net is a constant annoyance.

Let's set the default to the thing that works. 

