### PR TITLE
(MAINT) Add long sleep to the hup_server helper

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -293,6 +293,7 @@ module PuppetServerExtensions
   def hup_server(host = master, timeout = 30)
     pid = on(host, 'pgrep -fo puppetserver').stdout.chomp
     on(host, "kill -HUP #{pid}")
+    sleep 30
     url = "https://#{host}:8140/puppet/v3/status"
     cert = get_cert(master)
     key = get_key(master)


### PR DESCRIPTION
This PR adds a 30 second sleep to the hup server helper.  If the server
is processing a large catalog when it recieves the hup signal, it will
delay processing the hup signal until it has completed the large
catalog, or until 30 seconds pass.

@camlow325 and I have discussed replacing hup_server with a full
puppetserver stop and start.  We've discussed making the hup_server
helper more robust, perhaps by having a fork run off and hit the status
endpoint every half second until it sees the status endpoint go down and
come back up...

Ultimately, the helper is going to be replaced with 'service puppetserver
restart' because when Chris and Jane's work is merged, the init scripts
ought to block until the server completes processing the HUP signal.
