### PR TITLE
(QENG-4425) Pin docker-api gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ group :test do
   if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
     gem 'sqa-utils', '0.12.1'
   end
+
+  # docker-api 1.32.0 requires ruby 2.0.0
+  gem 'docker-api', '1.31.0'
 end
 
 if File.exists? "#{__FILE__}.local"


### PR DESCRIPTION
docker-api version 1.32.0 introduced a dependency on ruby >= 2.0.
This commit pins us to the older docker version in order to avoid
that dependency until we no longer have ruby 1.9.3 in our test
matrices.