### PR TITLE
(PUP-6335) Add note explaining duplication in certificate_authority.clj

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -119,6 +119,9 @@
   certificate."
   "1.3.6.1.5.5.7.3.2")
 
+;; Note: When updating the following OIDs make sure to also update the OIDs here:
+;; https://github.com/puppetlabs/puppet/blob/master/lib/puppet/ssl/oids.rb#L29-L67
+
 (def puppet-oid-arc
   "The parent OID for all Puppet Labs specific X.509 certificate extensions."
   "1.3.6.1.4.1.34380.1")


### PR DESCRIPTION
The information captured in various vars in certificate_authority.clj is
duplicated in the puppet codebase. Creating a shared oids file isn't
easily achieveable today, so instead this commit adds a comment above
those vars in certificate_authority.clj explaining that any changes to
the oids need to be replicated in the puppet codebase.