### PR TITLE
(SERVER-1400) Bump puppet-agent package version

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", nil, :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.170.g236f05f", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "1.5.0", :string)
+                         "236f05f43c0f62e720dadc9a8b69c86a763734f3", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This bumps the version of the puppet-agent package used in acceptance
tests to 1.5.2.170.g236f05f which contains puppet at
fffcf8a6bf59f6cb2d1d9a555a8c6c28e5d33606 which is the same commit that
the puppet submodule is currently at.

Hopefully, this change will fix the 'scheduled_task' test failures
currently happening on Jankins.