### PR TITLE
(docs) Add resource_types deprecation notes.

### DIFF
--- a/documentation/deprecated_features.markdown
+++ b/documentation/deprecated_features.markdown
@@ -347,3 +347,27 @@ use cases.
 
 `trapperkeeper-authorization` unifies authorization configuration across all
 of these endpoints into a single file and provides more granular control.
+
+### The "resource_types" API endpoint
+
+#### Now
+
+The [`resource_type` and `resource_types` Puppet HTTP API endpoints](https://docs.puppet.com/puppet/4.6/reference/http_api/http_resource_type.html) return information about classes, defined types, and node definitions.
+
+The [`environment_classes` HTTP API in Puppet Server](./puppet-api/v3/environment_classes.html) serves as a replacement for the Puppet resource type API for classes.
+
+#### In a Future Major Release
+
+The `resource_type` and `resource_types` HTTP APIs will be removed.
+
+#### Detecting and Updating
+
+If your application calls the `resource_type` or `resource_types` HTTP API endpoints for information about classes, point those calls to the `environment_classes` endpoint. The `environment_classes` endpoint has different features and returns different values than `resource_type`; see the [changes in the environment classes API](./puppet-api/v3/environment_classes.html#changes-in-the-environment-classes-api) for details.
+
+The `environment_classes` endpoint ignores Puppet's Ruby-based authorization methods and configuration in favor of Puppet Server's Trapperkeeper authorization. For more information, see the ["Authorization" section](./puppet-api/v3/environment_classes.html#authorization) of the environment classes API documentation.
+
+#### Context
+
+Users often rely on the `resource_types` endpoint for lists of classes and associated parameters in an environment. For such requests, the `resource_types` endpoint is inefficient and can trigger problematic events, such as [manifests being parsed during a catalog request](https://tickets.puppetlabs.com/browse/SERVER-1200).
+
+To fill these requests more efficiently and safely, Puppet Server 2.3.0 introduced the narrowly defined `environment_classes` endpoint.

--- a/documentation/deprecated_features.markdown
+++ b/documentation/deprecated_features.markdown
@@ -348,7 +348,7 @@ use cases.
 `trapperkeeper-authorization` unifies authorization configuration across all
 of these endpoints into a single file and provides more granular control.
 
-### The "resource_types" API endpoint
+### Puppet's "resource_types" API endpoint
 
 #### Now
 
@@ -370,4 +370,4 @@ The `environment_classes` endpoint ignores Puppet's Ruby-based authorization met
 
 Users often rely on the `resource_types` endpoint for lists of classes and associated parameters in an environment. For such requests, the `resource_types` endpoint is inefficient and can trigger problematic events, such as [manifests being parsed during a catalog request](https://tickets.puppetlabs.com/browse/SERVER-1200).
 
-To fill these requests more efficiently and safely, Puppet Server 2.3.0 introduced the narrowly defined `environment_classes` endpoint.
+To fulfill these requests more efficiently and safely, Puppet Server 2.3.0 introduced the narrowly defined `environment_classes` endpoint.

--- a/documentation/puppet-api/v3/environment_classes.markdown
+++ b/documentation/puppet-api/v3/environment_classes.markdown
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Puppet Server: Puppet API: Environment Classes"
-canonical: "/puppetserver/latest/puppet/v3/environment_classes.html"
+canonical: "/puppetserver/latest/puppet-api/v3/environment_classes.html"
 ---
 
 [classes]: https://docs.puppet.com/puppet/latest/reference/lang_classes.html
@@ -19,13 +19,13 @@ canonical: "/puppetserver/latest/puppet/v3/environment_classes.html"
 [Etag]: https://tools.ietf.org/html/rfc7232#section-2.3
 
 The environment classes API serves as a replacement for the Puppet [resource type API][]
-for [classes][].
+for [classes][], which is [deprecated](../../deprecated_features.markdown) as of Puppet
+Server 2.3.0 and Puppet 4.5.
 
 This endpoint is available only when the Puppet master is running Puppet Server, not
-on Ruby Puppet masters, such as the
-[deprecated WEBrick Puppet master][]. It also ignores the Ruby-based Puppet master's
-authorization methods and configuration. See the [Authorization section](#authorization)
-for more information.
+on Ruby Puppet masters, such as the [deprecated WEBrick Puppet master][]. It also ignores
+the Ruby-based Puppet master's authorization methods and configuration. See the
+[Authorization section](#authorization) for more information.
 
 ## Changes in the environment classes API
 
@@ -184,9 +184,10 @@ Content-Type: text/json
 
 #### GET request with Etag roundtripped from a previous GET request
 
-If you send the [Etag][] value that was returned from the previous request to the server in a follow-up request,  and the underlying environment
-cache has not been invalidated, the server will return an HTTP 304 (Not Modified) response. See
-the [Headers and Caching Behavior](#headers-and-caching-behavior) section for more
+If you send the [Etag][] value that was returned from the previous request to the server
+in a follow-up request, and the underlying environment cache has not been invalidated, the
+server will return an HTTP 304 (Not Modified) response. See the
+[Headers and Caching Behavior](#headers-and-caching-behavior) section for more
 information about caching and invalidation of entries.
 
 ```
@@ -366,7 +367,8 @@ environment's class information.
 
 #### Clearing class information cache entries
 
-After updating an environment's manifests, you must clear the server's class information cache entries, so the server can parse the latest manifests and reflect class changes to
+After updating an environment's manifests, you must clear the server's class information
+cache entries, so the server can parse the latest manifests and reflect class changes to
 the class information in queries to the environment classes endpoint. To clear cache
 entries on the server, do one of the following:
 


### PR DESCRIPTION
Supports [DOC-2646](https://tickets.puppetlabs.com/browse/DOC-2646).