### PR TITLE
Bump Puppet to latest agent in Davis (743255d)

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.5.0')
+      expect(subject).to eq('4.6.0')
     end
   end
 


### PR DESCRIPTION
Forgot when I tested https://github.com/puppetlabs/puppetserver/pull/1111 that the version we were failing against in PE for the Davis pipeline was not what we are testing in FOSS (so now FOSS is red [here](https://jenkins.puppetlabs.com/job/platform_puppetserver_integration-system_no-conditional_smoke-master/106/LAYOUT=ubuntu1604-64ma-64a,LDAP_TYPE=default,PLATFORM=default,label=beaker/testReport/junit/(root)/acceptance_suites_tests_authorization/default_rules_rb/))

Previously the master branch was pinned to 4.5.0 release of puppet in preparation for Couch hardening. This updates puppetserver#master to what is now promoted into Davis. This includes improvements to indirector REST API errors and the new OID arc for cert extensions.

Still failing to run these locally... (not they're running and failing)