### PR TITLE
(maint) Add MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at http://pup.pt/maintainers",
+  "issues": "https://tickets.puppetlabs.com/browse/SERVER",
+  "people": [
+    {
+      "github": "KevinCorcoran",
+      "email": "kevin.corcoran@puppet.com",
+      "name": "Kevin Corcoran"
+    },
+    {
+      "github": "camlow325",
+      "email": "jeremy.barlow@puppet.com",
+      "name": "Jeremy Barlow"
+    },
+    {
+      "github": "cprice404",
+      "email": "chris@puppet.com",
+      "name": "Chris Price"
+    },
+    {
+      "github": "rlinehan",
+      "email": "ruth@puppet.com",
+      "name": "Ruth Linehan"
+    },
+    {
+      "github": "haus",
+      "email": "matthaus@puppet.com",
+      "name": "Matthaus Owens"
+    },
+    {
+      "github": "justinstoller",
+      "name": "Justin Stoller"
+    },
+    {
+      "github": "jpinsonault",
+      "name": "Joe Pinsonault"
+    }
+  ]
+}

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -30,6 +30,7 @@
     },
     {
       "github": "justinstoller",
+      "email": "justin@puppet.com",
       "name": "Justin Stoller"
     },
     {

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -35,6 +35,7 @@
     },
     {
       "github": "jpinsonault",
+      "email": "joe.pinsonault@puppet.com",
       "name": "Joe Pinsonault"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ libraries. We're very grateful to the developers for building such a great
 product and for helping us work through a few bugs that we've discovered along
 the way.
 
-## Maintainence
+## Maintenance
 
-Maintainers: Chris Price <chris@puppet.com>, Jeremy Barlow <jeremy.barlow@puppet.com>, Kevin Corcoran <kevin.corcoran@puppet.com>
+Maintainers: See the [MAINTAINERS file](./MAINTAINERS)
 
-Tickets: For issues in o/s only: https://tickets.puppetlabs.com/browse/SERVER. For issues in o/s or PE: https://tickets.puppetlabs.com/browse/PE. Set component = Puppet Server
+Tickets: For issues in o/s only: https://tickets.puppetlabs.com/browse/SERVER. For issues in PE: https://tickets.puppetlabs.com/browse/PE. Set component = Puppet Server


### PR DESCRIPTION
Hi @KevinCorcoran @cprice404 @camlow325  @rlinehan @justinstoller @haus @jpinsonault:

Anticipating some possible questions:

* This PR add a MAINTAINERS file to document who is maintaining this repo. The list of people started with the top 10 PR mergers in the last year, plus a little conversation here https://github.com/puppetlabs/kylo_scratchpad/pull/1/files#r76404602
* If the list seems wrong, let's feel free to edit it.
* The format of the file is documented here: http://github.com/puppetlabs/maintainers
* And I used https://rubygems.org/gems/maintainers to construct the file
* I pushed the PR branch to the puppetlabs space (rather than mine) so that all parties can edit collaboratively as needed
* Note that this is a public repo. The email and name fields are optional here. As a starting point, I pre-populated them with the publicly available names/emails available for all of us on github (but took bogus or non-puppet emails as an indication that you may not want to share your puppet.com email). Please feel free to edit your email and name fields for any reason.

