### PR TITLE
(maint) Merge up stable to master

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "ab9e395ef55565a8e896bd847e90a1c3dfb225f5", :string)
+                         "1.5.0", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/
@@ -290,8 +290,7 @@ module PuppetServerExtensions
   end
 
   def hup_server(host = master, timeout = 30)
-    pidfile = on(host, 'puppet master --configprint rundir').stdout.chomp + '/puppetserver' 
-    pid = on(host, "cat #{pidfile}").stdout.chomp
+    pid = on(host, 'pgrep -f puppetserver').stdout.chomp
     on(host, "kill -HUP #{pid}")
     url = "https://#{host}:8140/puppet/v3/status"
     cert = get_cert(master)

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def tk-version "1.4.0")
 (def tk-jetty-version "1.5.9")
 (def ks-version "1.3.0")
-(def ps-version "2.4.0-master-SNAPSHOT")
+(def ps-version "2.4.0-stable-SNAPSHOT")
 
 (defn deploy-info
   [url]

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def tk-version "1.4.0")
 (def tk-jetty-version "1.5.9")
 (def ks-version "1.3.0")
-(def ps-version "2.4.0-stable-SNAPSHOT")
+(def ps-version "2.5.0-master-SNAPSHOT")
 
 (defn deploy-info
   [url]

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -7,7 +7,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["puppet-agent >= 1.4.2"],
+      redhat: { dependencies: ["puppet-agent >= 1.5.0"],
                # This is terrible, but we need write access to puppet's
                # var/conf dirs, so we need to add ourselves to the group.
                # Then we need to chmod some dirs until the Puppet packaging
@@ -34,7 +34,7 @@ ezbake: {
                ]
              }
 
-      debian: { dependencies: ["puppet-agent (>= 1.4.2)"],
+      debian: { dependencies: ["puppet-agent (>= 1.5.0)"],
                # see redhat comments on why this is terrible
                postinst: [
                  "install --owner={{user}} --group={{user}} -d /opt/puppetlabs/server/data/puppetserver/jruby-gems",


### PR DESCRIPTION
This should get master acceptance tests passing again.

Also, bump puppetserver version to 2.5.0-master for post 2.4.0 development.