### PR TITLE
(SERVER-1570) ExecutionStub should raise error on failonfail

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -2,43 +2,63 @@ require 'spec_helper'
 
 require 'puppet/server/execution'
 
+def test_execute(command, args = nil, options = {})
+  if args.nil?
+    orig_command_str = command
+  else
+    orig_command_str = "#{command} #{args.join(" ")}"
+  end
+  # NOTE: the `execute` function is not part of the public API,
+  #  but is still the best level of abstraction to use for this sort
+  #  of test, so we're abusing Ruby's `send` for these tests.
+  Puppet::Server::Execution.send(:execute,
+                                 orig_command_str,
+                                 command, options, args)
+end
+
 describe Puppet::Server::Execution do
   context "execution stub" do
     it "should return an instance of ProcessOutput" do
-      result = Puppet::Server::Execution.execute("echo hi")
+      result = test_execute("echo hi")
       expect(result).to be_a Puppet::Util::Execution::ProcessOutput
     end
 
     it "should return the STDOUT of the process" do
-      result = Puppet::Server::Execution.execute("echo hi")
+      result = test_execute("echo hi")
       expect(result).to eq "hi\n"
     end
 
     it "should return an instance of ProcessOutput for a command with args" do
-      result = Puppet::Server::Execution.execute("echo",  ["hi"])
+      result = test_execute("echo",  ["hi"])
       expect(result).to be_a Puppet::Util::Execution::ProcessOutput
     end
 
     it "should return the STDOUT of the process for a command with args" do
-      result = Puppet::Server::Execution.execute("echo", ["hi"])
+      result = test_execute("echo", ["hi"])
       expect(result).to eq "hi\n"
     end
 
     it "returns an instance of ProcessOutput for a command with an empty array of args" do
-      result = Puppet::Server::Execution.execute("echo hi", [])
+      result = test_execute("echo hi", [])
       expect(result).to be_a Puppet::Util::Execution::ProcessOutput
       expect(result).to eq "hi\n"
     end
 
     it "should return the exit code of the process" do
-      result = Puppet::Server::Execution.execute("echo hi")
+      result = test_execute("echo hi")
       expect(result.exitstatus).to eq 0
 
-      result = Puppet::Server::Execution.execute("echo",  ["hi"])
+      result = test_execute("echo",  ["hi"])
       expect(result.exitstatus).to eq 0
 
-      result = Puppet::Server::Execution.execute("false")
+      result = test_execute("false")
       expect(result.exitstatus).not_to eq 0
+    end
+
+    it "should raise an error if `failonfail` is true and the process returns non-zero" do
+      expect {
+        test_execute("false", nil, {:failonfail => true})
+      }.to raise_error(Puppet::ExecutionFailure, /^Execution of 'false' returned 1/)
     end
   end
 end

--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -2,18 +2,12 @@ require 'spec_helper'
 
 require 'puppet/server/execution'
 
-def test_execute(command, args = nil, options = {})
-  if args.nil?
-    orig_command_str = command
-  else
-    orig_command_str = "#{command} #{args.join(" ")}"
-  end
+def test_execute(command, options = {})
   # NOTE: the `execute` function is not part of the public API,
   #  but is still the best level of abstraction to use for this sort
   #  of test, so we're abusing Ruby's `send` for these tests.
   Puppet::Server::Execution.send(:execute,
-                                 orig_command_str,
-                                 command, options, args)
+                                 command, options)
 end
 
 describe Puppet::Server::Execution do
@@ -29,17 +23,17 @@ describe Puppet::Server::Execution do
     end
 
     it "should return an instance of ProcessOutput for a command with args" do
-      result = test_execute("echo",  ["hi"])
+      result = test_execute(["echo", "hi"])
       expect(result).to be_a Puppet::Util::Execution::ProcessOutput
     end
 
     it "should return the STDOUT of the process for a command with args" do
-      result = test_execute("echo", ["hi"])
+      result = test_execute(["echo", "hi"])
       expect(result).to eq "hi\n"
     end
 
     it "returns an instance of ProcessOutput for a command with an empty array of args" do
-      result = test_execute("echo hi", [])
+      result = test_execute("echo hi")
       expect(result).to be_a Puppet::Util::Execution::ProcessOutput
       expect(result).to eq "hi\n"
     end
@@ -48,7 +42,7 @@ describe Puppet::Server::Execution do
       result = test_execute("echo hi")
       expect(result.exitstatus).to eq 0
 
-      result = test_execute("echo",  ["hi"])
+      result = test_execute(["echo",  "hi"])
       expect(result.exitstatus).to eq 0
 
       result = test_execute("false")
@@ -57,7 +51,7 @@ describe Puppet::Server::Execution do
 
     it "should raise an error if `failonfail` is true and the process returns non-zero" do
       expect {
-        test_execute("false", nil, {:failonfail => true})
+        test_execute("false", {:failonfail => true})
       }.to raise_error(Puppet::ExecutionFailure, /^Execution of 'false' returned 1/)
     end
   end

--- a/src/ruby/puppetserver-lib/puppet/server/execution.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/execution.rb
@@ -7,31 +7,41 @@ class Puppet::Server::Execution
   def self.initialize_execution_stub
     Puppet::Util::ExecutionStub.set do |command, options, stdin, stdout, stderr|
       if command.is_a?(Array)
+        orig_command_str = command.join(" ")
         binary = command.first
         args = command[1..-1]
       else
+        orig_command_str = command
         binary = command
         args = nil
       end
 
-      # TODO - options is currently ignored - https://tickets.puppetlabs.com/browse/SERVER-74
+      # TODO - options relating to stdout/stderr are not yet handled, see SERVER-74 and
+      #  PUP-6640
 
       # We're going to handle STDIN/STDOUT/STDERR in java, so we don't need
       # them here.  However, Puppet::Util::Execution.execute doesn't close them
       # for us, so we have to do that now.
       [stdin, stdout, stderr].each { |io| io.close rescue nil }
 
-      execute(binary, args)
+      execute(orig_command_str, binary, options, args)
     end
   end
 
-  def self.execute(command, args = nil)
+  private
+  def self.execute(orig_command_str, command, options, args)
     if args && !args.empty?
       result = ShellUtils.executeCommand(command, args.to_java(:string))
     else
       result = ShellUtils.executeCommand(command)
     end
 
-    Puppet::Util::Execution::ProcessOutput.new(result.getOutput, result.getExitCode)
+    # TODO - not all options from Puppet::Util::Execution are supported yet, see SERVER-74
+
+    if options[:failonfail] and result.exit_code != 0
+      raise Puppet::ExecutionFailure, "Execution of '#{orig_command_str}' returned #{result.exit_code}: #{result.output.strip}"
+    end
+
+    Puppet::Util::Execution::ProcessOutput.new(result.output, result.exit_code)
   end
 end


### PR DESCRIPTION
Prior to this commit, Puppet Server's implementation of `ExecutionStub`
would ignore the `:failonfail` option.  The documented behavior is to
raise a `Puppet::ExecutionFailure` if the command returns a non-zero
exit code.

This commit refactors the ExecutionStub code a bit to allow the
options hash to be passed in (which also required some refactoring
of the tests).  Then, if `:failonfail` is set, we raise the appropriate
error when the exit code is non-zero.