### PR TITLE
(QENG-3393) Teach hup_server to eat EOFError

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -303,7 +303,7 @@ module PuppetServerExtensions
       begin
         response = https_request(url, 'GET', cert, key)
       rescue StandardError => e
-        expected_errors = [ Errno::ECONNREFUSED, Errno::ECONNRESET,
+        expected_errors = [ EOFError, Errno::ECONNREFUSED, Errno::ECONNRESET,
                             OpenSSL::SSL::SSLError ]
         if !expected_errors.include?e.class
           raise e


### PR DESCRIPTION
This commit adds `EOFError` to the list of exceptions that `hup_server` eats. We weren't catching all of the possible errors we might get from the server when trying to connect while it is coming down or starting up. This is one; there might be more. Additional discussion in QENG-3393.