### PR TITLE
(MAINT) Merge up 2.3.x branch to stable

### DIFF
--- a/documentation/restarting.markdown
+++ b/documentation/restarting.markdown
@@ -35,6 +35,7 @@ There are three ways to trigger your Puppet Server environment to refresh and pi
 ### Changes applied after a HUP signal or full Server restart
 
 * Changes to Puppet Server [configuration files](./configuration.markdown) in its `conf.d` directory.
+* Changes to the CA CRL file.  For example, a `puppet cert clean`
 
 ### Changes that require a full Server restart
 


### PR DESCRIPTION
There was a docs fix that required creating a temporary 2.3.x
branch.  This commit merges up that docs change from 2.3.x to stable.