### PR TITLE
(SERVER-1163) Refactor initialize-and-create-jruby-config

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -85,7 +85,7 @@
   "facter.jar")
 
 (schema/defn ^:always-validate
-  add-facter-jar-to-system-classloader
+  add-facter-jar-to-system-classloader!
   "Searches the ruby load path for a file whose name matches that of the
   facter jar file.  The first one found is added to the system classloader's
   classpath.  If no match is found, an info message is written to the log
@@ -227,13 +227,7 @@
                               (extract-puppet-config (:jruby-puppet raw-config)))
          uninitialized-jruby-config (-> (extract-jruby-config (:jruby-puppet raw-config))
                                         (assoc :max-borrows-per-instance
-                                               (:max-requests-per-instance jruby-puppet-config)))
-         jruby-config (create-jruby-config
-                       jruby-puppet-config
-                       uninitialized-jruby-config
-                       agent-shutdown-fn
-                       profiler)]
-     (log/info "Initializing the JRuby service")
+                                               (:max-requests-per-instance jruby-puppet-config)))]
      (when (and warn-legacy-auth-conf? (:use-legacy-auth-conf jruby-puppet-config))
        (log/warn "The 'jruby-puppet.use-legacy-auth-conf' setting is set to"
                  "'true'.  Support for the legacy Puppet auth.conf file is"
@@ -241,8 +235,7 @@
                  "this setting to 'false' and migrate your authorization rule"
                  "definitions in the /etc/puppetlabs/puppet/auth.conf file to"
                  "the /etc/puppetlabs/puppetserver/conf.d/auth.conf file."))
-     (add-facter-jar-to-system-classloader (:ruby-load-path jruby-config))
-     jruby-config)))
+     (create-jruby-config jruby-puppet-config uninitialized-jruby-config agent-shutdown-fn profiler))))
 
 
 (def EnvironmentClassInfoCacheEntry

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -21,11 +21,13 @@
                            [:PoolManagerService create-pool]]
   (init
     [this context]
+    (log/info "Initializing the JRuby service")
     (let [jruby-config (core/initialize-and-create-jruby-config
                         (get-config)
                         (get-profiler)
                         (partial shutdown-on-error (tk-services/service-id this))
                         true)
+          _ (core/add-facter-jar-to-system-classloader! (:ruby-load-path jruby-config))
           pool-context (create-pool jruby-config)]
       (-> context
           (assoc :pool-context pool-context)

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -68,17 +68,17 @@
             (some #(= jar %) (class-loader-files)))]
     (testing "facter jar loaded from first position"
       (let [temp-jar (create-temp-facter-jar)]
-        (jruby-puppet-core/add-facter-jar-to-system-classloader [(fs-parent-as-string temp-jar)])
+        (jruby-puppet-core/add-facter-jar-to-system-classloader! [(fs-parent-as-string temp-jar)])
         (is (true? (jar-in-class-loader-file-list? temp-jar)))))
     (testing "facter jar loaded from last position"
       (let [temp-jar (create-temp-facter-jar)]
-        (jruby-puppet-core/add-facter-jar-to-system-classloader [(temp-dir-as-string)
+        (jruby-puppet-core/add-facter-jar-to-system-classloader! [(temp-dir-as-string)
                                                           (fs-parent-as-string temp-jar)])
         (is (true? (jar-in-class-loader-file-list? temp-jar)))))
     (testing "only first jar loaded when two present"
       (let [first-jar (create-temp-facter-jar)
             last-jar (create-temp-facter-jar)]
-        (jruby-puppet-core/add-facter-jar-to-system-classloader [(fs-parent-as-string first-jar)
+        (jruby-puppet-core/add-facter-jar-to-system-classloader! [(fs-parent-as-string first-jar)
                                                           (temp-dir-as-string)
                                                           (fs-parent-as-string last-jar)])
         (is (true? (jar-in-class-loader-file-list? first-jar))
@@ -87,7 +87,7 @@
           "last jar in the list was unexpectedly not found")))
     (testing "class loader files unchanged when no jar found"
       (let [class-loader-files-before-load (class-loader-files)
-            _ (jruby-puppet-core/add-facter-jar-to-system-classloader [(temp-dir-as-string)
+            _ (jruby-puppet-core/add-facter-jar-to-system-classloader! [(temp-dir-as-string)
                                                                 (temp-dir-as-string)])
             class-loader-files-after-load (class-loader-files)]
         (is (= class-loader-files-before-load class-loader-files-after-load))))))


### PR DESCRIPTION
Moves the call to add-facter-jar-to-system-classloader out of
initialize-and-create-jruby-config into the jruby-puppet-service

Moves a logging statement out of initialize-and-create-jruby-config