### PR TITLE
(SERVER-858) Upgrade to jruby-utils 0.2.1 / JRuby 1.7.26

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,19 +36,6 @@
                  [liberator "0.12.0"]
                  [org.apache.commons/commons-exec "1.3"]
 
-                 [org.jruby/jruby-core "1.7.20.1"
-                  :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
-                 ;; jffi and jnr-x86asm are explicit dependencies because,
-                 ;; in JRuby's poms, they are defined using version ranges,
-                 ;; and :pedantic? :abort won't tolerate this.
-                 [com.github.jnr/jffi "1.2.9"]
-                 [com.github.jnr/jffi "1.2.9" :classifier "native"]
-                 [com.github.jnr/jnr-x86asm "1.0.2"]
-                 ;; NOTE: jruby-stdlib packages some unexpected things inside
-                 ;; of its jar; please read the detailed notes above the
-                 ;; 'uberjar-exclusions' example toward the end of this file.
-                 [org.jruby/jruby-stdlib "1.7.20.1"]
-
                  ;; we do not currently use this dependency directly, but
                  ;; we have documentation that shows how users can use it to
                  ;; send their logs to logstash, so we include it in the jar.
@@ -56,7 +43,7 @@
                  [net.logstash.logback/logstash-logback-encoder "4.5.1"]
 
 
-                 [puppetlabs/jruby-utils "0.2.0"]
+                 [puppetlabs/jruby-utils "0.2.1"]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-authorization "0.7.0"]
                  [puppetlabs/trapperkeeper-scheduler "0.0.1"]

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -389,7 +389,7 @@
             jruby-scripting-container (:scripting-container jruby-instance)
             jruby-env (.runScriptlet jruby-scripting-container "ENV")]
         (try
-          (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO"}
+          (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY" "FOO"}
                  (set (keys jruby-env))))
           (is (= (.get jruby-env "FOO") (System/getenv "HOME")))
           (finally


### PR DESCRIPTION
This commit upgrades the jruby-utils dependency to 0.2.1, transitively
updating JRuby dependencies to 1.7.26.  Explicit JRuby dependencies were
removed since they can now be inherited from jruby-utils.