### PR TITLE
Merge stable to master at 82ae322e

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,7 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.300.ga3e58f3", :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.343.gba39f2f", :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "a3e58f345f2f4dd48ed247ee731508fee3a57ec0", :string)
+                         "ba39f2f2fd1b4def9a7f366d469acb1c5f6db824", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/
@@ -224,8 +224,8 @@ module PuppetServerExtensions
     OpenSSL::X509::Certificate.new(rawcert)
   end
 
-  # Gets the key from the host hash if it is present, other wise uses 
-  # the encode_key method to get the key from the host, and stores it in the 
+  # Gets the key from the host hash if it is present, other wise uses
+  # the encode_key method to get the key from the host, and stores it in the
   # host hash
   def get_key(host)
     if host.host_hash[:key].class == OpenSSL::PKey::RSA then
@@ -303,9 +303,9 @@ module PuppetServerExtensions
       begin
         response = https_request(url, 'GET', cert, key)
       rescue StandardError => e
-        expected_errors = [ Errno::ECONNREFUSED, Errno::ECONNRESET, 
+        expected_errors = [ Errno::ECONNREFUSED, Errno::ECONNRESET,
                             OpenSSL::SSL::SSLError ]
-        if !expected_errors.include?e.class 
+        if !expected_errors.include?e.class
           raise e
         else
           # Does this message violate the Wolfe Principle?
@@ -316,13 +316,13 @@ module PuppetServerExtensions
       timeout = timeout - sleeptime
     end
   end
-  
+
   # appends match-requests to TK auth.conf
-  #   Provides many defaults so that users of this method can simply 
+  #   Provides many defaults so that users of this method can simply
   #   and easily allow a host in TK auth.conf
   #
   # NOTE: This method allows the caller to define invalid TK auth rules
-  # by design.  
+  # by design.
   #
   #   TK Auth is documented here:
   #   https://github.com/puppetlabs/puppetserver/blob/master
@@ -338,10 +338,10 @@ module PuppetServerExtensions
   #           true.
   #   deny:   hostname, glob or regex lookback to deny
   #   sort_order:
-  #   path:   
+  #   path:
   #   type:   Valid values are 'path' or 'regex'
   #   method: Should accept string or array or strings.
-  #           Valid strings include 'head', 'get', 'put', 'post', 'delete' 
+  #           Valid strings include 'head', 'get', 'put', 'post', 'delete'
   #
   require 'hocon/config_factory'
   def append_match_request(args)
@@ -358,10 +358,10 @@ module PuppetServerExtensions
     method                = args[:method] || default_http_methods
     query_params          = args[:query_params] || {}
     #TODO: handle TK-293 X509 extensions.
-    authconf_file         = args[:authconf_file] || 
+    authconf_file         = args[:authconf_file] ||
 	options[:'puppetserver-confdir']+'/auth.conf'
 
-    match_request = { 'match-request' =>   
+    match_request = { 'match-request' =>
        {  'path'        => path,
           'type'        => type,
           'method'      => method,
@@ -370,7 +370,7 @@ module PuppetServerExtensions
        'name'        => name
        }
 
-    #Note: If you set 'allow', 'allow-unauthenticated', and 'deny' you will 
+    #Note: If you set 'allow', 'allow-unauthenticated', and 'deny' you will
     #have an invalid match-request.
     match_request.merge!('allow' => allow) if allow
     match_request.merge!('allow-unauthenticated' => true) if allow_unauthenticated
@@ -379,7 +379,7 @@ module PuppetServerExtensions
     authconf_text = on(master, "cat #{authconf_file}").stdout
     authconf_hash = Hocon.parse(authconf_text)
     authconf_hash['authorization']['rules'] << match_request
- 
+
     modify_tk_config(host, authconf_file, authconf_hash, true)
   end
 


### PR DESCRIPTION
 Merge branch 'stable' into master at 82ae322e

    * stable:
      (SERVER-1454) Repin puppet to master branch ba39f2f for json_pure fix
      (SERVER-1454) Bump puppet pins to pick up json-pure pin
      (SERVER-1454) Bump puppet pins to pick up json-pure pin
      (maint) Update puppet-agent pin to 1.5.2
      (SERVER-1400) Bump puppet/puppet-agent dependencies
      (SERVER-1400) Bump puppet-agent package version
      (maint) Fix puppet version in JRuby spec test
      (SERVER-1400) Update Puppet submodule to fffcf8a6
      (SERVER-1304) Upgrade to ezbake 0.2.12
      (SERVER-1378) fix warning from "gem list"
      (MAINT) Merge up 2.3.x branch to stable

    Conflicts:
      - projects.clj - Kept the ps-version on master, 2.5.0-master-SNAPSHOT,
        and not the one from stable, 2.5.0-stable-SNAPSHOT.

This only pulls in two sets of changes:

- Bumps to the Puppet submodule and puppet-agent pins to fairly recent versions from the Puppet master branch.  These are needed to pin the json_pure gem that the JRuby Unit Test job uses so it will pass when run under Ruby 1.9.3.

- Whitespace changes in the `acceptance/lib/helper.rb` file.