### PR TITLE
(maint) Bump puppet-agent version

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.173.g4ae6ee2", :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.272.g861f164", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "4ae6ee2fcb30ef676a2a3f87e21648ce0fdbc9f7", :string)
+                         "861f164b7296a28ff13391b4720c108ae7f2264c", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
The packages for the previous puppet-agent SHA we were pinned too were purged.
This commit updates us to the latest passing puppet-agent version off stable.