### PR TITLE
(SERVER-1502) Add the trapperkeeper-status service and web route

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -259,28 +259,32 @@ module PuppetServerExtensions
   # and slightly modified.
   # url: (String) URL to poke
   # method: (Symbol) :post, :get
-  # cert: (OpenSSL::X509::Certificate, String) The certificate to
+  # cert: (OpenSSL::X509::Certificate, nil) The certificate to
   #       use for authentication.
-  # key: (OpenSSL::PKey::RSA, String) The private key to use for
+  # key: (OpenSSL::PKey::RSA, nil) The private key to use for
   #      authentication
   # body: (String) Request body (default empty)
   require 'net/http'
   require 'uri'
-  def https_request(url, request_method, cert, key, body = nil)
+  def https_request(url, request_method, cert = nil, key = nil, body = nil)
     # Make insecure https request
     uri = URI.parse(url)
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if cert.is_a?(OpenSSL::X509::Certificate)
-      http.cert = cert
-    else
-      raise TypeError, "cert must be an OpenSSL::X509::Certificate object, not #{cert.class}"
+    if !cert.nil?
+      if cert.is_a?(OpenSSL::X509::Certificate)
+        http.cert = cert
+      else
+        raise TypeError, "cert must be an OpenSSL::X509::Certificate object, not #{cert.class}"
+      end
     end
 
-    if key.is_a?(OpenSSL::PKey::RSA)
-      http.key = key
-    else
-      raise TypeError, "key must be an OpenSSL::PKey:RSA object, not #{key.class}"
+    if !key.nil?
+      if key.is_a?(OpenSSL::PKey::RSA)
+        http.key = key
+      else
+        raise TypeError, "key must be an OpenSSL::PKey:RSA object, not #{key.class}"
+      end
     end
 
     http.use_ssl = true

--- a/acceptance/suites/tests/status_service/status_service.rb
+++ b/acceptance/suites/tests/status_service/status_service.rb
@@ -1,0 +1,19 @@
+require 'json'
+
+test_name 'Validate status service is functional'
+
+with_puppet_running_on(master, {}) do
+  step 'Make a status service request'
+  url = "https://#{master}:8140/status/v1/services?level=debug"
+  response = https_request(url, 'GET')
+
+  step 'Validate status response'
+  assert_equal("200", response.code,
+               "Unexpected response status code for request, " +
+                   "body: #{response.body}")
+  body = JSON.parse(response.body)
+  refute_nil(body, 'Response body unexpectedly nil')
+  refute_nil(body["status-service"],
+             'Response body unexpectedly did not contain status service: ' +
+                 response.body)
+end

--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -11,6 +11,7 @@ puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
 puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
+puppetlabs.trapperkeeper.services.status.status-service/status-service
 
 # To enable the CA service, leave the following line uncommented
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service

--- a/dev/puppetserver.conf.sample
+++ b/dev/puppetserver.conf.sample
@@ -33,6 +33,9 @@ web-router-service: {
     # puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service
     # service is in the bootstrap.cfg
     "puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service": ""
+
+    # This controls the mount point for the status API
+    "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
 }
 
 # configuration for the JRuby interpreters

--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -14,6 +14,7 @@
             [puppetlabs.services.versioned-code-service.versioned-code-service :refer [versioned-code-service]]
             [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer [scheduler-service]]
+            [puppetlabs.trapperkeeper.services.status.status-service :refer [status-service]]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.app :as tka]
             [clojure.tools.namespace.repl :refer (refresh)]
@@ -61,7 +62,8 @@
                legacy-routes-service
                authorization-service
                versioned-code-service
-               scheduler-service]
+               scheduler-service
+               status-service]
               ((resolve 'user/puppetserver-conf)))))
   (alter-var-root #'system tka/init)
   (tka/check-for-errors! system))

--- a/ezbake/config/conf.d/web-routes.conf
+++ b/ezbake/config/conf.d/web-routes.conf
@@ -7,4 +7,7 @@ web-router-service: {
 
     # This controls the mount point for the puppet admin API.
     "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
+
+    # This controls the mount point for the status API
+    "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
 }

--- a/ezbake/system-config/services.d/bootstrap.cfg
+++ b/ezbake/system-config/services.d/bootstrap.cfg
@@ -11,3 +11,4 @@ puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
 puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
+puppetlabs.trapperkeeper.services.status.status-service/status-service

--- a/project.clj
+++ b/project.clj
@@ -60,6 +60,7 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-authorization "0.7.0"]
                  [puppetlabs/trapperkeeper-scheduler "0.0.1"]
+                 [puppetlabs/trapperkeeper-status "0.3.5"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
                  [puppetlabs/ring-middleware "1.0.0"]


### PR DESCRIPTION
This commit adds the trapperkeeper-status service to Puppet Server and
registers an HTTP web-route for it at "/status".