### PR TITLE
(MAINT) Add a sleep to hup_server

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -316,6 +316,10 @@ module PuppetServerExtensions
       timeout = timeout - sleeptime
       sleeptime *= 2
     end
+    # FIXME: We seem to get in a situation in which puppetserver is ready
+    # before file sync is ready. Adding a sleep will get CI greenn until we
+    # can track this down
+    sleep 10
   end
   
   # appends match-requests to TK auth.conf


### PR DESCRIPTION
This is a workaround to make CI green while we locate and fix an apparent race condition. The behavior we are seeing is that after calling `file_sync_commit` and/or `wait_for_clients_to_sync` immediately following `hup_server`, some of tests, and only in CI, fail with ECONNREFUSED. It seems like puppetserver is ready before (at least) the file sync commit and status endpoints are. We can't capture it in local runs.