### PR TITLE
(maint) Exclude unnecessary gem groups from JRuby testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ namespace :spec do
       BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
       lein run -m org.jruby.Main \
-        -S bundle install --path='#{TEST_BUNDLE_DIR}'
+        -S bundle install --without extra development --path='#{TEST_BUNDLE_DIR}'
       CMD
       sh bundle_install
     end


### PR DESCRIPTION
Previously we installed all of Puppet's gem groups for JRuby testing.

Gems in the `extra` group have caused breakages in CI even though they
are unused in puppetserver testing.

This updates the Rakefile to exclude `extra` and `development` gem
groups from the installation during JRuby specs to improve CI stability.