### PR TITLE
(maint) Update puppet-agent pin to 1.5.2

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.176.g21e3a74", :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "21e3a7433f8e0413ff75f14071d6540c51294eb2", :string)
+                         "1.5.2", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.5.3')
+      expect(subject).to eq('4.5.2')
     end
   end
 


### PR DESCRIPTION
The packages at the SHA for our previous puppet-agent pin were purged (they
get purged every 2 weeks), so this updates the puppet-agent pin to 1.5.2 (last
released) and puppet submodule to 4.5.2 (included in puppet-agent 1.5.2).