### PR TITLE
(SERVER-1442) Update FOSS puppetserver checkin to be on interval

### DIFF
--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -10,6 +10,7 @@ puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service
 puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
 puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
+puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 
 # To enable the CA service, leave the following line uncommented
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service

--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -13,6 +13,7 @@
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :refer [authorization-service]]
             [puppetlabs.services.versioned-code-service.versioned-code-service :refer [versioned-code-service]]
             [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
+            [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer [scheduler-service]]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.app :as tka]
             [clojure.tools.namespace.repl :refer (refresh)]
@@ -59,7 +60,8 @@
                puppet-admin-service
                legacy-routes-service
                authorization-service
-               versioned-code-service]
+               versioned-code-service
+               scheduler-service]
               ((resolve 'user/puppetserver-conf)))))
   (alter-var-root #'system tka/init)
   (tka/check-for-errors! system))

--- a/ezbake/system-config/services.d/bootstrap.cfg
+++ b/ezbake/system-config/services.d/bootstrap.cfg
@@ -10,3 +10,4 @@ puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
 puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
 puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
+puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service

--- a/project.clj
+++ b/project.clj
@@ -59,6 +59,7 @@
                  [puppetlabs/jruby-utils "0.1.0"]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-authorization "0.7.0"]
+                 [puppetlabs/trapperkeeper-scheduler "0.0.1"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
                  [puppetlabs/ring-middleware "1.0.0"]

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -17,7 +17,7 @@
    [:CaService initialize-master-ssl! retrieve-ca-cert! retrieve-ca-crl! get-auth-handler]
    [:JRubyPuppetService]
    [:AuthorizationService wrap-with-authorization-check]
-   [:SchedulerService interspaced stop-job]
+   [:SchedulerService interspaced]
    [:VersionedCodeService get-code-content]]
   (init
    [this context]

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -13,6 +13,7 @@
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as webrouting]
             [puppetlabs.services.config.puppet-server-config-service :as ps-config]
             [puppetlabs.services.legacy-routes.legacy-routes-service :as legacy-routes]
+            [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as tk-scheduler]
             [puppetlabs.services.puppet-admin.puppet-admin-service :as admin]
             [puppetlabs.services.ca.certificate-authority-disabled-service :as disabled-ca]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization]
@@ -97,7 +98,8 @@
          admin/puppet-admin-service
          disabled-ca/certificate-authority-disabled-service
          authorization/authorization-service
-         vcs/versioned-code-service]
+         vcs/versioned-code-service
+         tk-scheduler/scheduler-service]
         {}
 
         (is (= 404 (:status (http-get "/production/certificate_statuses/all")))

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -31,6 +31,8 @@
             [puppetlabs.services.ca.certificate-authority-service :as ca]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service
              :as authorization]
+            [puppetlabs.trapperkeeper.services.scheduler.scheduler-service
+             :as tk-scheduler]
             [puppetlabs.services.versioned-code-service.versioned-code-service
              :as vcs])
   (:import (com.puppetlabs.puppetserver JRubyPuppetResponse JRubyPuppet)
@@ -674,7 +676,8 @@
         ca/certificate-authority-service
         authorization/authorization-service
         admin/puppet-admin-service
-        vcs/versioned-code-service]
+        vcs/versioned-code-service
+        tk-scheduler/scheduler-service]
        {:jruby-puppet {:max-active-instances 1
                        :environment-class-cache-enabled true}
         :webserver {:ssl-ca-cert (:localcacert puppetserver-settings)

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -12,6 +12,7 @@
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-testutils]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
+            [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer [scheduler-service]]
             [clj-semver.core :as semver]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.internal :as tk-internal]
@@ -20,7 +21,7 @@
 
 (def service-and-deps
   [puppet-server-config-service jruby-puppet-pooled-service jetty9-service
-   profiler/puppet-profiler-service jruby-pool-manager-service])
+   profiler/puppet-profiler-service jruby-pool-manager-service scheduler-service])
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/config/puppet_server_config_service_test")

--- a/test/unit/puppetlabs/services/master/master_service_test.clj
+++ b/test/unit/puppetlabs/services/master/master_service_test.clj
@@ -7,6 +7,7 @@
     [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-utils]
     [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
     [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
+    [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer [scheduler-service]]
     [puppetlabs.services.request-handler.request-handler-service :refer [request-handler-service]]
     [puppetlabs.trapperkeeper.app :as tk-app]
     [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-testutils]
@@ -41,7 +42,8 @@
              profiler/puppet-profiler-service
              certificate-authority-service
              authorization-service
-             versioned-code-service]
+             versioned-code-service
+             scheduler-service]
 
             (-> (jruby-testutils/jruby-puppet-tk-config
                   (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))
@@ -102,7 +104,8 @@
                profiler/puppet-profiler-service
                certificate-authority-disabled-service
                authorization-service
-               versioned-code-service]
+               versioned-code-service
+               scheduler-service]
 
               (-> (jruby-testutils/jruby-puppet-tk-config
                     (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -19,6 +19,7 @@
             [puppetlabs.services.protocols.versioned-code :as vc]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9]
+            [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as tk-scheduler]
             [puppetlabs.services.request-handler.request-handler-service :as handler-service]
             [puppetlabs.services.config.puppet-server-config-service :as ps-config]
             [puppetlabs.services.master.master-service :as master-service]
@@ -311,7 +312,8 @@
                       ca-service/certificate-authority-service
                       authorization-service/authorization-service
                       routing-service/webrouting-service
-                      custom-vcs]]
+                      custom-vcs
+                      tk-scheduler/scheduler-service]]
         (jruby-bootstrap/with-puppetserver-running-with-services
          app services {:jruby-puppet {:max-active-instances 1}}
          (jruby-testutils/wait-for-jrubies app)


### PR DESCRIPTION
Prior to this commit, the checkin for puppetserver would only run on
start up. This commit updates that functionality by using
trapperkeeper/scheduler to schedule a regular interval checkin job that
will run at start up, and then again every 24 hours.