### PR TITLE
(MAINT) Wait for server to return 200 before returning

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -298,7 +298,7 @@ module PuppetServerExtensions
     key = get_key(master)
     response_code = "0"
     sleeptime = 1
-    while response_code != "404" && timeout > 0
+    while response_code != "200" && timeout > 0
       sleep sleeptime
       begin
         response = https_request(url, 'GET', cert, key)
@@ -309,17 +309,12 @@ module PuppetServerExtensions
           raise e
         else
           # Does this message violate the Wolfe Principle?
-          #puts "Caught and buried #{e}: this is expected because the server is restarting"
+          puts "Ignoring expected exception '#{e}' because server is restarting"
         end
       end
       response_code = response.code unless response == nil
       timeout = timeout - sleeptime
-      sleeptime *= 2
     end
-    # FIXME: We seem to get in a situation in which puppetserver is ready
-    # before file sync is ready. Adding a sleep will get CI greenn until we
-    # can track this down
-    sleep 10
   end
   
   # appends match-requests to TK auth.conf


### PR DESCRIPTION
After HUPping the server, the `hup_server` method should wait until the server returns a HTTP 200 on the status endpoint. The current behavior, bailing after getting an HTTP 404 on the status endpoint, returns control from `hup_server` before the server has fully restarted. As a result, some file sync commit operations that occur immediately following a `hup_server` call fail with `ECONNREFUSED` because the server has not even finished shutting down. With this change,`ECONNREFUSED` doesn't occur and life is wonderful.