### PR TITLE
(SERVER-1378) Merge up stable to master, 2016-06-08

### DIFF
--- a/documentation/restarting.markdown
+++ b/documentation/restarting.markdown
@@ -36,6 +36,7 @@ There are three ways to trigger your Puppet Server environment to refresh and pi
 ### Changes applied after a HUP signal or full Server restart
 
 * Changes to Puppet Server [configuration files](./configuration.markdown) in its `conf.d` directory.
+* Changes to the CA CRL file.  For example, a `puppet cert clean`
 
 ### Changes that require a full Server restart
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.7.0")
 (def tk-version "1.4.0")
 (def tk-jetty-version "1.5.9")
-(def ks-version "1.3.0")
+(def ks-version "1.3.1")
 (def ps-version "2.5.0-master-SNAPSHOT")
 
 (defn deploy-info


### PR DESCRIPTION
This merges up from stable, mostly for the purposes of getting the kitchensink upgrade, which fixes SERVER-1378.