### PR TITLE
(MAINT) Bump version for 2.6.1-stable-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def tk-version "1.5.0")
 (def tk-jetty-version "1.5.10")
 (def ks-version "1.3.1")
-(def ps-version "2.6.0")
+(def ps-version "2.6.1-stable-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the project.clj version to 2.6.1-stable-SNAPSHOT for a
future potential release.