### PR TITLE
(MAINT) Replace server restarts with server HUPs

### DIFF
--- a/acceptance/suites/externalCA_tests/020-external-ca/030_revoke_agents.rb
+++ b/acceptance/suites/externalCA_tests/020-external-ca/030_revoke_agents.rb
@@ -16,11 +16,11 @@ step 'Revoke certificate of Non-Master Agents' do
   end
 end
 
-step 'Push CRL to master & restart puppetserver' do
+step 'Push CRL to master & HUP puppetserver' do
   pm_fqdn = fact_on(master, "fqdn").chomp
   on(ca, "cd /root/rakeca/intermediate;scp -o stricthostkeychecking=no ca_crl.pem root@#{pm_fqdn}:/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem")
   on(master, puppet('agent','--test', "--server #{master}"), :acceptable_exit_codes => [0,2])
-  on(master, "service puppetserver restart")
+  hup_server(master)
   on(master, puppet('agent','--test', "--server #{master}"), :acceptable_exit_codes => [0,2])
 end
 

--- a/acceptance/suites/tests/00_smoke/validate-syslog-logback.rb
+++ b/acceptance/suites/tests/00_smoke/validate-syslog-logback.rb
@@ -42,8 +42,7 @@ EOM
 
 teardown do
   on(master, "mv #{logback_backup} #{logback_path}")
-  on(master, "service #{service} restart")
-  on(master, "service #{service} status")
+  hup_server(master)
 end
 
 step 'Backup logback'

--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -32,7 +32,7 @@ teardown do
   remove_cicsetting=cicsetting('absent')
   create_remote_file(master, '/tmp/config_code_id_command_script_disable.pp', remove_cicsetting)
   on master, 'puppet apply /tmp/config_code_id_command_script_disable.pp'
-  on master, 'service puppetserver restart'
+  hup_server(master)
  
   on(master, 'rm -rf /root/.ssh/gittest_rsa*', :accept_all_exit_codes => true)
   on(master, 'puppet resource user git ensure=absent')
@@ -177,7 +177,7 @@ step 'SETUP: Configure the code-id script' do
   on master, 'puppet module install puppetlabs-hocon' 
   create_remote_file(master, '/tmp/config_code_id_command_script.pp', cicsetting() )
   on master, 'puppet apply /tmp/config_code_id_command_script.pp'
-  on master, 'service puppetserver restart'
+  hup_server(master)
 end
 
 step 'Get the current code-id'


### PR DESCRIPTION
Now that TK has HUP support, we can replace {some|many|most} server restarts with server HUPs, which will reduce acceptance suite's total runtime. This change makes 3 such changes. There are restarts or starts and stops in the acceptance suite, but they seemed to part of the test in those cases. 

In local testing, these 3 changes reduced the runtime of an ubuntu1604-mda-redhat6-64a-windows2008r2 config from 29:05 to 20:51. Runtime for a redhat6-64mda-ubuntu1404-64a-windows2008r2-64a went from 23:53 to 22:46.  Not highly rigorous testing, but there ya go.