### PR TITLE
(SERVER-366) Limit log disk usage

### DIFF
--- a/ezbake/config/logback.xml
+++ b/ezbake/config/logback.xml
@@ -5,10 +5,18 @@
         </encoder>
     </appender>
 
-    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+    <appender name="F1" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- TODO: this path should not be hard-coded -->
         <file>/var/log/puppetserver/puppetserver.log</file>
         <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- rollover daily -->
+            <fileNamePattern>/var/log/puppetserver/puppetserver-%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>
         </encoder>

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(def tk-version "1.1.4-SNAPSHOT")
+(def tk-version "1.1.4")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "1.1.4")
+(def ps-version "1.1.4-SNAPSHOT")
 
 (defn deploy-info
   [url]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def tk-version "1.1.1")
+(def tk-version "1.1.4-SNAPSHOT")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
 (def ps-version "1.1.4-SNAPSHOT")
@@ -14,6 +14,11 @@
   :description "Puppet Server"
 
   :dependencies [[org.clojure/clojure "1.6.0"]
+
+                 ;; begin version conflict resolution dependencies
+                 [org.slf4j/slf4j-api "1.7.20"]
+                 ;; end version conflict resolution dependencies
+
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
@@ -65,7 +70,8 @@
                        :group "puppet"
                        :start-timeout "120"
                        :build-type "foss"
-                       :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"}
+                       :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"
+                       :logrotate-enabled false}
                 :resources {:dir "tmp/ezbake-resources"}
                 :config-dir "ezbake/config"}
 
@@ -83,6 +89,7 @@
 
   :profiles {:dev {:source-paths  ["dev"]
                    :dependencies  [[org.clojure/tools.namespace "0.2.4"]
+                                   [ch.qos.logback/logback-access "1.1.7"]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
                                    [puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
@@ -97,9 +104,10 @@
              :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}
 
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
+                                               [ch.qos.logback/logback-access "1.1.7"]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.2.12"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.2.13-SNAPSHOT"]]
                       :name "puppetserver"}
 
              :uberjar {:aot [puppetlabs.trapperkeeper.main]}

--- a/project.clj
+++ b/project.clj
@@ -89,6 +89,9 @@
 
   :profiles {:dev {:source-paths  ["dev"]
                    :dependencies  [[org.clojure/tools.namespace "0.2.4"]
+                                   ; This logback dependency is here to resolve a pedantic conflict between
+                                   ; trapperkeeper 1.1.4 and trapperkeeper-webserver-jetty9. This isn't ideal,
+                                   ; but should only be necessary on the 1.x branch of PS.
                                    [ch.qos.logback/logback-access "1.1.7"]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
@@ -104,6 +107,9 @@
              :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}
 
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
+                                               ; This logback dependency is here to resolve a pedantic conflict between
+                                               ; trapperkeeper 1.1.4 and trapperkeeper-webserver-jetty9. This isn't ideal,
+                                               ; but should only be necessary on the 1.x branch of PS.
                                                [ch.qos.logback/logback-access "1.1.7"]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]

--- a/project.clj
+++ b/project.clj
@@ -113,7 +113,7 @@
                                                [ch.qos.logback/logback-access "1.1.7"]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.2.13-SNAPSHOT"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.2.13"]]
                       :name "puppetserver"}
 
              :uberjar {:aot [puppetlabs.trapperkeeper.main]}

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.4-SNAPSHOT")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "1.1.4-SNAPSHOT")
+(def ps-version "1.1.4")
 
 (defn deploy-info
   [url]

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -1,8 +1,16 @@
 <configuration debug="false" scan="true">
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>/var/log/puppetserver/puppetserver-access.log</file>
+    <append>true</append>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy"><!-- rollover daily -->
+      <fileNamePattern>/var/log/puppetserver/puppetserver-access-%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+      <!-- each file should be at most 10MB, keep 90 days worth of history, but at most 1GB total-->
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>90</maxHistory>
+      <totalSizeCap>1GB</totalSizeCap>
+    </rollingPolicy>
     <encoder>
-        <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
+      <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
     </encoder>
   </appender>
   <appender-ref ref="FILE" />


### PR DESCRIPTION
This commit updates puppetserver's logback file to limit the amount of space
log files can take up.

Since logback is handling log rotation now, `logrotate` is disabled through a new ezbake setting

---

This PR relies on SNAPSHOT builds of ezbake 02.x and trapperkeeper 1.1x, so those two will need to be released before this is merged

The new logback changes will be ported to the master branch as well

