### PR TITLE
(SERVER-1412) package gems

### DIFF
--- a/dev/puppetserver.conf.sample
+++ b/dev/puppetserver.conf.sample
@@ -44,9 +44,14 @@ jruby-puppet: {
     # Puppet server expects to load Puppet from this location
     ruby-load-path: [./ruby/puppet/lib, ./ruby/facter/lib, ./ruby/hiera/lib]
 
-    # This setting determines where JRuby will look for gems.  It is also
-    # used by the `puppetserver gem` command line tool.
+    # This setting determines where JRuby will install gems.  It is used for loading gems,
+    # and also by the `puppetserver gem` command line tool.
     gem-home: ./target/jruby-gems
+
+    # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
+    # the gem-home directory as well as any other directories that gems can be loaded
+    # from (including the vendored gems directory for gems that ship with puppetserver)
+    gem-path: ./target/vendored-jruby-gems
 
     # (optional) path to puppet conf dir; if not specified, will use the puppet default
     master-conf-dir: ./target/master-conf-dir

--- a/dev/puppetserver.conf.sample
+++ b/dev/puppetserver.conf.sample
@@ -51,7 +51,7 @@ jruby-puppet: {
     # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
     # the gem-home directory as well as any other directories that gems can be loaded
     # from (including the vendored gems directory for gems that ship with puppetserver)
-    gem-path: ./target/vendored-jruby-gems
+    gem-path: ${jruby-puppet.gem-home}":./target/jruby-gems"
 
     # (optional) path to puppet conf dir; if not specified, will use the puppet default
     master-conf-dir: ./target/master-conf-dir

--- a/dev/puppetserver.conf.sample
+++ b/dev/puppetserver.conf.sample
@@ -51,7 +51,7 @@ jruby-puppet: {
     # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
     # the gem-home directory as well as any other directories that gems can be loaded
     # from (including the vendored gems directory for gems that ship with puppetserver)
-    gem-path: ${jruby-puppet.gem-home}":./target/jruby-gems"
+    gem-path: [${jruby-puppet.gem-home}, "./target/jruby-gems"]
 
     # (optional) path to puppet conf dir; if not specified, will use the puppet default
     master-conf-dir: ./target/master-conf-dir

--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -26,6 +26,8 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
     * `gem-home`: The location where JRuby looks for gems. It is also used by the `puppetserver gem` command line tool. If nothing is specified, JRuby uses the Puppet default `/opt/puppetlabs/server/data/puppetserver/jruby-gems`.
 
+    * `gem-path`: The complete "GEM_PATH" for jruby.  If set, it should include the `gem-home` directory, as well as any other directories that gems can be loaded from (including the vendored gems directory for gems that ship with puppetserver).  The default value is  `/opt/puppetlabs/server/data/puppetserver/jruby-gems:/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems`.
+
     * `environment-vars:` Optional. A map of environment variables which are made visible to Ruby code running within JRuby, for example, via the Ruby `ENV` class.
 
         By default, the only environment variables whose values are set into JRuby from the shell are `HOME` and `PATH`.
@@ -102,6 +104,7 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 jruby-puppet: {
     ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
     gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems
+    gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems:/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems
     environment-vars: { "FOO" : ${FOO}
                         "LANG" : "de_DE.UTF-8" }
     master-conf-dir: /etc/puppetlabs/puppet

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "2.6.0-master-SNAPSHOT")
+(def ps-version "2.6.1-master-SNAPSHOT")
 
 (defn deploy-info
   [url]

--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -1,0 +1,2 @@
+semantic_puppet 0.1.2
+hocon 1.1.2

--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -1,2 +1,2 @@
-semantic_puppet 0.1.2
-hocon 1.1.2
+semantic_puppet 0.1.3
+hocon 1.1.3

--- a/resources/ext/build-scripts/install-vendored-gems.sh
+++ b/resources/ext/build-scripts/install-vendored-gems.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+cat "${DIR}/gem-list.txt"
+
+echo "jruby-puppet: { gem-home: ${DESTDIR}/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems }" > jruby.conf
+
+while read LINE
+do
+  gem_name=$(echo $LINE |awk '{print $1}')
+  gem_version=$(echo $LINE |awk '{print $2}')
+  java -cp puppet-server-release.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install ${gem_name} --version ${gem_version}
+done < "${DIR}/gem-list.txt"

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -4,10 +4,14 @@ jruby-puppet: {
     # Puppet server expects to load Puppet from this location
     ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
 
-    # This setting determines where JRuby will look for gems.  It is also
-    # used by the `puppetserver gem` command line tool.
+    # This setting determines where JRuby will install gems.  It is used for loading gems,
+    # and also by the `puppetserver gem` command line tool.
     gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems
 
+    # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
+    # the gem-home directory as well as any other directories that gems can be loaded
+    # from (including the vendored gems directory for gems that ship with puppetserver)
+    gem-path: "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems:/opt/puppetlabs/server/data/puppetserver/jruby-gems"
 
     # PLEASE NOTE: Use caution when modifying the below settings. Modifying
     # these settings will change the value of the corresponding Puppet settings

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -11,7 +11,7 @@ jruby-puppet: {
     # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
     # the gem-home directory as well as any other directories that gems can be loaded
     # from (including the vendored gems directory for gems that ship with puppetserver)
-    gem-path: "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems:/opt/puppetlabs/server/data/puppetserver/jruby-gems"
+    gem-path: ${jruby-puppet.gem-home}":/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"
 
     # PLEASE NOTE: Use caution when modifying the below settings. Modifying
     # these settings will change the value of the corresponding Puppet settings

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -11,7 +11,7 @@ jruby-puppet: {
     # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
     # the gem-home directory as well as any other directories that gems can be loaded
     # from (including the vendored gems directory for gems that ship with puppetserver)
-    gem-path: ${jruby-puppet.gem-home}":/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"
+    gem-path: [${jruby-puppet.gem-home}, "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"]
 
     # PLEASE NOTE: Use caution when modifying the below settings. Modifying
     # these settings will change the value of the corresponding Puppet settings

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -8,6 +8,11 @@ ezbake: {
    pe: {}
    foss: {
       redhat: { dependencies: ["puppet-agent >= 1.6.0"],
+                build-dependencies: ["%{open_jdk}"],
+                # Install some gems
+                install: [
+                  "bash ./ext/build-scripts/install-vendored-gems.sh"
+                ]
                # This is terrible, but we need write access to puppet's
                # var/conf dirs, so we need to add ourselves to the group.
                # Then we need to chmod some dirs until the Puppet packaging
@@ -35,6 +40,11 @@ ezbake: {
              }
 
       debian: { dependencies: ["puppet-agent (>= 1.6.0)"],
+                build-dependencies: ["openjdk-7-jre-headless | openjdk-8-jre-headless"],
+                # Install some gems
+                install: [
+                  "bash ./ext/build-scripts/install-vendored-gems.sh"
+                ]
                # see redhat comments on why this is terrible
                postinst: [
                  "install --owner={{user}} --group={{user}} -d /opt/puppetlabs/server/data/puppetserver/jruby-gems",

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -210,11 +210,13 @@
     (jruby-core/initialize-config (assoc modified-jruby-config :lifecycle lifecycle-fns))))
 
 (schema/defn initialize-and-create-jruby-config :- jruby-schemas/JRubyConfig
-  "Handles the initialization of the jruby-puppet config for the purpose of returning a
-  jruby config. This function will only use the :jruby-puppet and :http-client sections
-  from raw-config. If values are not provided, everything in :http-client :jruby-puppet
-  will be given default values, except for :ruby-load-path, :gem-home, and :gem-path in the
-  :jruby-puppet subsection.
+  "Handles the initialization of the jruby-puppet config (from the puppetserver.conf file),
+  for the purpose of converting it to the structure required by the jruby-utils
+  library (puppetlabs.services.jruby-pool-manager.jruby-schemas/JRubyConfig).
+  This function will use data from the :jruby-puppet and :http-client sections
+  of puppetserver.conf, from raw-config. If values are not provided, everything in
+  :http-client :jruby-puppet will be given default values, except for
+  :ruby-load-path and :gem-home, which are required.
 
   The 1-arity function takes only a config and supplies a default of nil for the profiler,
   an empty fn for the agent-shutdown-fn, and suppresses warnings about legacy auth.conf.

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -9,7 +9,8 @@
             [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
             [puppetlabs.i18n.core ::as i18n :refer [trs]]
-            [clojure.tools.logging :as log])
+            [clojure.tools.logging :as log]
+            [clojure.string :as str])
   (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
            (clojure.lang IFn)
            (java.util HashMap)))
@@ -164,7 +165,7 @@
 (schema/defn ^:always-validate initialize-gem-path
   [{:keys [gem-home gem-path] :as jruby-config} :- {schema/Keyword schema/Any}]
   (if gem-path
-    jruby-config
+    (assoc jruby-config :gem-path (str/join ":" gem-path))
     (assoc jruby-config :gem-path (str gem-home ":" default-vendored-gems-dir))))
 
 (schema/defn ^:always-validate

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -322,6 +322,7 @@
       (jruby-testutils/jruby-puppet-config
        {:ruby-load-path  jruby-testutils/ruby-load-path
         :gem-home        jruby-testutils/gem-home
+        :gem-path        jruby-testutils/gem-path
         :master-conf-dir jruby-testutils/conf-dir
         :master-code-dir jruby-testutils/code-dir
         :master-var-dir  jruby-testutils/var-dir
@@ -378,6 +379,7 @@
             (merge
               {:ruby-load-path   jruby-testutils/ruby-load-path
                :gem-home         jruby-testutils/gem-home
+               :gem-path         jruby-testutils/gem-path
                :master-conf-dir  jruby-testutils/conf-dir
                :master-code-dir  jruby-testutils/code-dir
                :master-var-dir   jruby-testutils/var-dir
@@ -389,7 +391,8 @@
             jruby-scripting-container (:scripting-container jruby-instance)
             jruby-env (.runScriptlet jruby-scripting-container "ENV")]
         (try
-          (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY" "FOO"}
+          (is (= #{"HOME" "PATH" "GEM_HOME" "GEM_PATH"
+                   "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY" "FOO"}
                  (set (keys jruby-env))))
           (is (= (.get jruby-env "FOO") (System/getenv "HOME")))
           (finally

--- a/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -82,7 +82,8 @@ jruby-config :- jruby-schemas/JRubyConfig
   ([options]
    (jruby-core/initialize-config
     (merge {:ruby-load-path (jruby-puppet-core/managed-load-path jruby-puppet-testutils/ruby-load-path)
-            :gem-home jruby-puppet-testutils/gem-home}
+            :gem-home jruby-puppet-testutils/gem-home
+            :gem-path jruby-puppet-testutils/gem-path}
            options))))
 
 (defn create-scripting-container

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -14,6 +14,7 @@
    {:name "puppetserver", :update-server-url "http://localhost:11111"},
    :jruby-puppet
    {:gem-home "./target/jruby-gem-home",
+    :gem-path "./target/jruby-gem-home:./target/vendored-jruby-gems"
     :ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib"]}})
 
 (defmacro capture-out
@@ -132,6 +133,7 @@
   (testing "provided values are not overriden"
     (let [jruby-puppet-config (jruby-puppet-core/initialize-puppet-config {} {})
           unitialized-jruby-config {:gem-home "/foo"
+                                    :gem-path "/foo:/bar"
                                     :compile-mode :jit
                                     :borrow-timeout 1234
                                     :max-active-instances 4321
@@ -147,6 +149,7 @@
 
       (testing "jruby-config values are not overridden if provided"
         (is (= "/foo" (:gem-home initialized-jruby-config)))
+        (is (= "/foo:/bar" (:gem-path initialized-jruby-config)))
         (is (= :jit (:compile-mode initialized-jruby-config)))
         (is (= 1234 (:borrow-timeout initialized-jruby-config)))
         (is (= 4321 (:max-active-instances initialized-jruby-config)))
@@ -166,4 +169,8 @@
         (is (= :off (:compile-mode initialized-jruby-config)))
         (is (= jruby-core/default-borrow-timeout (:borrow-timeout initialized-jruby-config)))
         (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:max-active-instances initialized-jruby-config)))
-        (is (= 0 (:max-borrows-per-instance initialized-jruby-config)))))))
+        (is (= 0 (:max-borrows-per-instance initialized-jruby-config))))
+
+      (testing "gem-path defaults to gem-home plus the vendored gems dir if not provided"
+        (is (= "/foo:/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"
+               (:gem-path initialized-jruby-config)))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -133,7 +133,7 @@
   (testing "provided values are not overriden"
     (let [jruby-puppet-config (jruby-puppet-core/initialize-puppet-config {} {})
           unitialized-jruby-config {:gem-home "/foo"
-                                    :gem-path "/foo:/bar"
+                                    :gem-path ["/foo" "/bar"]
                                     :compile-mode :jit
                                     :borrow-timeout 1234
                                     :max-active-instances 4321

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -17,6 +17,7 @@
 
 (def ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib"])
 (def gem-home "./target/jruby-gem-home")
+(def gem-path "./target/jruby-gem-home:./target/vendored-jruby-gems")
 (def compile-mode :off)
 
 (def conf-dir "./target/master-conf")
@@ -126,7 +127,8 @@ create-mock-pool-instance :- JRubyInstance
                   :master-log-dir log-dir
                   :use-legacy-auth-conf false})
                 (jruby-core/initialize-config {:ruby-load-path ruby-load-path
-                                               :gem-home gem-home}))
+                                               :gem-home gem-home
+                                               :gem-path gem-path}))
          max-requests-per-instance (:max-borrows-per-instance combined-configs)
          updated-config (-> combined-configs
                             (assoc :max-requests-per-instance max-requests-per-instance)

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -91,6 +91,7 @@
       (let [jruby-service (reify jruby/JRubyPuppetService
                             (get-pool-context [_] (jruby-pool-manager-core/create-pool-context
                                                    (jruby-core/initialize-config {:gem-home "bar"
+                                                                                  :gem-path "bar:foobar"
                                                                                   :ruby-load-path ["foo"]})))
                             (get-environment-class-info [_ _ env]
                               (if (= env "production")

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -335,6 +335,7 @@
                           (get-pool-context [_]
                             (jruby-pool-manager-core/create-pool-context
                              (jruby-core/initialize-config {:gem-home "foo"
+                                                            :gem-path "foo:foobar"
                                                             :ruby-load-path ["bar"]}))))]
       (logutils/with-test-logging
        (testing "slingshot bad requests translated to ring response"


### PR DESCRIPTION
This PR adds the `semantic_puppet` and `hocon` gems to the puppetserver package, by installing the gems at packing time and then including them in the package.  It also adds the ability to configure the `:gem-path`, which by default will now include both the new, vendored jruby gems directory, and the original jruby gems directory.

(I've built packages and run the smoke tests in beaker locally, so I think this is ready to go.)