### PR TITLE
(MAINT) Bump version for 1.2.0 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.4")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "1.1.4-SNAPSHOT")
+(def ps-version "1.2.0")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the version of Puppet Server in the project.clj file
for the 1.2.0 release.