### PR TITLE
(SERVER-1571) ensure environment passed to clj shellutils

### DIFF
--- a/dev-resources/puppetlabs/puppetserver/shell_utils_test/env
+++ b/dev-resources/puppetlabs/puppetserver/shell_utils_test/env
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+env

--- a/src/clj/puppetlabs/puppetserver/shell_utils.clj
+++ b/src/clj/puppetlabs/puppetserver/shell_utils.clj
@@ -39,9 +39,11 @@
 
 (schema/defn ^:always-validate java-exe-options :- ShellUtils$ExecutionOptions
   [{:keys [env in]} :- ExecutionOptions]
-  (doto (ShellUtils$ExecutionOptions.)
-    (.setEnv (if env (ks/mapkeys name env) {}))
-    (.setStdin in)))
+  (let [exe-options (ShellUtils$ExecutionOptions.)]
+    (.setStdin exe-options in)
+    (when env
+      (.setEnv exe-options (ks/mapkeys name env)))
+    exe-options))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.puppetserver.shell-utils-test
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.shell-utils :as sh-utils]
-            [puppetlabs.kitchensink.core :as ks])
+            [puppetlabs.kitchensink.core :as ks]
+            [clojure.string :as str])
   (:import (java.io ByteArrayInputStream)))
 
 (def test-resources
@@ -11,6 +12,13 @@
 (defn script-path
   [script-name]
   (str test-resources "/" script-name))
+
+(defn parse-env-output
+  [env-output]
+  (->> env-output
+       str/split-lines
+       (map #(str/split % #"=" 2))
+       (into {})))
 
 (deftest returns-the-exit-code
   (testing "true should return 0"
@@ -36,11 +44,32 @@
                           (script-path "num-args")
                           {:args ["a" "b" "c" "d" "e"]}))))))
 
+(deftest inherits-env-correctly
+  (testing "inherits environment variables if not specified"
+    (let [env-output (:stdout (sh-utils/execute-command
+                               (script-path "env")))
+          env (parse-env-output env-output)]
+      (is (< 3 (count env))
+          (str "Expected at least 3 environment variables, got:\n" env-output))
+      (is (contains? env "PATH"))
+      (is (contains? env "PWD"))
+      (is (contains? env "HOME")))))
+
 (deftest sets-env-correctly
   (testing "sets environment variables correctly"
     (is (= "foo\n" (:stdout (sh-utils/execute-command
                              (script-path "echo_foo_env_var")
-                             {:env {"FOO" "foo"}}))))))
+                             {:env {"FOO" "foo"}}))))
+
+    (let [env-output (:stdout (sh-utils/execute-command
+                               (script-path "env")
+                               {:env {"FOO" "foo"}}))
+          env (parse-env-output env-output)]
+      (is (= 2 (count env)))
+      ;; it seems that the JVM always includes a PWD env var, no
+      ;; matter what.
+      (is (= #{"FOO" "PWD"}
+             (ks/keyset env))))))
 
 (deftest pass-stdin-correctly
   (testing "passes stdin stream to command"


### PR DESCRIPTION
A recent refactor resulted in a subtle change in behavior in the
clojure shellutils wrapper, wherein if you did not pass an
explicit list of environment variables to the command, you would
end up with an empty map of environment variables for the shell
command.  Prior to that refactor, you would instead have inherited
all of the environment variables from the java process, which is
the desired behavior.  This change broke some acceptance tests which
were relying on having access to environment variables such as PATH.

This commit changes the environment variable behavior back to the
previous setup, where the java environment variables will be passed
through to the shell command unless you explicitly override the
environment.