### PR TITLE
(SERVER-1456) Upgrade nss before puppetserver install in CI pre-suite

### DIFF
--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -24,6 +24,22 @@ step "Install MRI Puppet Agents."
 step "Run puppet as puppet user to prevent permissions errors later."
   puppet_apply_as_puppet_user
 
+step "Upgrade nss to version that is hopefully compatible with jdk version puppetserver will use." do
+  nss_package=nil
+  variant, _, _, _ = master['platform'].to_array
+  case variant
+  when /^(debian|ubuntu)$/
+    nss_package_name="libnss3"
+  when /^(redhat|el|centos)$/
+    nss_package_name="nss"
+  end
+  if nss_package_name
+    master.upgrade_package(nss_package_name)
+  else
+    logger.warn("Don't know what nss package to use for #{variant} so not installing one")
+  end
+end
+
 if (test_config[:puppetserver_install_mode] == :upgrade)
   step "Upgrade Puppet Server."
     upgrade_package(master, "puppetserver")


### PR DESCRIPTION
This commit ensures that the nss package is upgraded to the latest
available version before openjdk and puppetserver are installed during a
CI test run.  Prior to this change, the nss package was not upgraded,
which could lead to puppetserver erroring out with a
`java.lang.InternalError` at service startup - due to apparent version
conflicts between pre-3.21.0 versions of nss and openjdk 1.7.0_111 and
later.