### PR TITLE
(MAINT) Bump version for 2.6.0 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def tk-version "1.5.0")
 (def tk-jetty-version "1.5.10")
 (def ks-version "1.3.1")
-(def ps-version "2.6.0-stable-SNAPSHOT")
+(def ps-version "2.6.0")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the version of Puppet Server in the project.clj file
for the 2.6.0 release.