### PR TITLE
(maint) Pass in a custom tmpdir to install_puppetlabs_dev_repos

### DIFF
--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -3,7 +3,7 @@ when :package
   step "Setup Puppet Server repositories." do
     package_build_version = ENV['PACKAGE_BUILD_VERSION']
     if package_build_version
-      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version
+      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version, 'tmp/repos/puppetserver'
     else
       abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
     end
@@ -14,7 +14,7 @@ puppet_build_version = test_config[:puppet_build_version]
 if puppet_build_version
   step "Setup Puppet Labs Dev Repositories." do
     hosts.each do |host|
-      install_puppetlabs_dev_repo host, 'puppet', puppet_build_version
+      install_puppetlabs_dev_repo host, 'puppet', puppet_build_version, 'tmp/repos/puppet'
     end
   end
 end


### PR DESCRIPTION
Because the install_puppetlabs_dev_repo uses the same tmpdir under the
hood to prepare repos, if the contents of the repos are not the same,
they will end up causing package install failures, as was seen today
when a new Packages.bz2 file caused the second repo to be corrupted.
This commit manually cleans up the tmpdir to avoid this, until this can
be fixed in beaker itself.