### PR TITLE
(SERVER-1378) fix warning from "gem list"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.7.0")
 (def tk-version "1.4.0")
 (def tk-jetty-version "1.5.9")
-(def ks-version "1.3.0")
+(def ks-version "1.3.1")
 (def ps-version "2.4.1-stable-SNAPSHOT")
 
 (defn deploy-info


### PR DESCRIPTION
This commit upgrades us to kitchensink 0.3.1, which contains a fix
that gets rid of a warning that comes from a new version of clojure.tools.cli.

In older versions of kitchensink we were using a feature of
clojure.tools.cli called `:flag`, which is now deprecated.

This code path was exercised by `puppetserver gem`, which meant that
every time a user interacted with that command (explicitly or via
the puppet module that manages puppetserver gems), the deprecation
warning would be logged.

I've manually tested (via `lein gem`) that upgrading to the newer
kitchensink makes the warning go away.