### PR TITLE
(MAINT) Bump puppet-agent pin to bec3ff8

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -23,7 +23,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "1.6.0",
+                         "1.6.1.39.gbec3ff8",
                          :string) ||
                          get_puppet_version
 
@@ -32,7 +32,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "1.6.0",
+                         "bec3ff8678f4981ecf9ad8065166b44c59125d58",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.6.0')
+      expect(subject).to eq('4.6.2')
     end
   end
 


### PR DESCRIPTION
This commit bumps the puppet-agent pin forward to bec3ff8 and
corresponding puppet submodule to 06fd34b.