### PR TITLE
(SERVER-1455) Ezbake 0.4.3, empty pidfile fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -131,7 +131,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.4.2"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.4.3"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
This commit upgrades us to ezbake 0.4.3, which contains a fix for
a bug where the packages would create an empty pidfile at install
time, before the service was started.