### PR TITLE
(SERVER-1400) Bump puppet/puppet-agent dependencies

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.170.g236f05f", :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.176.g21e3a74", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "236f05f43c0f62e720dadc9a8b69c86a763734f3", :string)
+                         "21e3a7433f8e0413ff75f14071d6540c51294eb2", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
Bump the puppet submodule to 257d5b2d6ed94def50e8d6e040302d1c87135947
which contains a fix for the scheduled_task tests which are failing on
Jankins.  Correspondingly, bump the puppet-agent package dependency to
1.5.2.176.g21e3a74.