### PR TITLE
(maint) Make shell-utils/validate-command! public

### DIFF
--- a/src/clj/puppetlabs/puppetserver/shell_utils.clj
+++ b/src/clj/puppetlabs/puppetserver/shell_utils.clj
@@ -32,8 +32,16 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Internal
 
-(schema/defn ^:private ^:always-validate
-  validate-command!
+(def default-execution-options
+  {:args []
+   :env nil
+   :in nil})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(schema/defn ^:always-validate
+validate-command!
   "Checks the command string to ensure that it is an absolute path, executable
   and that the file exists. An exception is thrown if any of those are not the
   case."
@@ -53,14 +61,6 @@
       (not (.canExecute command-file))
       (throw (IllegalArgumentException.
               (trs "The referenced command ''{0}'' is not executable" command))))))
-
-(def default-execution-options
-  {:args []
-   :env nil
-   :in nil})
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Public
 
 (schema/defn ^:always-validate
   execute-command-streamed :- ExecutionResultStreamed


### PR DESCRIPTION
In some cases it would be advantageous to log a warning at application
startup (or fail to start entirely) if a command is invalid for some
reason. This is not possible while validate-command! is a private
function, so this commit removes the private annotation and moves it
into the public section of shell-utils.