### PR TITLE
(docs) Update & expand bootstrap.cfg/ca.cfg notes

### DIFF
--- a/documentation/bootstrap_upgrade_notes.markdown
+++ b/documentation/bootstrap_upgrade_notes.markdown
@@ -26,11 +26,11 @@ If you edited or manage your `bootstrap.cfg` file, do the following:
 
 ### Before you upgrade: `ca.cfg`
 
-> **Warning:** Back up your masters' [`ssldir`](https://docs.puppet.com/puppet/latest/reference/dirs_ssldir.html) (or at least your `crl.pem` file) before the upgrade. If anything unexpected happens, such as a master's newly enabled CA services or an emergency rollback overwriting them during the upgrade, this ensures that you can restore your previous certificates and certificate revocation list.
+> **Warning:** Back up your masters' [`ssldir`](https://docs.puppet.com/puppet/latest/reference/dirs_ssldir.html) (or at least your `crl.pem` file) before the upgrade. If a master unexpectedly enables CA services or an emergency rollback overwrites your certificates and certificate revocation list, you'll need to restore them from backups.
 
-After upgrading to Puppet Server 2.5.0, CA services will be enabled on all Puppet Server masters, even if you edited the [`bootstrap.cfg` file][] before upgrading to disable them. This happens because Puppet Server 2.5 creates a new configuration file, `/etc/puppetlabs/puppetserver/services.d/ca.cfg`, if it doesn't already exist, and this new file enables CA services by default.
+Puppet Server 2.5 creates a new configuration file, `/etc/puppetlabs/puppetserver/services.d/ca.cfg`, if it doesn't already exist, and this new file enables CA services by default.
 
-To ensure that CA services remain disabled after upgrading, create the `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file with contents that disable the CA services _before_ upgrading to Server 2.5.0. Unlike the `boostrap.cfg` file, package managers **do not** overwrite the new `ca.cfg` file, allowing future upgrades to respect settings without attempting to overwrite them.
+To ensure that CA services remain disabled after upgrading, create the `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file with contents that disable the CA services _before_ you upgrade to Server 2.5.0. Unlike the `boostrap.cfg` file, package managers **do not** overwrite the new `ca.cfg` file, allowing future upgrades to respect settings without attempting to overwrite them.
 
 This example `ca.cfg` file disables the CA services:
 

--- a/documentation/bootstrap_upgrade_notes.markdown
+++ b/documentation/bootstrap_upgrade_notes.markdown
@@ -4,25 +4,35 @@ title: "Puppet Server: Bootstrap Upgrade Notes"
 canonical: "/puppetserver/latest/bootstrap_upgrade_notes.html"
 ---
 
-> **Note:** If you have previously disabled your CA, please read this.
+[`bootstrap.cfg` file]: https://docs.puppet.com/puppetserver/2.4/external_ca_configuration.html#disabling-the-internal-puppet-ca-service
 
-In the past, Puppet Server users who have modified their `bootstrap.cfg` file to disable the CA on their compile masters and support a multi-master setup have been subject to a painful upgrade experience.
+> **Note:** If you have disabled the certificate authority (CA) services on a Puppet Server master running Puppet Server 2.4.x or earlier, please read this before upgrading the master to Puppet Server 2.5.0. If you haven't, or you don't manage or modify your [`bootstrap.cfg` file][], consult the rest of the [Puppet Server 2.5.0 release notes](https://docs.puppet.com/puppetserver/2.5/release_notes.html).
 
-Starting in Puppet Server 2.5.0 this problem will start to be resolved. However, it's important to note that users who have disabled the CA service in bootstrap.cfg will need to exercise caution when upgrading to 2.5.0. Subsequent releases should no longer be subject to this issue. This page will walk you through what upgrading will be like if you are managing `bootstrap.cfg` yourself.
+Users of Puppet Server 2.4.x and earlier could modify their [`bootstrap.cfg` file][] in order to disable the CA on compile masters and support a multi-master configuration. Upgrades between these older versions have been painful, however, due to package managers attempting to overwrite this file during upgrades.
+
+This could cause two problems:
+
+1.  If users disabled CA services and chose the packaged version during the upgrade, CA services would be re-enabled on the master after the upgrade, which could break their multi-master setup.
+
+2.  If users disabled CA services and chose their version of `bootstrap.cfg`, and the new version contained settings for new services that were added to the packaged version of `bootstrap.cfg`, and in that case, the server will fail to start.
+
+Puppet Server 2.5.0 takes the first steps toward resolving this problem while maintaining configurability by changing how service bootstrap configuration works. However, users of Puppet Server 2.4.x and older who disabled the CA service in `bootstrap.cfg` **must take special precautions when upgrading to 2.5.0** to prevent the upgrade process from re-enabling the CA service or potentially overwriting files in the `ssldir`. (Subsequent releases should no longer be subject to this issue.)
 
 ## Upgrading to 2.5.0 or newer
 
-If you are not managing your `bootstrap.cfg` file, you don't need to do anything.
+Puppet Server 2.5.0 no longer uses the [`bootstrap.cfg` file][] to configure service bootstrapping. Instead, it reads files within the `/etc/puppetlabs/puppetserver/services.d/` directory, which can contain multiple files --- some designed to be edited by users --- that configure service bootstrapping.
 
-If you are managing your `bootstrap.cfg`, here's what you need to be aware of:
+If you edited or manage your `bootstrap.cfg` file, do the following:
 
-### `ca.cfg`
+### Before you upgrade: `ca.cfg`
 
-Puppet Server will no longer look at `/etc/puppetlabs/puppetserver/bootstrap.cfg` for bootstrap entries. If you have modified `bootstrap.cfg` to disable the CA service, you will have to edit `/etc/puppetlabs/puppetserver/services.d/ca.cfg` and disable it there.
+> **Warning:** Back up your masters' [`ssldir`](https://docs.puppet.com/puppet/latest/reference/dirs_ssldir.html) (or at least your `crl.pem` file) before the upgrade. If anything unexpected happens, such as a master's newly enabled CA services or an emergency rollback overwriting them during the upgrade, this ensures that you can restore your previous certificates and certificate revocation list.
 
-It's a good idea to create `/etc/puppetlabs/puppetserver/services.d/ca.cfg` with the CA disabled *before* upgrading, since the `puppetserver` service will be restarted on upgrade if the service is running when you upgrade. If you don't, the default `ca.cfg` created during the upgrade will re-enable the CA service.
+After upgrading to Puppet Server 2.5.0, CA services will be enabled on all Puppet Server masters, even if you edited the [`bootstrap.cfg` file][] before upgrading to disable them. This happens because Puppet Server 2.5 creates a new configuration file, `/etc/puppetlabs/puppetserver/services.d/ca.cfg`, if it doesn't already exist, and this new file enables CA services by default.
 
-An example of `ca.cfg` with the CA disabled:
+To ensure that CA services remain disabled after upgrading, create the `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file with contents that disable the CA services _before_ upgrading to Server 2.5.0. Unlike the `boostrap.cfg` file, package managers **do not** overwrite the new `ca.cfg` file, allowing future upgrades to respect settings without attempting to overwrite them.
+
+This example `ca.cfg` file disables the CA services:
 
 ```
 # To enable the CA service, leave the following line uncommented
@@ -31,26 +41,15 @@ An example of `ca.cfg` with the CA disabled:
 puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
 ```
 
-## Background
+### After you upgrade: New bootstrap configuration files
 
-Previously, if a user had modified their bootstrap.cfg (most likely to disable the CA), and if the new package contained any changes to `bootstrap.cfg`, the user would have to choose between their version of the file and the packaged version of the file. One of two bad things would happen:
+Starting in Puppet Server 2.5.0, the `bootstrap.cfg` file has been split into multiple configuration files in two locations:
 
-1. If they have the CA disabled and choose the packaged version, the CA would be re-enabled, and this might break their multi-master setup.
-2. If they have the CA disabled and choose their version of `bootstrap.cfg`, there may have been new services that were added to the packaged version of `bootstrap.cfg`, and in that case, the server will fail to start.
+-   `/etc/puppetlabs/puppetserver/services.d/`: For services that users are expected to edit.
+-   `/opt/puppetlabs/server/apps/puppetserver/config/services.d/`: For services users _shouldn't_ edit.
 
-The crux of the issue is that `bootstrap.cfg` currently contains some items we expect the user to change, and some they should not ever need to change.
+Any files with a `.cfg` extension in either of these locations are combined to form the final set of services Puppet Server will use.
 
-### The solution
+The CA-related configuration settings previously in `bootstrap.cfg` are set in `/etc/puppetlabs/puppetserver/services.d/ca.cfg`. If services added in future versions have user-configurable settings, the configuration files will be in this directory. When upgrading Puppet Server 2.5.0 and newer with a package manager, it should not overwrite files already in this directory.
 
-Starting in Puppet Server 2.5.0, the `bootstrap.cfg` file has been split into multiple .cfg files in two locations:
-* `/etc/puppetlabs/puppetserver/services.d/` - Intended for services users are expected to edit
-* `/opt/puppetlabs/server/apps/puppetserver/config/services.d/` - Intended for services users should not edit
-
-Any `.cfg` files in these two locations are combined to form the final set of services Puppet Server will use.
-
-The CA related services from the old `bootstrap.cfg` have been moved to `/etc/puppetlabs/puppetserver/services.d/ca.cfg`
-
-The remaining services have been moved to `/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg`
-
-In the future, any new services that are intended to be modified by users can be be added in .cfg files along side `ca.cfg`, which will avoid upgrade conflicts. Similarly, the services internal to Puppet Server can be modified however they need to be without affecting users.
-
+The remaining services are configured in `/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg`. This allows us to create and enforce default configuration files for other services across upgrades.

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -80,11 +80,18 @@ Puppet Server is built on top of our open-source Clojure application framework, 
 
 One of the features that Trapperkeeper provides is the ability to enable or disable individual services that an application provides. In Puppet Server, you can use this feature to enable or disable the CA service. The CA service is enabled by default, but if you're running a multi-master environment or using an external CA, you might want to disable the CA service on some nodes.
 
-You can do this by modifying your `ca.cfg` file, usually located with other service bootstrapping configuration files in `/etc/puppetlabs/puppetserver/services.d/`.
+Starting in Puppet Server 2.5.0, the service bootstrap configuration files are in two locations:
 
-> **Note:** If you're upgrading from Puppet Server 2.4 or earlier to Server 2.5 or newer, read the [bootstrap upgrade notes](./bootstrap_upgrade_notes.markdown) first.
+-   `/etc/puppetlabs/puppetserver/services.d/`: For services that users are expected to manually configure if necessary, such as CA-related settings.
+-   `/opt/puppetlabs/server/apps/puppetserver/config/services.d/`: For services users _shouldn't_ need to configure.
 
-In that file, find and modify these lines to enable or disable the service:
+Any files with a `.cfg` extension in either of these locations are combined to form the final set of services Puppet Server will use.
+
+The CA-related configuration settings are set in `/etc/puppetlabs/puppetserver/services.d/ca.cfg`. If services added in future versions have user-configurable settings, the configuration files will also be in this directory. When upgrading Puppet Server 2.5.0 and newer with a package manager, it should not overwrite files already in this directory.
+
+> **Note:** If you're upgrading from Puppet Server 2.4.x or earlier to Server 2.5 or newer, read and act on the [bootstrap upgrade notes](./bootstrap_upgrade_notes.markdown) **before upgrading**.
+
+In the `ca.cfg` file, find and modify these lines as directed to enable or disable the service:
 
 ~~~
 # To enable the CA service, leave the following line uncommented

--- a/documentation/external_ca_configuration.markdown
+++ b/documentation/external_ca_configuration.markdown
@@ -4,7 +4,6 @@ title: "Puppet Server: External CA Configuration"
 canonical: "/puppetserver/latest/external_ca_configuration.html"
 ---
 
-
 Puppet Server supports the ability to configure certificates from an existing
 external CA. This is similar to Ruby Puppet master functionality under a Rack-enabled web server like Apache with Passenger. Much of the existing
 documentation on [External CA Support for the Ruby Puppet Master](https://docs.puppet.com/puppet/latest/reference/config_ssl_external_ca.html)
@@ -20,18 +19,20 @@ external server. See [External SSL Termination with Puppet Server](./external_ss
 
 ## Disabling the Internal Puppet CA Service
 
-If you are using certs from an external CA, you'll need to disable the internal Puppet CA service. However, the `ca` setting from the `puppet.conf` file isn't honored by Puppet Server, so you'll disable the service in the `bootstrap.cfg` file (usually located in `/etc/puppetserver/bootstrap.cfg`).
+> **Note:** If you're upgrading from Puppet Server 2.4.x or earlier to Puppet Server 2.5, read and act on the [bootstrap upgrade notes](./bootstrap_upgrade_notes.markdown) **before upgrading**.
 
-To disable the Puppet CA service in `bootstrap.cfg`, comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...":
+If you are using certs from an external CA, you'll need to disable the internal Puppet CA service. However, the `ca` setting from the `puppet.conf` file isn't honored by Puppet Server. To disable the service, modify the `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file.
 
-~~~
+To disable the Puppet CA service in the `ca.cfg` file, comment out the line following "To enable the CA service..." and uncomment the line following "To disable the CA service...", as so:
+
+```
 # To enable the CA service, leave the following line uncommented
 # puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
 # To disable the CA service, comment out the above line and uncomment the line below
 puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
-~~~
+```
 
-For more information on the `bootstrap.cfg` file, see [Service Bootstrapping](./configuration.markdown#service-bootstrapping).
+For more information, see [Service Bootstrapping](./configuration.markdown#service-bootstrapping).
 
 ## Web Server Configuration
 

--- a/documentation/puppet_conf_setting_diffs.markdown
+++ b/documentation/puppet_conf_setting_diffs.markdown
@@ -4,7 +4,6 @@ title: "Puppet Server: Differing Behavior in puppet.conf"
 canonical: "/puppetserver/latest/puppet_conf_setting_diffs.html"
 ---
 
-
 Puppet Server honors almost all settings in puppet.conf and should pick them
 up automatically. However, some Puppet Server settings differ from a Ruby Puppet master's puppet.conf settings; we've detailed these differences below. For more complete information on puppet.conf settings, see our [Configuration Reference](https://docs.puppet.com/puppet/latest/reference/configuration.html) page.
 
@@ -23,7 +22,7 @@ listens, use either `host` (unencrypted) or `ssl-host` (SSL encrypted) in the
 
 Puppet Server does not use this setting. Instead, Puppet Server acts as a
 certificate authority based on the certificate authority service configuration
-in the `bootstrap.cfg` file. See [Service Bootstrapping](./configuration.markdown#service-bootstrapping) for more details.
+in the `ca.cfg` file. See [Service Bootstrapping](./configuration.markdown#service-bootstrapping) for more details.
 
 ### [`ca_ttl`](https://docs.puppetlabs.com/references/latest/configuration.html#cattl)
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -20,11 +20,23 @@ This is a feature and bug-fix release of Puppet Server.
 >
 > If you disabled the certificate authority (CA) on Puppet Server by editing the [`bootstrap.cfg`][service bootstrapping] file on older versions of Puppet Server --- for instance, because you have a multi-master configuration with the default CA disabled on some masters, or use an external CA --- be aware that Puppet Server 2.5.0 no longer uses the `bootstrap.cfg` file.
 >
-> If you modified `bootstrap.cfg` and then upgrade from earlier versions of Puppet Server to 2.5.0, CA services will be enabled on all upgraded Puppet Server masters. To ensure that CA services remain disabled after upgrading, create `/etc/puppetlabs/puppetserver/services.d/ca.cfg` with the CA disabled _before_ upgrading. The `puppetserver` service restarts after the upgrade if the service is running before the upgrade, and the service restart also reloads the new `ca.cfg` file.
+> Puppet Server 2.5.0 instead creates a new configuration file, `/etc/puppetlabs/puppetserver/services.d/ca.cfg`, if it doesn't already exist, and this new file enables CA services by default.
 >
-> Also, back up your masters' [`ssldir`](https://docs.puppet.com/puppet/latest/reference/dirs_ssldir.html) (or at least your `crl.pem` file) before the upgrade to ensure that you can restore your previous certificates and certificate revocation list should a master's newly enabled CA overwrite them during the upgrade.
+> To ensure that CA services remain disabled after upgrading, create the `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file with contents that disable the CA services _before_ you upgrade to Server 2.5.0. The `puppetserver` service restarts after the upgrade if the service is running before the upgrade, and the service restart also reloads the new `ca.cfg` file.
+>
+> Also, back up your masters' [`ssldir`](https://docs.puppet.com/puppet/latest/reference/dirs_ssldir.html) (or at least your `crl.pem` file) _before_ you upgrade to ensure that you can restore your previous certificates and certificate revocation list, so you can restore them in case any mistakes or failures to disable the CA services in `ca.cfg` lead to a master unexpectedly enabling CA services and overwriting them during.
 >
 > For more details, including a sample `ca.cfg` file that disables CA services, see the [bootstrap upgrade notes](./bootstrap_upgrade_notes.markdown).
+
+> ### Potential warnings when upgrading with a modified init configuration
+>
+> If you modified the init configuration file --- for instance, to [configure Puppet Server's JVM memory allocation](./install_from_packages.html#memory-allocation) or [maximum heap size](./tuning_guide.html) --- you might see a warning during the upgrade that the updated package will overwrite the file (`/etc/sysconfig/puppetserver` in Red Hat and derivatives, or `/etc/default/puppetserver` in Debian-based systems).
+>
+> The changes to the file support the new service bootstrapping behaviors. If you don't accept changes to the file, you might see a `Service ':PoolManagerService' not found` or similar warning. To satisfy this warning, make sure the `BOOTSTRAP_CONFIG` setting in the init configuration file is set to:
+>
+>     BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetserver/services.d/,/opt/puppetlabs/server/apps/puppetserver/services.d"
+>
+> If you modified other settings in the file before upgrading, and then overwrite the file during the upgrade, you might need to reapply those modifications after the upgrade.
 
 ### New feature: Flexible service bootstrapping/CA configuration file
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -16,11 +16,15 @@ Released August 11, 2016.
 
 This is a feature and bug-fix release of Puppet Server.
 
-> **Note:** If you disabled the certificate authority (CA) on Puppet Server by editing the [`bootstrap.cfg`][service bootstrapping] file on older versions of Puppet Server, be aware that Puppet Server 2.5.0 no longer uses the `bootstrap.cfg` file.
+> ### Potential breaking issues when upgrading with a modified `bootstrap.cfg`
 >
-> To ensure that CA services remain disabled after upgrading to Server 2.5.0, create `/etc/puppetlabs/puppetserver/services.d/ca.cfg` with the CA disabled *before* upgrading. The `puppetserver` service restarts on upgrade if the service is running when you upgrade, which reloads the `ca.cfg` file.
+> If you disabled the certificate authority (CA) on Puppet Server by editing the [`bootstrap.cfg`][service bootstrapping] file on older versions of Puppet Server --- for instance, because you have a multi-master configuration with the default CA disabled on some masters, or use an external CA --- be aware that Puppet Server 2.5.0 no longer uses the `bootstrap.cfg` file.
 >
-> For more details, including an sample `ca.cfg` file that disables CA services, see the [bootstrap upgrade notes](./bootstrap_upgrade_notes.markdown).
+> If you modified `bootstrap.cfg` and then upgrade from earlier versions of Puppet Server to 2.5.0, CA services will be enabled on all upgraded Puppet Server masters. To ensure that CA services remain disabled after upgrading, create `/etc/puppetlabs/puppetserver/services.d/ca.cfg` with the CA disabled _before_ upgrading. The `puppetserver` service restarts after the upgrade if the service is running before the upgrade, and the service restart also reloads the new `ca.cfg` file.
+>
+> Also, back up your masters' [`ssldir`](https://docs.puppet.com/puppet/latest/reference/dirs_ssldir.html) (or at least your `crl.pem` file) before the upgrade to ensure that you can restore your previous certificates and certificate revocation list should a master's newly enabled CA overwrite them during the upgrade.
+>
+> For more details, including a sample `ca.cfg` file that disables CA services, see the [bootstrap upgrade notes](./bootstrap_upgrade_notes.markdown).
 
 ### New feature: Flexible service bootstrapping/CA configuration file
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -24,7 +24,7 @@ This is a feature and bug-fix release of Puppet Server.
 >
 > To ensure that CA services remain disabled after upgrading, create the `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file with contents that disable the CA services _before_ you upgrade to Server 2.5.0. The `puppetserver` service restarts after the upgrade if the service is running before the upgrade, and the service restart also reloads the new `ca.cfg` file.
 >
-> Also, back up your masters' [`ssldir`](https://docs.puppet.com/puppet/latest/reference/dirs_ssldir.html) (or at least your `crl.pem` file) _before_ you upgrade to ensure that you can restore your previous certificates and certificate revocation list, so you can restore them in case any mistakes or failures to disable the CA services in `ca.cfg` lead to a master unexpectedly enabling CA services and overwriting them during.
+> Also, back up your masters' [`ssldir`](https://docs.puppet.com/puppet/latest/reference/dirs_ssldir.html) (or at least your `crl.pem` file) _before_ you upgrade to ensure that you can restore your previous certificates and certificate revocation list, so you can restore them in case any mistakes or failures to disable the CA services in `ca.cfg` lead to a master unexpectedly enabling CA services and overwriting them.
 >
 > For more details, including a sample `ca.cfg` file that disables CA services, see the [bootstrap upgrade notes](./bootstrap_upgrade_notes.markdown).
 

--- a/documentation/restarting.markdown
+++ b/documentation/restarting.markdown
@@ -41,6 +41,6 @@ There are three ways to trigger your Puppet Server environment to refresh and pi
 ### Changes that require a full Server restart
 
 * Changes to JVM arguments, such as [heap size settings](./tuning_guide.markdown#jvm-heap-size), that are typically configured in your `/etc/sysconfig/puppetserver` file.
-* Changes to [`bootstrap.cfg`](./configuration.markdown#service-bootstrapping) to enable or disable Puppet Server's certificate authority (CA) service.
+* Changes to [`ca.cfg`](./configuration.markdown#service-bootstrapping) to enable or disable Puppet Server's certificate authority (CA) service.
 
 For these types of changes, you must restart the process by using the operating system's service framework, for example, by using the `systemctl` or `service` commands.

--- a/documentation/restarting.markdown
+++ b/documentation/restarting.markdown
@@ -40,7 +40,7 @@ There are three ways to trigger your Puppet Server environment to refresh and pi
 
 ### Changes that require a full Server restart
 
-* Changes to JVM arguments, such as [heap size settings](./tuning_guide.markdown#jvm-heap-size), that are typically configured in your `/etc/sysconfig/puppetserver` file.
+* Changes to JVM arguments, such as [heap size settings](./tuning_guide.markdown#jvm-heap-size), that are typically configured in your `/etc/sysconfig/puppetserver` or `/etc/default/puppetserver` file.
 * Changes to [`ca.cfg`](./configuration.markdown#service-bootstrapping) to enable or disable Puppet Server's certificate authority (CA) service.
 
 For these types of changes, you must restart the process by using the operating system's service framework, for example, by using the `systemctl` or `service` commands.

--- a/documentation/tuning_guide.markdown
+++ b/documentation/tuning_guide.markdown
@@ -87,7 +87,7 @@ case of Puppet Server, you'll find this setting in the "defaults" file for Puppe
 Server for your operating system; this will generally be something like
 `/etc/sysconfig/puppetserver` or `/etc/defaults/puppetserver`.)
 
-> **Upgrade note:** If you modified the defaults file in Puppet Server 2.4.x or earlier, then lost those modifications or see `Service ':PoolManagerService' not found` warnings after upgrading to Puppet Server 2.5, be aware that the package might have attempted to overwite the file during the upgrade. See the [Puppet Server 2.5 release notes](https://docs.puppet.com/puppetserver/2.5/release_notes.html) for details.
+> **Upgrade note:** If you modified the defaults file in Puppet Server 2.4.x or earlier, then lost those modifications or see `Service ':PoolManagerService' not found` warnings after upgrading to Puppet Server 2.5, be aware that the package might have attempted to overwrite the file during the upgrade. See the [Puppet Server 2.5 release notes](https://docs.puppet.com/puppetserver/2.5/release_notes.html) for details.
 
 If your application's memory usage approaches this value, the JVM will try to
 get more aggressive with garbage collection to free up memory. In certain

--- a/documentation/tuning_guide.markdown
+++ b/documentation/tuning_guide.markdown
@@ -87,7 +87,7 @@ case of Puppet Server, you'll find this setting in the "defaults" file for Puppe
 Server for your operating system; this will generally be something like
 `/etc/sysconfig/puppetserver` or `/etc/defaults/puppetserver`.)
 
-> **Upgrade note:** If you modified the defaults file in Puppet Server 2.4.x or earlier, then lost those modifications after upgrading to Puppet Server 2.5, be aware that the package might have overwritten the file during the upgrade. See the [Puppet Server 2.5 release notes](https://docs.puppet.com/puppetserver/2.5/release_notes.html) for details.
+> **Upgrade note:** If you modified the defaults file in Puppet Server 2.4.x or earlier, then lost those modifications or see `Service ':PoolManagerService' not found` warnings after upgrading to Puppet Server 2.5, be aware that the package might have attempted to overwite the file during the upgrade. See the [Puppet Server 2.5 release notes](https://docs.puppet.com/puppetserver/2.5/release_notes.html) for details.
 
 If your application's memory usage approaches this value, the JVM will try to
 get more aggressive with garbage collection to free up memory. In certain

--- a/documentation/tuning_guide.markdown
+++ b/documentation/tuning_guide.markdown
@@ -87,6 +87,8 @@ case of Puppet Server, you'll find this setting in the "defaults" file for Puppe
 Server for your operating system; this will generally be something like
 `/etc/sysconfig/puppetserver` or `/etc/defaults/puppetserver`.)
 
+> **Upgrade note:** If you modified the defaults file in Puppet Server 2.4.x or earlier, then lost those modifications after upgrading to Puppet Server 2.5, be aware that the package might have overwritten the file during the upgrade. See the [Puppet Server 2.5 release notes](https://docs.puppet.com/puppetserver/2.5/release_notes.html) for details.
+
 If your application's memory usage approaches this value, the JVM will try to
 get more aggressive with garbage collection to free up memory. In certain
 situations, you may see increased CPU activity related to this garbage collection. If the JVM is unable to recover enough memory to keep the application running


### PR DESCRIPTION
-   Rewrite and expand parts of the bootstrap upgrade notes.
-   Update references to bootstrap.cfg/ca.cfg across the docs.
-   Expand the release note warning.