### PR TITLE
(SERVER-1336) Bump version to 2.4.0 for release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def tk-version "1.4.0")
 (def tk-jetty-version "1.5.9")
 (def ks-version "1.3.0")
-(def ps-version "2.4.0-stable-SNAPSHOT")
+(def ps-version "2.4.0")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
Do not merge until nightly (https://jenkins.puppetlabs.com/view/puppetserver/view/all/job/platform_puppetserver_integration-system_no-conditional_full-stable/ - job kicked off at 1:45am PDT May 17) has passed CI.