### PR TITLE
(MAINT) Update to latest green puppet-agent, prep for 1.6.0

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -22,7 +22,9 @@ module PuppetServerExtensions
                          "PUPPETSERVER_VERSION", nil, :string)
 
     puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION", "1.5.2.343.gba39f2f", :string) ||
+                         nil, "Puppet Version", "PUPPET_VERSION",
+                         "1.5.2.411.g5cb5a63",
+                         :string) ||
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -30,7 +32,8 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "ba39f2f2fd1b4def9a7f366d469acb1c5f6db824", :string)
+                         "5cb5a63982c01f3ed0182c25b61213d208573d8d",
+                         :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This commit updates us to the latest versions of puppet/puppet-agent
that are passing CI.  These should be very close to the final
tagged versions for 1.6.0, so getting them into our CI now will
help make sure we're ready for release.