### PR TITLE
(EZ-89) For discussion - Install rubygems for jruby environment

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -125,7 +125,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.5.0"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.0.0-SNAPSHOT"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -32,6 +32,13 @@ ezbake: {
                pre-start-action: [
                  "/usr/bin/install --directory --owner={{user}} --group={{user}} --mode=775 /var/run/puppetlabs/puppetserver"
                ]
+               # Install some gems
+               install: [
+                 "echo \\\"jruby-puppet: { gem-home: ${DESTDIR}/opt/puppetlabs/server/data/puppetserver/jruby-gems }\\\" > jruby.conf",
+                 "java -cp puppet-server-release.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install msgpack --version 1.0.0",
+                 "java -cp puppet-server-release.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install nokogiri --version 1.6.8",
+                 "java -cp puppet-server-release.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install fast_gettext --version 1.2.0"
+                ]
              }
 
       debian: { dependencies: ["puppet-agent (>= 1.6.0)"],
@@ -52,6 +59,13 @@ ezbake: {
                # Note, pre-start-actions need to have fully qualified paths
                pre-start-action: [
                  "/usr/bin/install --directory --owner={{user}} --group={{user}} --mode=775 /var/run/puppetlabs/puppetserver"
+               ]
+               # Install some gems
+               install: [
+                 "echo \\\"jruby-puppet: { gem-home: ${DESTDIR}/opt/puppetlabs/server/data/puppetserver/jruby-gems }\\\" > jruby.conf",
+                 "java -cp puppet-server-release.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install msgpack --version 1.0.0",
+                 "java -cp puppet-server-release.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install nokogiri --version 1.6.8",
+                 "java -cp puppet-server-release.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install fast_gettext --version 1.2.0"
                ]
              }
    }

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -8,6 +8,7 @@ ezbake: {
    pe: {}
    foss: {
       redhat: { dependencies: ["puppet-agent >= 1.6.0"],
+                build-dependencies: ["%{open_jdk}"],
                # This is terrible, but we need write access to puppet's
                # var/conf dirs, so we need to add ourselves to the group.
                # Then we need to chmod some dirs until the Puppet packaging
@@ -42,6 +43,7 @@ ezbake: {
              }
 
       debian: { dependencies: ["puppet-agent (>= 1.6.0)"],
+                build-dependencies: ["openjdk-7-jre-headless | openjdk-8-jre-headless"],
                # see redhat comments on why this is terrible
                postinst: [
                  "install --owner={{user}} --group={{user}} -d /opt/puppetlabs/server/data/puppetserver/jruby-gems",


### PR DESCRIPTION
This depends on the ezbake changes at https://github.com/puppetlabs/ezbake/pull/358

This installs gems to the package buildroot using our vendored jruby. This is currently running with a sample set of gems that use native extensions. 

We should discuss what gems we actually want installed, and validate that the install location is correct. The server config will presumably need to be updated to reference that gem path.
