### PR TITLE
(MAINT) Update puppet to 3.8.7

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -28,7 +28,7 @@ module PuppetServerExtensions
 
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "e0e68f5a73990ab8767988cf2da503b76ce701de")
+                         "PUPPET_BUILD_VERSION", "3.8.7")
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
puppetserver was pinned to a snapshot of puppet with a fix for json_pure dependency issues. That's in 3.8.7 now