### PR TITLE
(SERVER-1268/TK-293) validates that TK Auth can allow access...

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -286,7 +286,7 @@ module PuppetServerExtensions
   end
 
   def hup_server(host = master, timeout = 30)
-    pidfile = on(host, 'puppet master --configprint rundir').stdout + '/puppetserver' 
+    pidfile = on(host, 'puppet master --configprint rundir').stdout.chomp + '/puppetserver' 
     pid = on(host, "cat #{pidfile}").stdout.chomp
     on(host, "kill -HUP #{pid}")
     url = "https://#{host}:8140/puppet/v3/status"

--- a/acceptance/suites/tests/authorization/fixtures/csr_attributes.yaml
+++ b/acceptance/suites/tests/authorization/fixtures/csr_attributes.yaml
@@ -1,0 +1,8 @@
+---
+custom_attributes:
+  1.2.840.113549.1.9.7: 342thbjkt82094y0uthhor289jnqthpc2290
+extension_requests:
+  pp_uuid: ED803750-E3C7-44F5-BB08-41A04433FE2E
+  pp_image_name: my_ami_image
+  pp_preshared_key: 342thbjkt82094y0uthhor289jnqthpc2290
+

--- a/acceptance/suites/tests/authorization/fixtures/extensions_test_auth.conf
+++ b/acceptance/suites/tests/authorization/fixtures/extensions_test_auth.conf
@@ -1,0 +1,127 @@
+authorization: {
+    version: 1
+    rules: [
+        {
+            # Allow only nodes with test extensions to retrieve any catalog
+            match-request: {
+                path: "/puppet/v3/catalog"
+                type: path
+                method: [get, post] 
+            }
+            allow: [ {extensions:{pp_uuid: ED803750-E3C7-44F5-BB08-41A04433FE2E}} ]
+            sort-order: 123
+            name: "extensions test puppetlabs catalog"
+
+        },
+        {
+            # Allow nodes to retrieve the certificate they requested earlier
+            match-request: {
+                path: "/puppet-ca/v1/certificate/"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs certificate"
+        },
+        {
+            # Allow all nodes to access the certificate revocation list
+            match-request: {
+                path: "/puppet-ca/v1/certificate_revocation_list/ca"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs crl"
+        },
+        {
+            # Allow nodes to request a new certificate
+            match-request: {
+                path: "/puppet-ca/v1/certificate_request"
+                type: path
+                method: [get, put]
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs csr"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/environments"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs environments"
+        },
+        {
+            # Allow nodes to access all file services; this is necessary for
+            # pluginsync, file serving from modules, and file serving from
+            # custom mount points (see fileserver.conf). Note that the `/file`
+            # prefix matches requests to file_metadata, file_content, and
+            # file_bucket_file paths.
+            match-request: {
+                path: "/puppet/v3/file"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file"
+        },
+        {
+            # Allow nodes to retrieve only their own node definition
+            match-request: {
+                path: "^/puppet/v3/node/([^/]+)$"
+                type: regex
+                method: get
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs node"
+        },
+        {
+            # Allow nodes to store only their own reports
+            match-request: {
+                path: "^/puppet/v3/report/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs report"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/status"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/static_file_content"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs static file content"
+        },
+        {
+          # Deny everything else. This ACL is not strictly
+          # necessary, but illustrates the default policy
+          match-request: {
+            path: "/"
+            type: path
+          }
+          deny: "*"
+          sort-order: 999
+          name: "puppetlabs deny all"
+        }
+    ]
+}

--- a/acceptance/suites/tests/authorization/x509_auth.rb
+++ b/acceptance/suites/tests/authorization/x509_auth.rb
@@ -1,0 +1,136 @@
+test_name "(SERVER-1268)/(TK-293) TK-AUTH uses certificate extensions for authentication" do
+
+confine :except, :platform => 'windows'
+  
+server = master.puppet['certname']
+ssldir = master.puppet['ssldir']
+confdir = master.puppet['confdir']
+
+teardown do
+  # restore the original tk auth.conf file
+  on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.bak /etc/puppetlabs/puppetserver/conf.d/auth.conf'
+end
+
+step "Backup the tk auth.conf file" do
+  on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.conf /etc/puppetlabs/puppetserver/conf.d/auth.bak'
+end
+
+# Do we have a functioning cert?
+step "Confirm agent can connect with existing cert" do
+  agents.each do |a|
+    if (not_controller(a))
+      rc = on(a,
+              puppet("agent --test --server #{server} --detailed-exitcodes"),
+              {:acceptable_exit_codes => [0,2]})
+    end
+  end
+end
+
+# Not anymore we don't
+step "Revoke and destroy the existing cert on the server" do
+  agents.each do |a| 
+    if (not_controller(a))
+      rc = on(master, 
+              puppet("cert destroy #{a.hostname}"),
+              {:acceptable_exit_codes => [0,2]})
+    end
+  end
+end
+
+step "HUP the server" do
+  hup_server
+end
+
+# After a server HUP, the agent cert should be rejected
+step "Confirm agent can't connect with existing cert" do
+  agents.each do |a|
+    if (not_controller(a))
+      rc = on(a,
+              puppet("agent --test --server #{server} --detailed-exitcodes"),
+              {:acceptable_exit_codes => [1]})
+    end
+  end
+end
+
+step "Remove the old certs on the agents so they'll make new ones" do
+  agents.each do |a|
+    if (not_controller(a))
+      rc = on(a,
+              "find #{confdir} -name #{a.hostname}.pem -delete",
+              {:acceptable_exit_codes => [0,1]})
+    end
+  end
+end
+
+# Lay down an attributes file for puppet to read when creating
+# a new cert
+# TODO: Make this a here doc with extensions that exist as vars so that they 
+# can be passed into our tk auth.conf rule generator.
+step "Copy the CSR attributes file into place" do
+  agents.each do |a|
+    if (not_controller(a))
+      rc = scp_to(a,
+                  'acceptance/suites/tests/authorization/fixtures/csr_attributes.yaml',
+                  "#{confdir}",
+                  {:acceptable_exit_codes => [0]})
+    end
+  end
+end
+
+step "Generate a new cert with a cert extension" do
+  agents.each do |a|
+    if (not_controller(a))
+      rc = on(a,
+              puppet("agent --test --server #{server} --detailed-exitcodes"),
+              {:acceptable_exit_codes => [1]})
+    end
+  end
+end
+
+step "Sign the certs" do
+  rc = on(master, 
+          puppet("cert sign --all"),
+          {:accept_all_exit_codes => true})
+end
+
+# tk_auth file that allows catalogs based on extensions rather than node names.
+# This will create a weakness in that if the DEFAULT tk_auth.conf file is 
+# modified in the future, 
+# we may need to modify our test tk_auth.conf file.
+# FIXME / TODO: create helper methods so that we can modify the tk auth.conf
+# file in place (and therefore test more use cases.)
+step "Lay down a test tk-auth.conf file" do
+  scp_to( master, 
+    'acceptance/suites/tests/authorization/fixtures/extensions_test_auth.conf',
+    '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+    :acceptable_exit_codes => 0 )
+end
+
+step "HUP the server" do
+  hup_server
+end
+
+# Confirm agents can connect with new cert
+step "Confirm agent can connect with the new cert" do
+  agents.each do |a|
+    if (not_controller(a))
+      rc = on(a,
+              puppet("agent --test --server #{server} --detailed-exitcodes"),
+              {:acceptable_exit_codes => [0,2]})
+    end
+
+    # Can we poke an HTTP API endpoint?
+    cert = get_cert(a)
+    key = get_key(a)
+    rc = https_request("https://#{server}:8140/puppet/v3/catalog/#{a.hostname}?environment=production",
+                       :get,
+                       cert,
+                       key)
+    if (rc.code != '200')
+      fail_test "Unexpected HTTP status code: #{rc.code}"
+    end
+  end
+end
+
+end
+


### PR DESCRIPTION
based on an x509 ssl extension rather than a hostname/cn.

This is %98 percent based on @kurtwall 's work in #1056.  This is an end user style test rather than an API level test.

If possible, it would be nice to get this merged into master before we merge down to stable.  If that isn't possible QA will adapt...

@johnduarte When you have a little time could you please review this?