### PR TITLE
(docs) Update bootstrap markdown, configuration doc

### DIFF
--- a/documentation/_puppetserver_nav.html
+++ b/documentation/_puppetserver_nav.html
@@ -21,7 +21,8 @@
           <li><a href="/puppetserver/{{ server_version }}/config_file_master.html">master.conf: Authorization by HTTP Header (deprecated)</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_logbackxml.html">logback.xml: Logging Level and Location</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_logging_advanced.html">Advanced Logging Configuration</a></li>
-        </ul>
+          <li><a href="/puppetserver/{{ server_version }}/bootstrap_upgrade_notes.html">Bootstrap Upgrade Notes</a></li>
+      </ul>
       </li>
       <li><a href="/puppetserver/{{ server_version }}/puppet_conf_setting_diffs.html">Differing Behavior in puppet.conf</a></li>
       <li><a href="/puppetserver/{{ server_version }}/gems.html">Using Ruby Gems</a></li>

--- a/documentation/bootstrap_upgrade_notes.markdown
+++ b/documentation/bootstrap_upgrade_notes.markdown
@@ -4,23 +4,26 @@ title: "Puppet Server: Bootstrap Upgrade Notes"
 canonical: "/puppetserver/latest/bootstrap_upgrade_notes.html"
 ---
 
-**NOTE: If you have previously disabled your CA, please read this.**
+> **Note:** If you have previously disabled your CA, please read this.
 
 In the past, Puppet Server users who have modified their `bootstrap.cfg` file to disable the CA on their compile masters and support a multi-master setup have been subject to a painful upgrade experience.
 
 Starting in Puppet Server 2.5.0 this problem will start to be resolved. However, it's important to note that users who have disabled the CA service in bootstrap.cfg will need to exercise caution when upgrading to 2.5.0. Subsequent releases should no longer be subject to this issue. This page will walk you through what upgrading will be like if you are managing `bootstrap.cfg` yourself.
 
-# Upgrading to 2.5.0 or newer
+## Upgrading to 2.5.0 or newer
+
 If you are not managing your `bootstrap.cfg` file, you don't need to do anything.
 
 If you are managing your `bootstrap.cfg`, here's what you need to be aware of:
 
-## `ca.cfg`
+### `ca.cfg`
+
 Puppet Server will no longer look at `/etc/puppetlabs/puppetserver/bootstrap.cfg` for bootstrap entries. If you have modified `bootstrap.cfg` to disable the CA service, you will have to edit `/etc/puppetlabs/puppetserver/services.d/ca.cfg` and disable it there.
 
 It's a good idea to create `/etc/puppetlabs/puppetserver/services.d/ca.cfg` with the CA disabled *before* upgrading, since the `puppetserver` service will be restarted on upgrade if the service is running when you upgrade. If you don't, the default `ca.cfg` created during the upgrade will re-enable the CA service.
 
 An example of `ca.cfg` with the CA disabled:
+
 ```
 # To enable the CA service, leave the following line uncommented
 #puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
@@ -28,7 +31,8 @@ An example of `ca.cfg` with the CA disabled:
 puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
 ```
 
-# Background
+## Background
+
 Previously, if a user had modified their bootstrap.cfg (most likely to disable the CA), and if the new package contained any changes to `bootstrap.cfg`, the user would have to choose between their version of the file and the packaged version of the file. One of two bad things would happen:
 
 1. If they have the CA disabled and choose the packaged version, the CA would be re-enabled, and this might break their multi-master setup.
@@ -36,7 +40,8 @@ Previously, if a user had modified their bootstrap.cfg (most likely to disable t
 
 The crux of the issue is that `bootstrap.cfg` currently contains some items we expect the user to change, and some they should not ever need to change.
 
-# The solution
+### The solution
+
 Starting in Puppet Server 2.5.0, the `bootstrap.cfg` file has been split into multiple .cfg files in two locations:
 * `/etc/puppetlabs/puppetserver/services.d/` - Intended for services users are expected to edit
 * `/opt/puppetlabs/server/apps/puppetserver/config/services.d/` - Intended for services users should not edit

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -76,7 +76,15 @@ authorization, add the following to Puppet Server's `logback.xml` file:
 
 ## Service Bootstrapping
 
-Puppet Server is built on top of our open-source Clojure application framework, [Trapperkeeper](https://github.com/puppetlabs/trapperkeeper). One of the features that Trapperkeeper provides is the ability to enable or disable individual services that an application provides. In Puppet Server, you can use this feature to enable or disable the CA service, by modifying your `bootstrap.cfg` file (usually located in `/etc/puppetserver/bootstrap.cfg`). In that file, find the lines that look like this:
+Puppet Server is built on top of our open-source Clojure application framework, [Trapperkeeper](https://github.com/puppetlabs/trapperkeeper).
+
+One of the features that Trapperkeeper provides is the ability to enable or disable individual services that an application provides. In Puppet Server, you can use this feature to enable or disable the CA service. The CA service is enabled by default, but if you're running a multi-master environment or using an external CA, you might want to disable the CA service on some nodes.
+
+You can do this by modifying your `ca.cfg` file, usually located with other service bootstrapping configuration files in `/etc/puppetlabs/puppetserver/services.d/`.
+
+> **Note:** If you're upgrading from Puppet Server 2.4 or earlier to Server 2.5 or newer, read the [bootstrap upgrade notes](./bootstrap_upgrade_notes.markdown) first.
+
+In that file, find and modify these lines to enable or disable the service:
 
 ~~~
 # To enable the CA service, leave the following line uncommented
@@ -84,8 +92,6 @@ puppetlabs.services.ca.certificate-authority-service/certificate-authority-servi
 # To disable the CA service, comment out the above line and uncomment the line below
 #puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
 ~~~
-
-In most cases, you'll want the CA service enabled. However, if you're running a multi-master environment or using an external CA, you might want to disable the CA service on some nodes.
 
 ## Enabling the Insecure SSLv3 Protocol
 


### PR DESCRIPTION
The on-page nav for the bootstrap upgrade notes page is missing most of the headings, and a code block is rendering incorrectly there. Adjust the markdown to render correctly on the docs site.

Also, add the bootstrap upgrade page to the backup site nav, and update the configuration docs to note the changes.