### PR TITLE
(SERVER-1454) Bump puppet pins to pick up json-pure pin

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -28,7 +28,7 @@ module PuppetServerExtensions
 
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "3.8.3")
+                         "PUPPET_BUILD_VERSION", "e0e68f5a73990ab8767988cf2da503b76ce701de")
 
     @config = {
       :base_dir => base_dir,

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -14,7 +14,7 @@ describe Puppet::Server::Master do
   context "puppet version" do
     it "returns the correct puppet version number" do
       master = Puppet::Server::Master.new({}, {})
-      master.puppetVersion.should == '3.8.3'
+      master.puppetVersion.should == '3.8.7'
     end
   end
 


### PR DESCRIPTION
This commit bumps up the Puppet submodule and puppet package versions in
order to pick up a pin of the json-pure gem to '~> 1.8', which allows
the Ruby spec tests to continue to be run under Ruby 1.9.3.  Previously,
the version of the json-pure gem that was being installed was not
pinned.  The recently released version, 2.0.2, dropped support for
running under versions of Ruby earlier than 2.0.