### PR TITLE
(maint) Bump version of Puppet Agent used in Acceptance tests

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", nil, :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.1.119.gdb533e0", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "1.5.0", :string)
+                         "db533e0356aa50c8ba64707f75b1b2a5eaac567e", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
Set version of puppet-agent (db533e0) in acceptance tests to one
that includes the puppet from our dev env (743255d).