### PR TITLE
(FOR REVIEW) (SERVER-1426) Update version to 2.5.0 for release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def tk-version "1.4.0")
 (def tk-jetty-version "1.5.9")
 (def ks-version "1.3.1")
-(def ps-version "2.5.0-stable-SNAPSHOT")
+(def ps-version "2.5.0")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
DO NOT MERGE UNTIL COORDINATING IN HIPCHAT!

This commit bumps our version number to 2.5.0 for release.  When CI runs against this commit it will produce the final maven artifacts for the 2.5.0 release automatically.