### PR TITLE
(SERVER-1310) Use standard exception format

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -57,7 +57,7 @@
 
 
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/trapperkeeper-authorization "0.6.1"]
+                 [puppetlabs/trapperkeeper-authorization "0.7.0"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
                  [puppetlabs/ring-middleware "1.0.0"]

--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,7 @@
                  [puppetlabs/trapperkeeper-authorization "0.6.1"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/ring-middleware "0.3.1"]
+                 [puppetlabs/ring-middleware "1.0.0"]
                  [puppetlabs/dujour-version-check "0.1.2" :exclusions [org.clojure/tools.logging]]
                  [puppetlabs/http-client "0.5.0"]
                  [puppetlabs/comidi "0.3.1"]]

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -529,26 +529,26 @@
    subject :- schema/Str]
   (when-not (= hostname subject)
     (sling/throw+
-      {:type    :hostname-mismatch
-       :message (str "Instance name \"" subject
-                     "\" does not match requested key \"" hostname "\"")}))
+      {:kind :hostname-mismatch
+       :msg (str "Instance name \"" subject
+                 "\" does not match requested key \"" hostname "\"")}))
 
   (when (contains-uppercase? hostname)
     (sling/throw+
-      {:type    :invalid-subject-name
-       :message "Certificate names must be lower case."}))
+      {:kind :invalid-subject-name
+       :msg "Certificate names must be lower case."}))
 
   (when-not (re-matches #"\A[ -.0-~]+\Z" subject)
     (sling/throw+
-      {:type    :invalid-subject-name
-       :message "Subject contains unprintable or non-ASCII characters"}))
+      {:kind :invalid-subject-name
+       :msg "Subject contains unprintable or non-ASCII characters"}))
 
   (when (.contains subject "*")
     (sling/throw+
-      {:type    :invalid-subject-name
-       :message (format
-                  "Subject contains a wildcard, which is not allowed: %s"
-                  subject)})))
+      {:kind :invalid-subject-name
+       :msg (format
+             "Subject contains a wildcard, which is not allowed: %s"
+             subject)})))
 
 (schema/defn allowed-extension?
   "A predicate that answers if an extension is allowed or not.
@@ -566,9 +566,9 @@
   (let [bad-extensions (remove allowed-extension? extensions)]
     (when-not (empty? bad-extensions)
       (let [bad-extension-oids (map :oid bad-extensions)]
-        (sling/throw+ {:type    :disallowed-extension
-                       :message (str "Found extensions that are not permitted: "
-                                     (str/join ", " bad-extension-oids))})))))
+        (sling/throw+ {:kind :disallowed-extension
+                       :msg (str "Found extensions that are not permitted: "
+                                 (str/join ", " bad-extension-oids))})))))
 
 (schema/defn validate-dns-alt-names!
   "Validate that the provided Subject Alternative Names extension is valid for
@@ -581,16 +581,16 @@
     (when-not (and (= (count name-types) 1)
                    (= (first name-types) :dns-name))
       (sling/throw+
-        {:type    :invalid-alt-name
-         :message "Only DNS names are allowed in the Subject Alternative Names extension"}))
+        {:kind :invalid-alt-name
+         :msg "Only DNS names are allowed in the Subject Alternative Names extension"}))
 
     (doseq [name names]
       (when (.contains name "*")
         (sling/throw+
-          {:type    :invalid-alt-name
-           :message (format
-                      "Cert subjectAltName contains a wildcard, which is not allowed: %s"
-                      name)})))))
+          {:kind :invalid-alt-name
+           :msg (format
+                 "Cert subjectAltName contains a wildcard, which is not allowed: %s"
+                 name)})))))
 
 (schema/defn create-csr-attrs-exts
   "Parse the CSR attributes yaml file at the given path and create a list of
@@ -941,8 +941,8 @@
   "Throw a slingshot exception if allow-duplicate-certs is false
    and we already have a certificate or CSR for the subject.
    The exception map will look like:
-   {:type    :duplicate-cert
-    :message <specific error message>}"
+   {:kind :duplicate-cert
+    :msg  <specific error message>}"
   [csr :- CertificateRequest
    {:keys [allow-duplicate-certs cacrl csrdir signeddir]} :- CaSettings]
   (let [subject (get-csr-subject csr)
@@ -959,8 +959,8 @@
         (if allow-duplicate-certs
           (log/infof "%s already has a %s certificate; new certificate will overwrite it" subject status)
           (sling/throw+
-            {:type    :duplicate-cert
-             :message (format "%s already has a %s certificate; ignoring certificate request" subject status)}))))))
+            {:kind :duplicate-cert
+             :msg (format "%s already has a %s certificate; ignoring certificate request" subject status)}))))))
 
 (schema/defn validate-csr-signature!
   "Throws an exception when the CSR's signature is invalid.
@@ -968,8 +968,8 @@
   [certificate-request :- CertificateRequest]
   (when-not (utils/signature-valid? certificate-request)
     (sling/throw+
-      {:type    :invalid-signature
-       :message "CSR contains a public key that does not correspond to the signing key"})))
+      {:kind :invalid-signature
+       :msg "CSR contains a public key that does not correspond to the signing key"})))
 
 (schema/defn ensure-no-dns-alt-names!
   "Throws an exception if the CSR contains DNS alt-names."
@@ -977,10 +977,10 @@
   (when-let [dns-alt-names (not-empty (dns-alt-names csr))]
     (let [subject (get-csr-subject csr)]
       (sling/throw+
-       {:type    :disallowed-extension
-        :message (format (str "CSR '%s' contains subject alternative names (%s), which are disallowed. "
-                              "Use `puppet cert --allow-dns-alt-names sign %s` to sign this request.")
-                         subject (str/join ", " dns-alt-names) subject)}))))
+       {:kind :disallowed-extension
+        :msg (format (str "CSR '%s' contains subject alternative names (%s), which are disallowed. "
+                          "Use `puppet cert --allow-dns-alt-names sign %s` to sign this request.")
+                     subject (str/join ", " dns-alt-names) subject)}))))
 
 
 (schema/defn ^:always-validate process-csr-submission!
@@ -1187,13 +1187,13 @@
   (thrown from one of the CSR validate-* function, using slingshot)"
   [x]
   (when (map? x)
-    (let [type (:type x)
+    (let [kind (:kind x)
           expected-types #{:disallowed-extension
                            :duplicate-cert
                            :hostname-mismatch
                            :invalid-signature
                            :invalid-subject-name}]
-      (contains? expected-types type))))
+      (contains? expected-types kind))))
 
 (schema/defn validate-csr
   "Validates the CSR (on disk) for the specified subject.
@@ -1215,8 +1215,8 @@
       (validate-extensions! extensions)
       (validate-csr-signature! csr)
 
-      (catch csr-validation-failure? {:keys [message]}
-        message))))
+      (catch csr-validation-failure? {:keys [msg]}
+        msg))))
 
 (schema/defn ^:always-validate delete-certificate!
   "Delete the certificate for the given subject.

--- a/src/clj/puppetlabs/puppetserver/cli/subcommand.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/subcommand.clj
@@ -37,8 +37,8 @@
                                        (parse-cli-args!))]
       (run-fn (load-tk-config config) extra-args))
     (catch map? m
-      (println (:message m))
-      (case (ks/without-ns (:type m))
+      (println (:msg m))
+      (case (ks/without-ns (:kind m))
         :cli-error (System/exit 1)
         :cli-help  (System/exit 0)))
     (finally

--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -2,7 +2,8 @@
   (:require [clojure.tools.logging :as log]
             [ring.util.response :as ring-response]
             [slingshot.slingshot :as sling]
-            [puppetlabs.ring-middleware.core :as mw]
+            [puppetlabs.ring-middleware.core :as middleware]
+            [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
             [schema.core :as schema]
             [puppetlabs.puppetserver.common :as ps-common]))
@@ -18,7 +19,7 @@
 (defn output-error
   [{:keys [uri]} {:keys [msg]} http-status]
   (log/errorf "Error %d on SERVER at %s: %s" http-status uri msg)
-  (mw/plain-response http-status msg))
+  (ringutils/plain-response http-status msg))
 
 (defn wrap-with-error-handling
   "Middleware that wraps a JRuby request with some error handling to return
@@ -27,11 +28,11 @@
   (fn [request]
     (sling/try+
      (handler request)
-     (catch mw/bad-request? e
+     (catch ringutils/bad-request? e
        (output-error request e 400))
      (catch jruby-timeout? e
        (output-error request e 503))
-     (catch mw/service-unavailable? e
+     (catch ringutils/service-unavailable? e
        (output-error request e 503)))))
 
 (defn wrap-with-jruby-instance
@@ -64,11 +65,11 @@
     (let [environment (get-environment-from-request request)]
       (cond
         (nil? environment)
-        (mw/throw-bad-request!
+        (ringutils/throw-bad-request!
          "An environment parameter must be specified")
 
         (not (nil? (schema/check ps-common/Environment environment)))
-        (mw/throw-bad-request!
+        (ringutils/throw-bad-request!
          (ps-common/environment-validation-error-msg environment))
 
         :else

--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -12,13 +12,13 @@
   "Determine if the supplied slingshot message is for a JRuby borrow timeout."
   [x]
   (when (map? x)
-    (= (:type x)
+    (= (:kind x)
        :puppetlabs.services.jruby.jruby-puppet-service/jruby-timeout)))
 
 (defn output-error
-  [{:keys [uri]} {:keys [message]} http-status]
-  (log/errorf "Error %d on SERVER at %s: %s" http-status uri message)
-  (mw/plain-response http-status message))
+  [{:keys [uri]} {:keys [msg]} http-status]
+  (log/errorf "Error %d on SERVER at %s: %s" http-status uri msg)
+  (mw/plain-response http-status msg))
 
 (defn wrap-with-error-handling
   "Middleware that wraps a JRuby request with some error handling to return

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -4,6 +4,7 @@
   (:require [puppetlabs.puppetserver.certificate-authority :as ca]
             [puppetlabs.puppetserver.ringutils :as ringutils]
             [puppetlabs.ring-middleware.core :as middleware]
+            [puppetlabs.ring-middleware.utils :as middleware-utils]
             [puppetlabs.puppetserver.liberator-utils :as liberator-utils]
             [puppetlabs.comidi :as comidi :refer [GET ANY PUT DELETE]]
             [bidi.schema :as bidi-schema]
@@ -52,7 +53,7 @@
     (catch ca/csr-validation-failure? {:keys [msg]}
       (log/error msg)
       ;; Respond to all CSR validation failures with a 400
-      (middleware/plain-response 400 msg))))
+      (middleware-utils/plain-response 400 msg))))
 
 (defn handle-get-certificate-revocation-list
   [{:keys [cacrl]}]
@@ -274,7 +275,7 @@
       (comidi/context ["/certificate_statuses/"]
         (ANY [[#"[^/]+" :ignored-but-required]] []
           (certificate-statuses ca-settings))
-        (ANY [""] [] (middleware/plain-response 400 "Missing URL Segment")))
+        (ANY [""] [] (middleware-utils/plain-response 400 "Missing URL Segment")))
       (GET ["/certificate/" :subject] [subject]
         (handle-get-certificate subject ca-settings))
       (comidi/context ["/certificate_request/" :subject]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -49,10 +49,10 @@
   (sling/try+
     (ca/process-csr-submission! subject certificate-request ca-settings)
     (rr/content-type (rr/response nil) "text/plain")
-    (catch ca/csr-validation-failure? {:keys [message]}
-      (log/error message)
+    (catch ca/csr-validation-failure? {:keys [msg]}
+      (log/error msg)
       ;; Respond to all CSR validation failures with a 400
-      (middleware/plain-response 400 message))))
+      (middleware/plain-response 400 msg))))
 
 (defn handle-get-certificate-revocation-list
   [{:keys [cacrl]}]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -140,13 +140,13 @@
   `(loop [pool-instance# (jruby/borrow-instance ~jruby-service ~reason)]
      (if (nil? pool-instance#)
        (sling/throw+
-         {:type    ::jruby-timeout
-          :message (str "Attempt to borrow a JRuby instance from the pool "
-                        "timed out; Puppet Server is temporarily overloaded. If "
-                        "you get this error repeatedly, your server might be "
-                        "misconfigured or trying to serve too many agent nodes. "
-                        "Check Puppet Server settings: "
-                        "jruby-puppet.max-active-instances.")}))
+         {:kind ::jruby-timeout
+          :msg (str "Attempt to borrow a JRuby instance from the pool "
+                    "timed out; Puppet Server is temporarily overloaded. If "
+                    "you get this error repeatedly, your server might be "
+                    "misconfigured or trying to serve too many agent nodes. "
+                    "Check Puppet Server settings: "
+                    "jruby-puppet.max-active-instances.")}))
      (when (jruby-schemas/shutdown-poison-pill? pool-instance#)
        (jruby/return-instance ~jruby-service pool-instance# ~reason)
        (mw/throw-service-unavailable!

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.services.jruby.jruby-puppet-service
   (:require [clojure.tools.logging :as log]
-            [puppetlabs.ring-middleware.core :as mw]
+            [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.services.jruby.jruby-puppet-core :as core]
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
@@ -149,7 +149,7 @@
                     "jruby-puppet.max-active-instances.")}))
      (when (jruby-schemas/shutdown-poison-pill? pool-instance#)
        (jruby/return-instance ~jruby-service pool-instance# ~reason)
-       (mw/throw-service-unavailable!
+       (ringutils/throw-service-unavailable!
          (str "Attempted to borrow a JRuby instance from the pool "
               "during a shutdown. Please try again.")))
      (if (jruby-schemas/retry-poison-pill? pool-instance#)

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -14,6 +14,7 @@
             [puppetlabs.puppetserver.jruby-request :as jruby-request]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.ring-middleware.core :as middleware]
+            [puppetlabs.ring-middleware.utils :as middleware-utils]
             [cheshire.core :as cheshire]
             [clojure.string :as str]
             [bidi.schema :as bidi-schema]
@@ -297,7 +298,7 @@
           (not-modified-response parsed-tag)
           (-> (response-with-etag info-as-json parsed-tag)
               (rr/content-type "application/json"))))
-      (middleware/json-response 200 info-for-json))))
+      (middleware-utils/json-response 200 info-for-json))))
 
 (schema/defn ^:always-validate
   environment-class-info-fn :- IFn

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -4,7 +4,7 @@
            (com.puppetlabs.puppetserver JRubyPuppetResponse))
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [puppetlabs.ring-middleware.core :as mw]
+            [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.ssl-utils.core :as ssl-utils]
             [puppetlabs.puppetserver.common :as ps-common]
             [ring.util.codec :as ring-codec]
@@ -124,7 +124,7 @@
   (try
     (ring-codec/url-decode header-cert)
     (catch Exception e
-      (mw/throw-bad-request!
+      (ringutils/throw-bad-request!
         (str "Unable to URL decode the "
              header-client-cert-name
              " header: "
@@ -137,7 +137,7 @@
     (try
       (ssl-utils/pem->certs reader)
       (catch Exception e
-        (mw/throw-bad-request!
+        (ringutils/throw-bad-request!
           (str "Unable to parse "
                header-client-cert-name
                " into certificate: "
@@ -152,10 +152,10 @@
           certs      (pem->certs pem)
           cert-count (count certs)]
       (condp = cert-count
-        0 (mw/throw-bad-request!
+        0 (ringutils/throw-bad-request!
             (str "No certs found in PEM read from " header-client-cert-name))
         1 (first certs)
-        (mw/throw-bad-request!
+        (ringutils/throw-bad-request!
           (str "Only 1 PEM should be supplied for "
                header-client-cert-name
                " but "
@@ -262,9 +262,9 @@
   (if (:include-code-id? request)
     (let [env (jruby-request/get-environment-from-request request)]
       (when-not (nil? (schema/check ps-common/Environment env))
-        (mw/throw-bad-request! (ps-common/environment-validation-error-msg env)))
+        (ringutils/throw-bad-request! (ps-common/environment-validation-error-msg env)))
       (when-not env
-        (mw/throw-bad-request! "Environment is required in a catalog request."))
+        (ringutils/throw-bad-request! "Environment is required in a catalog request."))
       (assoc-in request [:params "code_id"] (current-code-id env)))
     request))
 

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -810,20 +810,20 @@
       (let [settings (assoc settings :allow-duplicate-certs false)]
         (testing "throws exception if CSR already exists"
           (is (thrown-with-slingshot?
-               {:type :duplicate-cert
-                :message "test-agent already has a requested certificate; ignoring certificate request"}
+               {:kind :duplicate-cert
+                :msg "test-agent already has a requested certificate; ignoring certificate request"}
                (process-csr-submission! "test-agent" (csr-stream "test-agent") settings))))
 
         (testing "throws exception if certificate already exists"
           (is (thrown-with-slingshot?
-               {:type :duplicate-cert
-                :message "localhost already has a signed certificate; ignoring certificate request"}
+               {:kind :duplicate-cert
+                :msg "localhost already has a signed certificate; ignoring certificate request"}
                (process-csr-submission! "localhost"
                                         (io/input-stream (test-pem-file "localhost-csr.pem"))
                                         settings)))
           (is (thrown-with-slingshot?
-               {:type :duplicate-cert
-                :message "revoked-agent already has a revoked certificate; ignoring certificate request"}
+               {:kind :duplicate-cert
+                :msg "revoked-agent already has a revoked certificate; ignoring certificate request"}
                (process-csr-submission! "revoked-agent"
                                         (io/input-stream (test-pem-file "revoked-agent-csr.pem"))
                                         settings))))))
@@ -858,14 +858,14 @@
           (testing "subject policies are checked"
             (doseq [[policy subject csr-file exception]
                     [["subject-hostname mismatch" "foo" "hostwithaltnames.pem"
-                      {:type :hostname-mismatch
-                       :message "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}]
+                      {:kind :hostname-mismatch
+                       :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}]
                      ["invalid characters in name" "super/bad" "bad-subject-name-1.pem"
-                      {:type :invalid-subject-name
-                       :message "Subject contains unprintable or non-ASCII characters"}]
+                      {:kind :invalid-subject-name
+                       :msg "Subject contains unprintable or non-ASCII characters"}]
                      ["wildcard in name" "foo*bar" "bad-subject-name-wildcard.pem"
-                      {:type :invalid-subject-name
-                       :message "Subject contains a wildcard, which is not allowed: foo*bar"}]]]
+                      {:kind :invalid-subject-name
+                       :msg "Subject contains a wildcard, which is not allowed: foo*bar"}]]]
               (testing policy
                 (let [path (path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
@@ -891,14 +891,14 @@
           (testing "CSR will not be saved when"
             (doseq [[policy subject csr-file expected]
                     [["subject-hostname mismatch" "foo" "hostwithaltnames.pem"
-                      {:type :hostname-mismatch
-                       :message "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}]
+                      {:kind :hostname-mismatch
+                       :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}]
                      ["subject contains invalid characters" "super/bad" "bad-subject-name-1.pem"
-                      {:type :invalid-subject-name
-                       :message "Subject contains unprintable or non-ASCII characters"}]
+                      {:kind :invalid-subject-name
+                       :msg "Subject contains unprintable or non-ASCII characters"}]
                      ["subject contains wildcard character" "foo*bar" "bad-subject-name-wildcard.pem"
-                      {:type :invalid-subject-name
-                       :message "Subject contains a wildcard, which is not allowed: foo*bar"}]]]
+                      {:kind :invalid-subject-name
+                       :msg "Subject contains a wildcard, which is not allowed: foo*bar"}]]]
               (testing policy
                 (let [path (path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
@@ -909,16 +909,16 @@
           (testing "CSR will be saved when"
             (doseq [[policy subject csr-file expected]
                     [["subject alt name extension exists" "hostwithaltnames" "hostwithaltnames.pem"
-                      {:type :disallowed-extension
-                       :message (str "CSR 'hostwithaltnames' contains subject alternative names "
+                      {:kind :disallowed-extension
+                       :msg (str "CSR 'hostwithaltnames' contains subject alternative names "
                                      "(DNS:altname1, DNS:altname2, DNS:altname3), which are disallowed. "
                                      "Use `puppet cert --allow-dns-alt-names sign hostwithaltnames` to sign this request.")}]
                      ["unknown extension exists" "meow" "meow-bad-extension.pem"
-                      {:type :disallowed-extension
-                       :message "Found extensions that are not permitted: 1.9.9.9.9.9.9"}]
+                      {:kind :disallowed-extension
+                       :msg "Found extensions that are not permitted: 1.9.9.9.9.9.9"}]
                      ["public-private key mismatch" "luke.madstop.com" "luke.madstop.com-bad-public-key.pem"
-                      {:type :invalid-signature
-                       :message "CSR contains a public key that does not correspond to the signing key"}]]]
+                      {:kind :invalid-signature
+                       :msg "CSR contains a public key that does not correspond to the signing key"}]]]
               (testing policy
                 (let [path (path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
@@ -932,14 +932,14 @@
           (let [settings (assoc settings :allow-duplicate-certs false)
                 csr-with-mismatched-name (csr-stream "test-agent")]
             (is (thrown-with-slingshot?
-                 {:type :duplicate-cert
-                  :message "test-agent already has a requested certificate; ignoring certificate request"}
+                 {:kind :duplicate-cert
+                  :msg "test-agent already has a requested certificate; ignoring certificate request"}
                  (process-csr-submission! "not-test-agent" csr-with-mismatched-name settings)))))
         (testing "subject policies checked before extension & key policies"
           (let [csr-with-disallowed-alt-names (io/input-stream (test-pem-file "hostwithaltnames.pem"))]
             (is (thrown-with-slingshot?
-                 {:type :hostname-mismatch
-                  :message "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}
+                 {:kind :hostname-mismatch
+                  :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}
                  (process-csr-submission! "foo" csr-with-disallowed-alt-names settings)))))))))
 
 (deftest cert-signing-extension-test
@@ -1090,15 +1090,15 @@
                           :csr-attributes
                           (csr-attributes-file "insecure_csr_attributes.yaml"))]
         (is (thrown-with-slingshot?
-              {:type    :disallowed-extension
-               :message "Found extensions that are not permitted: 1.2.3.4"}
+              {:kind :disallowed-extension
+               :msg "Found extensions that are not permitted: 1.2.3.4"}
               (create-master-extensions subject subject-pub issuer-pub config)))))
 
     (testing "invalid DNS alt names are rejected"
       (let [dns-alt-names "*.wildcard"]
         (is (thrown-with-slingshot?
-              {:type    :invalid-alt-name
-               :message "Cert subjectAltName contains a wildcard, which is not allowed: *.wildcard"}
+              {:kind :invalid-alt-name
+               :msg "Cert subjectAltName contains a wildcard, which is not allowed: *.wildcard"}
               (create-master-extensions subject subject-pub issuer-pub
                                         (assoc (testutils/master-settings confdir)
                                                :dns-alt-names dns-alt-names))))))
@@ -1177,31 +1177,31 @@
 (deftest validate-subject!-test
   (testing "an exception is thrown when the hostnames don't match"
     (is (thrown-with-slingshot?
-          {:type    :hostname-mismatch
-           :message "Instance name \"test-agent\" does not match requested key \"not-test-agent\""}
+          {:kind :hostname-mismatch
+           :msg "Instance name \"test-agent\" does not match requested key \"not-test-agent\""}
           (validate-subject!
             "not-test-agent" "test-agent"))))
 
   (testing "an exception is thrown if the subject name contains a capital letter"
     (is (thrown-with-slingshot?
-          {:type    :invalid-subject-name
-           :message "Certificate names must be lower case."}
+          {:kind :invalid-subject-name
+           :msg "Certificate names must be lower case."}
           (validate-subject! "Host-With-Capital-Letters"
                              "Host-With-Capital-Letters")))))
 
 (deftest validate-dns-alt-names!-test
   (testing "Only DNS alt names are allowed"
     (is (thrown-with-slingshot?
-          {:type    :invalid-alt-name
-           :message "Only DNS names are allowed in the Subject Alternative Names extension"}
+          {:kind :invalid-alt-name
+           :msg "Only DNS names are allowed in the Subject Alternative Names extension"}
           (validate-dns-alt-names! {:oid "2.5.29.17"
                                     :critical false
                                     :value {:ip-address ["12.34.5.6"]}}))))
 
   (testing "No DNS wildcards are allowed"
     (is (thrown-with-slingshot?
-          {:type    :invalid-alt-name
-           :message "Cert subjectAltName contains a wildcard, which is not allowed: foo*bar"}
+          {:kind :invalid-alt-name
+           :msg "Cert subjectAltName contains a wildcard, which is not allowed: foo*bar"}
           (validate-dns-alt-names! {:oid "2.5.29.17"
                                     :critical false
                                     :value {:dns-name ["ahostname" "foo*bar"]}})))))

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -255,24 +255,24 @@
   "A cert provided in the x-client-cert header that cannot be decoded into
   an X509Certificate object throws the expected failure"
   (testing "Improperly URL encoded content"
-    (is (thrown+? [:type    :bad-request
-                   :message (str "Unable to URL decode the x-client-cert header: "
-                                 "For input string: \"1%\"")]
+    (is (thrown+? [:kind :bad-request
+                   :msg (str "Unable to URL decode the x-client-cert header: "
+                             "For input string: \"1%\"")]
                   (jruby-request-with-client-cert-header "%1%2"))))
   (testing "Bad certificate content"
-    (is (thrown+? [:type    :bad-request
-                   :message (str "Unable to parse x-client-cert into "
-                                 "certificate: -----END CERTIFICATE not found")]
+    (is (thrown+? [:kind :bad-request
+                   :msg (str "Unable to parse x-client-cert into "
+                             "certificate: -----END CERTIFICATE not found")]
                   (jruby-request-with-client-cert-header
                     "-----BEGIN%20CERTIFICATE-----%0AM"))))
   (testing "No certificate in content"
-    (is (thrown+? [:type    :bad-request
-                   :message "No certs found in PEM read from x-client-cert"]
+    (is (thrown+? [:kind :bad-request
+                   :msg "No certs found in PEM read from x-client-cert"]
                   (jruby-request-with-client-cert-header
                     "NOCERTSHERE"))))
   (testing "More than 1 certificate in content"
-    (is (thrown+? [:type    :bad-request
-                   :message "Only 1 PEM should be supplied for x-client-cert but 3 found"]
+    (is (thrown+? [:kind :bad-request
+                   :msg "Only 1 PEM should be supplied for x-client-cert but 3 found"]
                   (jruby-request-with-client-cert-header
                     (-> (str test-resources-dir "/master-with-all-cas.pem")
                         slurp

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -4,7 +4,7 @@
             [me.raynes.fs :as fs]
             [slingshot.test :refer :all]
             [ring.util.codec :as ring-codec]
-            [puppetlabs.ring-middleware.core :as mw]
+            [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.services.request-handler.request-handler-core :as core]
             [puppetlabs.ssl-utils.core :as ssl-utils]
             [puppetlabs.ssl-utils.simple :as ssl-simple]
@@ -343,7 +343,7 @@
         (let [bad-message "it's real bad"
               request-handler (core/build-request-handler dummy-service {} (constantly nil))]
           (with-redefs [core/as-jruby-request (fn [_ _]
-                                                (mw/throw-bad-request!
+                                                (ringutils/throw-bad-request!
                                                   bad-message))]
             (let [response (request-handler {:body (StringReader. "blah")})]
               (is (= 400 (:status response)) "Unexpected response status")


### PR DESCRIPTION
This moves us to use the standard exception format defined in the nogui repo. It also bumps our ring-middleware and tk-auth dependencies as they are also updated to use the new exception format.