### PR TITLE
(MAINT) Change pgrep to include o options (oldest)

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -291,7 +291,7 @@ module PuppetServerExtensions
   end
 
   def hup_server(host = master, timeout = 30)
-    pid = on(host, 'pgrep -f puppetserver').stdout.chomp
+    pid = on(host, 'pgrep -fo puppetserver').stdout.chomp
     on(host, "kill -HUP #{pid}")
     url = "https://#{host}:8140/puppet/v3/status"
     cert = get_cert(master)


### PR DESCRIPTION
The pgrep -f puppetserver bash command very occasionally returns two
pids; the pid of the puppetserver and the pid of the pgrep command its
self.  When this happens, hup_server tries to kill -HUP two pids.  This
of course causes the test to fail.

This commit resolves this issue by added the -o option to the pgrep
command.  With addition of the -o option, pgrep only returns the 
oldest matching process.