### PR TITLE
(MAINT) Bump version for 1.2.1-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.4")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "1.2.0")
+(def ps-version "1.2.1-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the project.clj version to 1.2.1-SNAPSHOT for a future
potential release.