### PR TITLE
(maint) Add semantic_puppet gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "ruby/hiera"]
 	path = ruby/hiera
 	url = https://github.com/puppetlabs/hiera.git
+[submodule "ruby/semantic_puppet"]
+	path = ruby/semantic_puppet
+	url = https://github.com/puppetlabs/semantic_puppet

--- a/dev/puppetserver.conf.sample
+++ b/dev/puppetserver.conf.sample
@@ -39,7 +39,7 @@ web-router-service: {
 jruby-puppet: {
     # Where the puppet-agent dependency places puppet, facter, etc...
     # Puppet server expects to load Puppet from this location
-    ruby-load-path: [./ruby/puppet/lib, ./ruby/facter/lib, ./ruby/hiera/lib]
+    ruby-load-path: [./ruby/puppet/lib, ./ruby/facter/lib, ./ruby/hiera/lib, ./ruby/semantic_puppet/lib]
 
     # This setting determines where JRuby will look for gems.  It is also
     # used by the `puppetserver gem` command line tool.

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -310,7 +310,7 @@
 (deftest autosign-csr?-ruby-exe-test
   (let [executable (autosign-exe-file "ruby-autosign-executable")
         csr-fn #(csr-stream "test-agent")
-        ruby-load-path ["ruby/puppet/lib" "ruby/facter/lib" "ruby/hiera/lib"]]
+        ruby-load-path ["ruby/puppet/lib" "ruby/facter/lib" "ruby/hiera/lib" "ruby/semantic_puppet/lib"]]
 
     (testing "stdout is added to master's log at debug level"
       (logutils/with-test-logging

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -48,7 +48,7 @@
    :manage-internal-file-permissions true
    :signeddir             (str cadir "/signed")
    :serial                (str cadir "/serial")
-   :ruby-load-path        ["ruby/puppet/lib" "ruby/facter/lib" "ruby/hiera/lib"]})
+   :ruby-load-path        ["ruby/puppet/lib" "ruby/facter/lib" "ruby/hiera/lib" "ruby/semantic_puppet/lib"]})
 
 (defn ca-sandbox!
   "Copy the `cadir` to a temporary directory and return

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -14,7 +14,7 @@
    {:name "puppetserver", :update-server-url "http://localhost:11111"},
    :jruby-puppet
    {:gem-home "./target/jruby-gem-home",
-    :ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib"]}})
+    :ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib" "./ruby/semantic_puppet/lib"]}})
 
 (defmacro capture-out
   "capture System.out and return it as the value of :out in the return map.

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -15,7 +15,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
 
-(def ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib"])
+(def ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib" "./ruby/semantic_puppet/lib"])
 (def gem-home "./target/jruby-gem-home")
 (def compile-mode :off)
 


### PR DESCRIPTION
Note that puppet is planning to add semantic_puppet as a
hard dependency. This commit adds the semantic_puppet gem
as a git submodule under ruby/, so that developers can
work with versions of puppet that have that dependency.

It also updates the ruby load path in several places to
add semantic_puppet.