### PR TITLE
(SERVER-1456) Merge branch '1.x' into stable (for nss upgrade pre-suite step)

### DIFF
--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -62,6 +62,22 @@ step "Install MRI Puppet Agents."
 
   end
 
+step "Upgrade nss to version that is hopefully compatible with jdk version puppetserver will use." do
+  nss_package=nil
+  variant, _, _, _ = master['platform'].to_array
+  case variant
+  when /^(debian|ubuntu)$/
+    nss_package_name="libnss3"
+  when /^(redhat|el|centos)$/
+    nss_package_name="nss"
+  end
+  if nss_package_name
+    master.upgrade_package(nss_package_name)
+  else
+    logger.warn("Don't know what nss package to use for #{variant} so not installing one")
+  end
+end
+
 if (test_config[:puppetserver_install_mode] == :upgrade)
   step "Upgrade Puppet Server."
     upgrade_package(master, "puppetserver")


### PR DESCRIPTION
Merge branch '1.x' into stable

* 1.x:
   (SERVER-1456) Upgrade nss before puppetserver install in CI pre-suite

Conflicts:
 -   acceptance/suites/pre_suite/foss/70_install_puppet.rb - Small
      conflicts in the "Install MRI Puppet Agents" steps, all resolved in
      favor of the existing implementation on the "stable" branch.  Pulled
      in the logic from 1.x to upgrade the nss package before installing
      Puppet Server.