### PR TITLE
(maint) Update to new version of puppet-agent

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.1.119.gdb533e0", :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.1.123.g8ef05af", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "db533e0356aa50c8ba64707f75b1b2a5eaac567e", :string)
+                         "8ef05af9c64c63b547879a58a95c4a11a096cbc6", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
I don't even... This is a few builds farther ahead than the last one (so should have similar content) but I **think** this link confirms that it has been promoted into PE and has been built against all of our desired platforms: http://agent-downloads.delivery.puppetlabs.net/2016.3/puppet-agent/1.5.1.123/repos/  Though at this point of frustration I wouldn't trust anything I say.