### PR TITLE
(SERVER-1440) Close up test-503-when-app-shuts-down race condition a bit

### DIFF
--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -221,7 +221,10 @@
            request {:uri "/puppet/v3/environments", :params {}, :headers {},
                     :request-method :GET, :body "", :ssl-client-cert cert, :content-type ""}
            ping-environment #(->> request (handler-core/wrap-params-for-jruby) (handler/handle-request handler-service))
+           ping-before-stop (ping-environment)
            stop-complete? (future (tk-app/stop app))]
+       (is (= 200 (:status ping-before-stop))
+           "environment request before stop failed")
        (let [start (System/currentTimeMillis)]
          (logging/with-test-logging
           (while (and


### PR DESCRIPTION
This commit adds an initial GET request to the environments endpoint to
the `test-503-when-app-shuts-down` test.  Without this extra call, it
is more likely for the environment ping logic in the test to exhaust up to
the maximum configured 10 second wait if the initialization of the second
JRubyPuppet instance, the one servicing the environments requests, takes
a sufficiently long amount of time.  This would, in turn, cause
assertions related to the service stop to fail because the stop was not
far enough along before the assertions were made.