### PR TITLE
(SERVER-1454) Bump puppet pins to pick up json-pure pin

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.300.ga3e58f3", :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2-232-g53abb67", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "a3e58f345f2f4dd48ed247ee731508fee3a57ec0", :string)
+                         "53abb674aee774fce29a0a80271cba3bdc4aa03d", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.6.0')
+      expect(subject).to eq('4.5.4')
     end
   end
 


### PR DESCRIPTION
This commit bumps up the Puppet submodule and puppet package versions in
order to pick up a pin of the json-pure gem to '~> 1.8', which allows
the Ruby spec test to continue to be run under Ruby 1.9.3.  Previously,
the version of the json-pure gem that was being installed was not
pinned.  The recently released version, 2.0.2, dropped support for
running under versions of Ruby earlier than 2.0.