### PR TITLE
(PE-17071) Include data_binding_terminus setting in puppet config keys

### DIFF
--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -34,6 +34,7 @@
     :csrdir
     :csr-attributes
     :dns-alt-names
+    :data-binding-terminus
     :hostcert
     :hostcrl
     :hostprivkey
@@ -41,7 +42,7 @@
     :keylength
     :localcacert
     :manage-internal-file-permissions
-    :privatekeydir    
+    :privatekeydir
     :requestdir
     :serial
     :signeddir


### PR DESCRIPTION
This commit updates the puppet-config-keys map to include
data_binding_terminus to be able to determine that puppet is configured
to use hiera.