### PR TITLE
(maint) Do not fail if journalctl is empty

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -163,7 +163,7 @@ module PuppetServerExtensions
     FileUtils.mkdir_p(destination)
     scp_from master, "/var/log/puppetlabs/puppetserver/puppetserver.log", destination
     if use_journalctl
-      puppetserver_daemon_log = on(master, "journalctl -u puppetserver").stdout.strip
+      puppetserver_daemon_log = on(master, "journalctl -u puppetserver", :acceptable_exit_codes => [0,1]).stdout.strip
       destination = File.join(destination, "puppetserver-daemon.log")
       File.open(destination, 'w') {|file| file.puts puppetserver_daemon_log }
     else

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -157,6 +157,10 @@ module PuppetServerExtensions
       if version.to_i >= 15
         use_journalctl = true
       end
+    when /^sles$/
+      if version.to_i >= 12
+        use_journalctl = true
+      end
     end
 
     destination = File.join("./log/latest/puppetserver/", relative_path)


### PR DESCRIPTION
This commit allows the `journal -u` command to return with a failure.
This would happen if a service has no output for some reason. Although
this is not common, this is the case for puppetserver on sles 12. The
start and stop of this process is not recorded in the systemd journal.
As a result, `journalctl -u puppetserver` will fail even though the
puppetserver service is running successfully.