### PR TITLE
(SERVER-1571) Support `:combine` to merge STDOUT/STDERR

### DIFF
--- a/spec/fixtures/puppet-server-lib/puppet/jvm/execution_spec/echo_stdout_and_stderr.sh
+++ b/spec/fixtures/puppet-server-lib/puppet/jvm/execution_spec/echo_stdout_and_stderr.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "hello stdout"
+echo "hello stderr" 1>&2
+

--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -22,6 +22,13 @@ describe Puppet::Server::Execution do
       expect(result).to eq "hi\n"
     end
 
+    it "should combine STDOUT/STDERR of the process when :combine is set" do
+      result = test_execute("./spec/fixtures/puppet-server-lib/puppet/jvm/execution_spec/echo_stdout_and_stderr.sh",
+                            {:combine => true})
+      expect(result).to match(/hello stdout/)
+      expect(result).to match(/hello stderr/)
+    end
+
     it "should return an instance of ProcessOutput for a command with args" do
       result = test_execute(["echo", "hi"])
       expect(result).to be_a Puppet::Util::Execution::ProcessOutput

--- a/src/clj/puppetlabs/puppetserver/shell_utils.clj
+++ b/src/clj/puppetlabs/puppetserver/shell_utils.clj
@@ -4,7 +4,7 @@
             [puppetlabs.kitchensink.core :as ks]
             [clojure.string :as string]
             [puppetlabs.i18n.core :as i18n :refer [trs]])
-  (:import (com.puppetlabs.puppetserver ShellUtils)
+  (:import (com.puppetlabs.puppetserver ShellUtils ShellUtils$ExecutionOptions)
            (java.io IOException InputStream OutputStream)
            (org.apache.commons.io IOUtils)))
 
@@ -37,11 +37,17 @@
    :env nil
    :in nil})
 
+(schema/defn ^:always-validate java-exe-options :- ShellUtils$ExecutionOptions
+  [{:keys [env in]} :- ExecutionOptions]
+  (doto (ShellUtils$ExecutionOptions.)
+    (.setEnv (if env (ks/mapkeys name env) {}))
+    (.setStdin in)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
 (schema/defn ^:always-validate
-validate-command!
+  validate-command!
   "Checks the command string to ensure that it is an absolute path, executable
   and that the file exists. An exception is thrown if any of those are not the
   case."
@@ -71,14 +77,12 @@ validate-command!
    (execute-command-streamed command {}))
   ([command :- schema/Str
     opts :- ExecutionOptions]
-   (let [{:keys [args env in]} (merge default-execution-options opts)]
+   (let [{:keys [args] :as opts} (merge default-execution-options opts)]
      (validate-command! command)
      (let [process (ShellUtils/executeCommand
                     command
                     (into-array String args)
-                    (if env
-                      (ks/mapkeys name env))
-                    in)]
+                    (java-exe-options opts))]
        {:exit-code (.getExitCode process)
         :stderr (.getError process)
         :stdout (.getOutputAsStream process)}))))

--- a/src/java/com/puppetlabs/puppetserver/ShellUtils.java
+++ b/src/java/com/puppetlabs/puppetserver/ShellUtils.java
@@ -139,7 +139,6 @@ public class ShellUtils {
     /**
      * Executes the given command in a separate process.
      *
-     *
      * @param command the command [String] to execute. arguments can be
      *                included in the string.
      * @return An ExecutionResult with output[String], error[String], and

--- a/src/ruby/puppetserver-lib/puppet/server/execution.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/execution.rb
@@ -6,9 +6,6 @@ java_import com.puppetlabs.puppetserver.ShellUtils
 class Puppet::Server::Execution
   def self.initialize_execution_stub
     Puppet::Util::ExecutionStub.set do |command, options, stdin, stdout, stderr|
-      # TODO - options relating to stdout/stderr are not yet handled, see SERVER-74 and
-      #  PUP-6640
-
       # We're going to handle STDIN/STDOUT/STDERR in java, so we don't need
       # them here.  However, Puppet::Util::Execution.execute doesn't close them
       # for us, so we have to do that now.
@@ -30,11 +27,15 @@ class Puppet::Server::Execution
       args = nil
     end
 
+    exe_options = ShellUtils::ExecutionOptions.new
+    if options[:combine]
+      exe_options.combine_stdout_stderr = true
+    end
 
     if args && !args.empty?
-      result = ShellUtils.executeCommand(binary, args.to_java(:string))
+      result = ShellUtils.executeCommand(binary, args.to_java(:string), exe_options)
     else
-      result = ShellUtils.executeCommand(binary)
+      result = ShellUtils.executeCommand(binary, exe_options)
     end
 
     # TODO - not all options from Puppet::Util::Execution are supported yet, see SERVER-74


### PR DESCRIPTION
This commit modifies the ShellUtils java code to support the ability
to combine STDOUT/STDERR into a single stream, and modifies the
Puppet::Server::Execution implementation of the Puppet ExecutionStub
so that if the `:combine` option is set, STDOUT/STDERR will be
combined.