### PR TITLE
(SERVER-1304) Upgrade to ezbake 0.2.12

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -99,7 +99,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.2.11"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.2.12"]]
                       :name "puppetserver"}
 
              :uberjar {:aot [puppetlabs.trapperkeeper.main]}


### PR DESCRIPTION
This commit bumps us up to ezbake 0.2.12, which includes a backport
of the master ezbake branch's change to stop setting
-XX:+HeapDumpOnOutOfMemoryError by default.