### PR TITLE
(maint) merge up master to stable may 25 2016

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -36,7 +36,7 @@ module PuppetServerExtensions
     # http://builds.delivery.puppetlabs.net/puppetdb/
     puppetdb_build_version =
       get_option_value(options[:puppetdb_build_version], nil,
-                       "PuppetDB Version", "PUPPETDB_BUILD_VERSION", "3.2.1", :string)
+                       "PuppetDB Version", "PUPPETDB_BUILD_VERSION", "4.1.0", :string)
 
     @config = {
       :base_dir => base_dir,
@@ -65,6 +65,7 @@ module PuppetServerExtensions
       /el/, # includes cent6,7 and redhat6,7
       /ubuntu-12/,
       /ubuntu-14/,
+      /ubuntu-16/,
     ]
   end
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -11,13 +11,13 @@ canonical: "/puppetserver/latest/install_from_packages.html"
 
 Puppet Server is configured to use 2 GB of RAM by default. If you'd like to just play around with an installation on a Virtual Machine, this much memory is not necessary. To change the memory allocation, see [Memory Allocation](#memory-allocation).
 
-> **Note:** Puppet masters running Puppet Server 2.3 depend on [Puppet Agent 1.4.0](https://docs.puppet.com/puppet/4.4/reference/about_agent.html) or newer, which installs [Puppet 4.4](https://docs.puppet.com/puppet/4.4/) and compatible versions of its related tools and dependencies on the server. Puppet agents running older versions of Puppet Agent can connect to Puppet Server 2.3 --- this requirement applies to the Puppet Agent running on the Puppet Server node *only*.
+> **Note:** Puppet masters running Puppet Server 2.4 depend on [Puppet Agent 1.5.0](https://docs.puppet.com/puppet/4.5/reference/about_agent.html) or newer, which installs [Puppet 4.5](https://docs.puppet.com/puppet/4.5/) and compatible versions of its related tools and dependencies on the server. Puppet agents running older versions of Puppet Agent can connect to Puppet Server 2.4 --- this requirement applies to the Puppet Agent running on the Puppet Server node *only*.
 >
 > If you're also using PuppetDB, check its [requirements](https://docs.puppet.com/puppetdb/latest/#system-requirements).
 
 ## Platforms with Packages
 
-Puppet provides official packages that install Puppet Server 2.3 and all of its prerequisites on the following platforms, as part of [Puppet Collections][repodocs].
+Puppet provides official packages that install Puppet Server 2.4 and all of its prerequisites on the following platforms, as part of [Puppet Collections][repodocs].
 
 ### Red Hat Enterprise Linux
 
@@ -33,6 +33,8 @@ Puppet provides official packages that install Puppet Server 2.3 and all of its 
 
 -   Ubuntu 12.04 (Precise)
 -   Ubuntu 14.04 (Trusty)
+-   Ubuntu 15.10 (Wily)
+-   Ubuntu 16.04 (Xenial)
 
 ## Quick Start
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -4,116 +4,89 @@ title: "Puppet Server: Release Notes"
 canonical: "/puppetserver/latest/release_notes.html"
 ---
 
-[static catalogs]: https://docs.puppet.com/puppet/4.4/reference/static_catalogs.html
-[file resources]: https://docs.puppet.com/puppet/4.4/reference/types/file.html
-[Puppet catalogs]: https://docs.puppet.com/puppet/4.4/reference/subsystem_catalog_compilation.html
-[environment classes API]: ./puppet-api/v3/environment_classes.markdown
-[classes]: https://docs.puppet.com/puppet/latest/reference/lang_classes.html
-[resource type API]: https://docs.puppet.com/puppet/latest/reference/http_api/http_resource_type.html
+[Trapperkeeper]: https://github.com/puppetlabs/trapperkeeper
+[service bootstrapping]: ./configuration.markdown#service-bootstrapping
+[auth.conf]: ./config_file_auth.markdown
 
-## Puppet Server 2.3.2
+## Puppet Server 2.4
 
-Released April 27, 2016.
+Released May 19, 2016.
 
-This is a bug-fix release that also resolves a security issue in endpoint URL decoding.
+This is a feature and bug-fix release of Puppet Server that also upgrades its included [Trapperkeeper][] framework from version 1.3.1 to 1.4.0.
 
-### **Security fix:** CVE-2016-2785 - Correctly decode endpoint URLs
+This release also adds packages for Ubuntu 15.10 (Wily Werewolf) and 16.04 LTS (Xenial Xerus), and no longer includes packages for Fedora 21, which reached its end of life in December.
 
-Previous versions of Puppet Server 2.x did not correctly decode specific character combinations that could potentially allow for a host to access endpoints restricted by [`auth.conf`](./config_file_auth.markdown) rules. Puppet Server 2.3.2 resolves this issue.
+### New platforms: Ubuntu 15.10 (Wily Werewolf) and 16.04 LTS (Xenial Xerus)
 
-* [CVE-2016-2785](https://puppet.com/security/cve/cve-2016-2785)
+Puppet Server 2.4.0 introduces [Puppet-built packages](https://docs.puppet.com/puppetserver/latest/install_from_packages.html) for Ubuntu 15.10 (Wily Werewolf) and 16.04 LTS (Xenial Xerus). For details about Puppet's package repositories, see the [Puppet Collections documentation](https://docs.puppet.com/puppet/latest/reference/puppet_collections.html).
 
-### Bug fix: Support Ruby master's custom trusted OID mappings
+-   [SERVER-1182](https://tickets.puppetlabs.com/browse/SERVER-1182)
 
-Puppet's Ruby master supports [custom trusted certificate extension object identifier (OID) mappings](https://docs.puppet.com/puppet/latest/reference/config_file_oid_map.html), but previous versions of Puppet Server 2.x did not. This could result in Puppet Server storing trusted extensions with their default numeric OIDs as their keys, instead of the expected custom-mapped short names.
+### New feature: X.509-compliant certificate extensions can match authorization rules
 
-Puppet Server 2.3.2 resolves this issue by supporting the `trusted_oid_mapping_file` and `csr_attributes` settings in [`puppet.conf`](https://docs.puppet.com/puppet/4.4/reference/config_file_main.html), which define paths to YAML files containing the custom mappings and certificate extension request (CSR) attributes, respectively.
+When using the [new authorization methods introduced in version 2.2.0](./config_file_auth.markdown#aside-changes-to-authorization-in-puppet-server-220), Puppet Server relied on matching a requester's certificate name (certname) when authorizing HTTPS requests via SSL. Starting with version 2.4.0, Server can also match [authorization rules][auth.conf] to the content of [X.509 certificate extensions](https://access.redhat.com/documentation/en-US/Red_Hat_Certificate_System/8.0/html/Admin_Guide/Standard_X.509_v3_Certificate_Extensions.html).
 
-For more information about mapping custom trusted OID names, see the Puppet documentation for the  [`custom_trusted_oid_mapping.yaml` file](https://docs.puppet.com/puppet/latest/reference/config_file_oid_map.html).
+Server 2.4.0 expands the syntax for [`allow` and `deny` parameters](./config_file_auth.markdown#allow-allow-unauthenticated-and-deny) in Server's `auth.conf` rules to allow for a map of `extensions` to match.
 
-* [SERVER-1150](https://tickets.puppet.com/browse/SERVER-1150)
+-   [TK-293: tk-auth should support x.509 extensions for authentication instead of just certname](https://tickets.puppetlabs.com/browse/TK-293)
 
-### All changes
+Server 2.4.0 also reads custom OID shortname maps defined in Puppet's [`custom_trusted_oid_mapping.yaml`](https://docs.puppet.com/puppet/latest/reference/config_file_oid_map.html).
 
-* [All Puppet Server issues targeted at this release](https://tickets.puppet.com/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%22SERVER%202.3.2%22%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC)
+-   [SERVER-1150](https://tickets.puppetlabs.com/browse/SERVER-1150)
+-   [SERVER-1245](https://tickets.puppetlabs.com/browse/SERVER-1245)
 
-## Puppet Server 2.3.1
+### New feature: Integrate with systemd services on Debian and Ubuntu
 
-Released March 21, 2016.
+Puppet Server 2.4.0 adds integration with `systemd` on Debian 8 and newer, and Ubuntu 16.04 LTS.
 
-This is a bug-fix release that resolves a disruptive logging configuration issue.
+-   [EZ-48](https://tickets.puppetlabs.com/browse/EZ-48)
 
-### Bug fix: Puppet Server starts when configured to log to syslog
+### Improvement: Responses to unauthenticated HTTPS requests include less information
 
-If its Logback service is configured to log to syslog, Puppet Server 2.3.0 fails to start. Puppet Server 2.3.1 fixes this regression, which did not affect prior versions of Puppet Server.
+When responding to unauthorized HTTPS requests, previous versions of Puppet Server 2.x returned the requester's IP address and [authorization rule][auth.conf] in addition to logging the failed request. Puppet Server 2.4.0 removes this information from the response and directs the responder to consult the server logs for details.
 
-* [SERVER-1215](https://tickets.puppet.com/browse/SERVER-1215)
+-   [TK-360: Error messages returned to client should not include IP or rule blocking the request](https://tickets.puppetlabs.com/browse/TK-360)
 
-### All changes
+### New feature: `always_retry_plugins` setting to configure Puppet feature caching
 
-* [All Puppet Server issues targeted at this release](https://tickets.puppet.com/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%22SERVER%202.3.1%22%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC)
+Puppet Server 2.4.0 respects the new [`always_retry_plugins` setting introduced in Puppet 4.5](https://docs.puppet.com/puppet/latest/reference/configuration.html#alwaysretryplugins), which determines how Puppet caches attempts to load Puppet resource types and features. However, Server changes this setting's value from its default (true) to false, in order to take advantage of additional caching for failures when loading types.
 
-## Puppet Server 2.3.0
+The `always_retry_plugins` setting also replaces the [`always_cache_features` setting](https://docs.puppet.com/puppet/4.5/reference/configuration.html#alwayscachefeatures), which is now deprecated. If you set `always_cache_features` to true in previous versions of Puppet Server, set `always_retry_plugins` to false.
 
-Released March 16, 2016.
+-   [PUP-5482](https://tickets.puppetlabs.com/browse/PUP-5482)
 
-This is a feature release that adds functionality for static catalogs, a new environment classes API, and restarting Puppet Server with a HUP signal.
+### New feature: Expanded logging for certificate autosigning attempts
 
-> ### New requirements
->
-> Puppet masters running Puppet Server 2.3 depend on [Puppet Agent 1.4.0](https://docs.puppet.com/puppet/4.4/reference/about_agent.html) or newer, which installs [Puppet 4.4](https://docs.puppet.com/puppet/4.4/) and compatible versions of its related tools and dependencies on the server. Puppet agents running older versions of Puppet Agent can connect to Puppet Server 2.3 --- this requirement applies to the Puppet Agent running on the Puppet Server node *only*.
+Starting with version 2.4.0, Puppet Server [logs](./configuration.markdown#logging) message and warnings when an autosign command generates STDERR output or returns a non-zero exit code. Server 2.4.0 also logs autosigning attempts at the INFO level, rather than DEBUG, to help make autosigning issues easier to diagnose without changing Server's logging level.
 
-### New feature: Static catalogs
+-   [SERVER-1187](https://tickets.puppetlabs.com/browse/SERVER-1187)
 
-Puppet Server 2.3.0 and Puppet 4.4.0 implement [static catalogs][], which inline metadata for [file resources][] into [Puppet catalogs][]. This improves the predictability of Puppet runs in workflows that use cached catalogs and file resources fetched from modules on a Puppet master.
+### Bug fix: Closed memory leak when restarting Server via SIGHUP
 
-* [SERVER-999](https://tickets.puppet.com/browse/SERVER-999)
+The Trapperkeeper components included with Puppet Server 2.3.x leaked a small amount of memory when [restarting Server with a HUP signal](./restarting.markdown). Puppet Server 2.4.0 includes updated components that resolve this issue.
 
-### New feature: `environment_classes` API
+-   [TK-372: Jetty JMX Memory Leak in TK WS J9](https://tickets.puppetlabs.com/browse/TK-372)
 
-The [environment classes API][] in Puppet Server 2.3.0 serves as a replacement for the Puppet [resource type API][] when requesting information about [classes][] available to a Puppet Server.
+### Bug fix: Implement DELETE request handling on the `certificate_reqest` endpoint
 
-* [SERVER-1110](https://tickets.puppet.com/browse/SERVER-1110)
+Unlike the Ruby Puppet master, previous versions of Puppet Server couldn't handle [DELETE requests to the `certificate_request` endpoint](https://docs.puppet.com/puppet/latest/reference/http_api/http_certificate_status.html#delete), even if authorization rules allowed for them. Server 2.4.0 resolves this by handling authorized DELETE requests in the same way that the Ruby master does.
 
-### New feature: Faster service restarts with HUP signals
+-   [SERVER-977](https://tickets.puppetlabs.com/browse/SERVER-977)
 
-Puppet Server 2.3.0 and newer support being restarted by sending a hangup signal, also known as [HUP or SIGHUP](./restarting.markdown), to the running Puppet Server process. You can send this signal to the Puppet Server process using the standard `kill` command. The HUP signal stops Puppet Server and reloads it gracefully, without terminating the JVM process. This is generally much faster than completely stopping and restarting the process, and allows you to quickly load changes to your Puppet Server master, including certain configuration changes.
+### Bug fixes: Certificate status endpoint behaviors
 
-* [SERVER-96](https://tickets.puppet.com/browse/SERVER-96)
+Puppet Server 2.4.0 resolves these issues with the [`certificate_status` endpoint](https://docs.puppet.com/puppet/latest/reference/http_api/http_certificate_status.html):
 
-### Bug fix: Puppet Server correctly parses complex script arguments
+-   **Handle nil values in `desired_state` more gracefully ([SERVER-542](https://tickets.puppetlabs.com/browse/SERVER-542)):** If the `desired_state` of a PUT request to the `certificate_status` endpoint was nil, previous versions of Server threw a NullPointerException. Server 2.4.0 resolves this issue.
+-   **Respect asterisks in `certificate_statuses` requests ([SERVER-864](https://tickets.puppetlabs.com/browse/SERVER-864)):** Previous versions of Server wouldn't return a list of certificates to authenticated `certificate_statuses` requests if the request included an asterisk (`*`). Server 2.4.0 resolves this issue.
 
-In versions 1.x and 2.2.x, Puppet Server would incorrectly parse commands executed by Puppet code that had complex string interpolation. For example, calls to the `generate()` function --- such as `generate('/bin/sh', '-c', "/usr/bin/python -c 'print \"foo\"'")` --- would spawn a Python REPL and consume a JRuby instance without returning anything. Puppet Server 2.3.0 fixes this issue.
+### Other issues
 
-* [SERVER-1160](https://tickets.puppet.com/browse/SERVER-1160)
-
-### Known issues
-
-#### Modifications to `bootstrap.cfg` might cause problems during upgrades to 2.3.0
-
-If you modified `bootstrap.cfg` (for instance, to [enable or disable the Certificate Authority service](./configuration.markdown#service-bootstrapping)), upgrading to Puppet Server 2.3.0 from earlier versions of Puppet Server might fail. For instance, on Red Hat-family distributions of Linux, you might see a warning during the package update:
-
-```
-2016-03-09 11:48:17,460 ERROR [main] [p.t.internal] Error during app buildup!
-java.lang.RuntimeException: Service ':VersionedCodeService' not found
-```
-
-To resolve this, add this line to your `bootstrap.cfg`:
-
-```
-puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
-```
-
-Alternatively, you can merge your changes into the new version of `bootstrap.cfg` (the `bootstrap.cfg.rpmnew` file in the above example) and replace `bootstrap.cfg` with the new file.
-
-* [SERVER-1058](https://tickets.puppet.com/browse/SERVER-1058)
-
-#### Puppet Server fails to start when configured to log to syslog
-
-If its Logback service is configured to log to syslog, Puppet Server 2.3.0 fails to start. Puppet Server 2.3.1 fixes this regression, which did not affect prior versions of Puppet Server.
-
-* [SERVER-1215](https://tickets.puppet.com/browse/SERVER-1215)
+-   **Remove hyphens in `puppet-server`:** We've [changed the name of our GitHub repository](https://tickets.puppetlabs.com/browse/SERVER-1206) from `puppet-server` to `puppetserver` and [removed the hyphen from many other references](https://tickets.puppetlabs.com/browse/SERVER-392).
+-   **Log Ruby backtraces ([SERVER-1273](https://tickets.puppetlabs.com/browse/SERVER-1273)):** Previous versions of Server didn't log Ruby backtraces. Server 2.4.0 does, just like a Ruby Puppet master.
+-   **Don't override the service startup timeout ([SERVER-557](https://tickets.puppetlabs.com/browse/SERVER-557)):** Previous versions of Server 2.x overrode the default 5-minute service startup timeout with a value of 120 seconds. Server 2.4.0 removes this override.
+-   **Extend the default `ca_ttl` ([SERVER-615](https://tickets.puppetlabs.com/browse/SERVER-615)):** Server 2.4.0 enforces a maximum time-to-live of 50 years (1,576,800,000 seconds) on `puppet.conf`'s [`ca_ttl` setting](https://docs.puppet.com/puppet/latest/reference/configuration.html#cattl).
 
 ### All changes
 
-* [All Puppet Server issues targeted at this release](https://tickets.puppet.com/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%22SERVER%202.3.0%22%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC)
+* [All Puppet Server issues targeted at this release](https://tickets.puppetlabs.com/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%22SERVER%202.4.0%22%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC)


### PR DESCRIPTION
to bring in the Xenial test helper changes for SERVER-1350 and also some docs changes.

Only conflict was in project.clj around the version number for puppetserver itself - I kept it as `2.5.0-master-SNAPSHOT`.