### PR TITLE
(SERVER-1402) (MAINT) Modify the pre-suite to ignore PUPPET_VERSION

### DIFF
--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -36,7 +36,7 @@ step "Install MRI Puppet Agents."
   hosts.each do |host|
     platform = host.platform
 
-    puppet_version = test_config[:puppet_version]
+    puppet_version = test_config[:puppet_build_version]
 
     if /windows/.match(platform)
       arch = host[:ruby_arch] || 'x86'
@@ -46,7 +46,7 @@ step "Install MRI Puppet Agents."
     elsif puppet_version
       install_package host, 'puppet-agent'
     else
-      puppet_version = test_config[:puppet_version]
+      puppet_version = test_config[:puppet_build_version]
 
       variant, _, _, _ = host['platform'].to_array
 


### PR DESCRIPTION
Modify the pre-suite to ignore `PUPPET_VERSION`/`puppet_version` and use  `PUPPET_BUILD_VERSION`/`puppet_build_version` consistently.

In 30_install_dev_repos.rb, we install a puppet-agent development repo on the master based on the value of `puppet_build_version`, which maps to the env var `PUPPET_BUILD_VERSION`. Later, in 70_install_puppet.rb, we _attempt_ to install the agent, but the logic ends up pulling in unwanted agent code.

As I read the code, at line 39, we fetch and check the value of `puppet_version`, which maps to the env var `PUPPET_VERSION`; if it is set, we fall through to the `elsif` on line 46 and install the default puppet-agent package, which is the _development_ version in the repo installed in 30_install_dev_repos.rb. But, if `puppet_version` is _not_ set, we fall through to line 49, where we fetch its value again (?) this time _without_ checking the returned value, and then attempt to install the agent using that value, which is empty/`nil`. As a result, we _still_ install the default puppet-agent package available, which is in the the dev repo installed earlier.

`PUPPET_VERSION` is not used in CI, AFAICT, but `PUPPET_BUILD_VERSION` is, so this change modifies the pre-suite to use the value of `PUPPET_BUILD_VERSION`.