### PR TITLE
(SERVER-1454) Repin puppet to master branch ba39f2f for json_pure fix

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2-232-g53abb67", :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.343.gba39f2f", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "53abb674aee774fce29a0a80271cba3bdc4aa03d", :string)
+                         "ba39f2f2fd1b4def9a7f366d469acb1c5f6db824", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.5.4')
+      expect(subject).to eq('4.6.0')
     end
   end
 


### PR DESCRIPTION
This commit adjusts the puppet submodule and puppet-agent pins to track
current artifacts from the Ruby Puppet master branch - f93e63b and
ba39f2f, respectively - in order to pick up the json_pure changes.  A
prior commit had repinned these to artifacts tracking the Ruby Puppet
stable branch, which is inappropriate to do currently because changes
recently merged down to the Puppet Server stable branch need to track
the Ruby Puppet master branch.