### PR TITLE
(QA-2605) Move QA test library to master_manipulator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test do
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.7")
   gem 'uuidtools'
   gem 'httparty'
+  gem 'master_manipulator'
 end
 
 if File.exists? "#{__FILE__}.local"


### PR DESCRIPTION
This commit adds the master_manipulator gem to the puppetserver Gemfile. This is the first of a series of commits to enable using QA's master_manipulator gem instead of test libraries embedded in the repos we test. 