### PR TITLE
(SERVER-1307) reject CSRs with authorization extensions

### DIFF
--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -154,6 +154,26 @@
                     :actual actual#})
         actual#))))
 
+;; This additional slingshot helper assumes our :kind/:msg maps and is probably
+;; brittle.
+(defmethod assert-expr 'thrown-with-slingshot-msg? [msg form]
+  (let [expected (nth form 1)
+        body     (nthnext form 2)]
+    `(sling/try+
+      ~@body
+      (do-report {:type :fail :message ~msg :expected ~expected :actual nil})
+      (catch map? actual#
+        (let [result# (if (or (= actual# ~expected)
+                              (and (= (:kind actual#) (:kind ~expected))
+                                   (re-matches (:msg ~expected) (:msg actual#))))
+                        :pass
+                        :fail)]
+          (do-report {:type result#
+                      :message ~msg
+                      :expected ~expected
+                      :actual actual#}))
+        actual#))))
+
 (defn contains-ext?
   "Does the provided extension list contain an extensions with the given OID."
   [ext-list oid]

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -142,19 +142,6 @@
   (testing subject
     (is (false? (autosign-csr? whitelist subject empty-stream [])))))
 
-(defmethod assert-expr 'thrown-with-slingshot? [msg form]
-  (let [expected (nth form 1)
-        body     (nthnext form 2)]
-    `(sling/try+
-      ~@body
-      (do-report {:type :fail :message ~msg :expected ~expected :actual nil})
-      (catch map? actual#
-        (do-report {:type (if (= actual# ~expected) :pass :fail)
-                    :message ~msg
-                    :expected ~expected
-                    :actual actual#})
-        actual#))))
-
 (defn contains-ext?
   "Does the provided extension list contain an extensions with the given OID."
   [ext-list oid]
@@ -867,21 +854,21 @@
     (testing "when false"
       (let [settings (assoc settings :allow-duplicate-certs false)]
         (testing "throws exception if CSR already exists"
-          (is (thrown-with-slingshot?
-               {:kind :duplicate-cert
-                :msg "test-agent already has a requested certificate; ignoring certificate request"}
+          (is (thrown+?
+               [:kind :duplicate-cert
+                :msg "test-agent already has a requested certificate; ignoring certificate request"]
                (process-csr-submission! "test-agent" (csr-stream "test-agent") settings))))
 
         (testing "throws exception if certificate already exists"
-          (is (thrown-with-slingshot?
-               {:kind :duplicate-cert
-                :msg "localhost already has a signed certificate; ignoring certificate request"}
+          (is (thrown+?
+               [:kind :duplicate-cert
+                :msg "localhost already has a signed certificate; ignoring certificate request"]
                (process-csr-submission! "localhost"
                                         (io/input-stream (test-pem-file "localhost-csr.pem"))
                                         settings)))
-          (is (thrown-with-slingshot?
-               {:kind :duplicate-cert
-                :msg "revoked-agent already has a revoked certificate; ignoring certificate request"}
+          (is (thrown+?
+               [:kind :duplicate-cert
+                :msg "revoked-agent already has a revoked certificate; ignoring certificate request"]
                (process-csr-submission! "revoked-agent"
                                         (io/input-stream (test-pem-file "revoked-agent-csr.pem"))
                                         settings))))))
@@ -916,19 +903,22 @@
           (testing "subject policies are checked"
             (doseq [[policy subject csr-file exception]
                     [["subject-hostname mismatch" "foo" "hostwithaltnames.pem"
-                      {:kind :hostname-mismatch
-                       :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}]
+                      #(= {:kind :hostname-mismatch
+                           :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}
+                          (select-keys % [:kind :msg]))]
                      ["invalid characters in name" "super/bad" "bad-subject-name-1.pem"
-                      {:kind :invalid-subject-name
-                       :msg "Subject contains unprintable or non-ASCII characters"}]
+                      #(= {:kind :invalid-subject-name
+                           :msg "Subject contains unprintable or non-ASCII characters"}
+                          (select-keys % [:kind :msg]))]
                      ["wildcard in name" "foo*bar" "bad-subject-name-wildcard.pem"
-                      {:kind :invalid-subject-name
-                       :msg "Subject contains a wildcard, which is not allowed: foo*bar"}]]]
+                      #(= {:kind :invalid-subject-name
+                           :msg "Subject contains a wildcard, which is not allowed: foo*bar"}
+                          (select-keys % [:kind :msg]))]]]
               (testing policy
                 (let [path (path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
                   (is (false? (fs/exists? path)))
-                  (is (thrown-with-slingshot? exception (process-csr-submission! subject csr settings)))
+                  (is (thrown+? exception (process-csr-submission! subject csr settings)))
                   (is (false? (fs/exists? path)))))))
 
           (testing "extension & key policies are not checked"
@@ -949,39 +939,45 @@
           (testing "CSR will not be saved when"
             (doseq [[policy subject csr-file expected]
                     [["subject-hostname mismatch" "foo" "hostwithaltnames.pem"
-                      {:kind :hostname-mismatch
-                       :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}]
+                      #(= {:kind :hostname-mismatch
+                           :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}
+                          (select-keys % [:kind :msg]))]
                      ["subject contains invalid characters" "super/bad" "bad-subject-name-1.pem"
-                      {:kind :invalid-subject-name
-                       :msg "Subject contains unprintable or non-ASCII characters"}]
+                      #(= {:kind :invalid-subject-name
+                           :msg "Subject contains unprintable or non-ASCII characters"}
+                          (select-keys % [:kind :msg]))]
                      ["subject contains wildcard character" "foo*bar" "bad-subject-name-wildcard.pem"
-                      {:kind :invalid-subject-name
-                       :msg "Subject contains a wildcard, which is not allowed: foo*bar"}]]]
+                      #(=  {:kind :invalid-subject-name
+                            :msg "Subject contains a wildcard, which is not allowed: foo*bar"}
+                           (select-keys % [:kind :msg]))]]]
               (testing policy
                 (let [path (path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
                   (is (false? (fs/exists? path)))
-                  (is (thrown-with-slingshot? expected (process-csr-submission! subject csr settings)))
+                  (is (thrown+? expected (process-csr-submission! subject csr settings)))
                   (is (false? (fs/exists? path)))))))
 
           (testing "CSR will be saved when"
             (doseq [[policy subject csr-file expected]
                     [["subject alt name extension exists" "hostwithaltnames" "hostwithaltnames.pem"
-                      {:kind :disallowed-extension
-                       :msg (str "CSR 'hostwithaltnames' contains subject alternative names "
-                                     "(DNS:altname1, DNS:altname2, DNS:altname3), which are disallowed. "
-                                     "Use `puppet cert --allow-dns-alt-names sign hostwithaltnames` to sign this request.")}]
+                      #(= {:kind :disallowed-extension
+                           :msg (str "CSR 'hostwithaltnames' contains subject alternative names "
+                                   "(DNS:altname1, DNS:altname2, DNS:altname3), which are disallowed. "
+                                   "Use `puppet cert --allow-dns-alt-names sign hostwithaltnames` to sign this request.")}
+                          (select-keys % [:kind :msg]))]
                      ["unknown extension exists" "meow" "meow-bad-extension.pem"
-                      {:kind :disallowed-extension
-                       :msg "Found extensions that are not permitted: 1.9.9.9.9.9.9"}]
+                      #(= {:kind :disallowed-extension
+                           :msg "Found extensions that are not permitted: 1.9.9.9.9.9.9"}
+                          (select-keys % [:kind :msg]))]
                      ["public-private key mismatch" "luke.madstop.com" "luke.madstop.com-bad-public-key.pem"
-                      {:kind :invalid-signature
-                       :msg "CSR contains a public key that does not correspond to the signing key"}]]]
+                      #(= {:kind :invalid-signature
+                           :msg "CSR contains a public key that does not correspond to the signing key"}
+                          (select-keys % [:kind :msg]))]]]
               (testing policy
                 (let [path (path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
                   (is (false? (fs/exists? path)))
-                  (is (thrown-with-slingshot? expected (process-csr-submission! subject csr settings)))
+                  (is (thrown+? expected (process-csr-submission! subject csr settings)))
                   (is (true? (fs/exists? path)))
                   (fs/delete path)))))))
 
@@ -989,15 +985,15 @@
         (testing "duplicates checked before subject policies"
           (let [settings (assoc settings :allow-duplicate-certs false)
                 csr-with-mismatched-name (csr-stream "test-agent")]
-            (is (thrown-with-slingshot?
-                 {:kind :duplicate-cert
-                  :msg "test-agent already has a requested certificate; ignoring certificate request"}
+            (is (thrown+?
+                 [:kind :duplicate-cert
+                  :msg "test-agent already has a requested certificate; ignoring certificate request"]
                  (process-csr-submission! "not-test-agent" csr-with-mismatched-name settings)))))
         (testing "subject policies checked before extension & key policies"
           (let [csr-with-disallowed-alt-names (io/input-stream (test-pem-file "hostwithaltnames.pem"))]
-            (is (thrown-with-slingshot?
-                 {:kind :hostname-mismatch
-                  :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""}
+            (is (thrown+?
+                 [:kind :hostname-mismatch
+                  :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""]
                  (process-csr-submission! "foo" csr-with-disallowed-alt-names settings)))))))))
 
 (deftest cert-signing-extension-test
@@ -1105,16 +1101,16 @@
       (let [config (assoc (testutils/master-settings confdir)
                           :csr-attributes
                           (csr-attributes-file "insecure_csr_attributes.yaml"))]
-        (is (thrown-with-slingshot?
-              {:kind :disallowed-extension
-               :msg "Found extensions that are not permitted: 1.2.3.4"}
+        (is (thrown+?
+              [:kind :disallowed-extension
+               :msg "Found extensions that are not permitted: 1.2.3.4"]
               (create-master-extensions subject subject-pub issuer-pub config)))))
 
     (testing "invalid DNS alt names are rejected"
       (let [dns-alt-names "*.wildcard"]
-        (is (thrown-with-slingshot?
-              {:kind :invalid-alt-name
-               :msg "Cert subjectAltName contains a wildcard, which is not allowed: *.wildcard"}
+        (is (thrown+?
+              [:kind :invalid-alt-name
+               :msg "Cert subjectAltName contains a wildcard, which is not allowed: *.wildcard"]
               (create-master-extensions subject subject-pub issuer-pub
                                         (assoc (testutils/master-settings confdir)
                                                :dns-alt-names dns-alt-names))))))
@@ -1219,32 +1215,32 @@
 
 (deftest validate-subject!-test
   (testing "an exception is thrown when the hostnames don't match"
-    (is (thrown-with-slingshot?
-          {:kind :hostname-mismatch
-           :msg "Instance name \"test-agent\" does not match requested key \"not-test-agent\""}
+    (is (thrown+?
+          [:kind :hostname-mismatch
+           :msg "Instance name \"test-agent\" does not match requested key \"not-test-agent\""]
           (validate-subject!
             "not-test-agent" "test-agent"))))
 
   (testing "an exception is thrown if the subject name contains a capital letter"
-    (is (thrown-with-slingshot?
-          {:kind :invalid-subject-name
-           :msg "Certificate names must be lower case."}
+    (is (thrown+?
+          [:kind :invalid-subject-name
+           :msg "Certificate names must be lower case."]
           (validate-subject! "Host-With-Capital-Letters"
                              "Host-With-Capital-Letters")))))
 
 (deftest validate-dns-alt-names!-test
   (testing "Only DNS alt names are allowed"
-    (is (thrown-with-slingshot?
-          {:kind :invalid-alt-name
-           :msg "Only DNS names are allowed in the Subject Alternative Names extension"}
+    (is (thrown+?
+          [:kind :invalid-alt-name
+           :msg "Only DNS names are allowed in the Subject Alternative Names extension"]
           (validate-dns-alt-names! {:oid "2.5.29.17"
                                     :critical false
                                     :value {:ip-address ["12.34.5.6"]}}))))
 
   (testing "No DNS wildcards are allowed"
-    (is (thrown-with-slingshot?
-          {:kind :invalid-alt-name
-           :msg "Cert subjectAltName contains a wildcard, which is not allowed: foo*bar"}
+    (is (thrown+?
+          [:kind :invalid-alt-name
+           :msg "Cert subjectAltName contains a wildcard, which is not allowed: foo*bar"]
           (validate-dns-alt-names! {:oid "2.5.29.17"
                                     :critical false
                                     :value {:dns-name ["ahostname" "foo*bar"]}})))))


### PR DESCRIPTION
Flat out reject any CSRs with authorization extensions. For the
immediate future, such CSRs must be signed using the puppet cert tool.

This PR also adds a small helper to the CA tests to help make assertions about slingshot errors.