### PR TITLE
(SERVER-1247) upgrade to ezbake 0.4.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -128,7 +128,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.4.0"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.4.2"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
This commit upgrades us to the latest version of ezbake, which fixes
a bug in the bootstrap `services.d` packaging on systemd platforms.