### PR TITLE
(maint) Bump Puppet & Agent to fix CI

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.272.g861f164", :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.300.ga3e58f3", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "861f164b7296a28ff13391b4720c108ae7f2264c", :string)
+                         "a3e58f345f2f4dd48ed247ee731508fee3a57ec0", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This commit has not fully passed the the agent pipeline's CI. This commit (and it has not ran since) is failing on building packages for platforms that we do not test in our CI pipelines (I do not believe those failures are actually related to this change). It successfully built packages for the platforms that we test, and running Puppet's `acceptance/tests/ticket_3360_allow_duplicate_csr_with_option_set.rb` without this patch fails locally, but passes with this bump.