### PR TITLE
Revert beaker-hostgenerator upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'jira-ruby', :group => :development
 group :test do
   gem 'rspec'
   gem 'beaker', '~>1.21.0'
-  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
+  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.7")
 
   # docker-api 1.32.0 requires ruby 2.0.0
   gem 'docker-api', '1.31.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,5 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-def location_for(place, fake_version = nil)
-  if place =~ /^(git[:@][^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
-  elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
-  else
-    [place, { :require => false }]
-  end
-end
-
 gem 'rake', :group => [:development, :test]
 gem 'jira-ruby', :group => :development
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,9 @@ gem 'jira-ruby', :group => :development
 group :test do
   gem 'rspec'
   gem 'beaker', '~>1.21.0'
-  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.7")
+  if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
+    gem 'sqa-utils', '0.12.1'
+  end
 
   # docker-api 1.32.0 requires ruby 2.0.0
   gem 'docker-api', '1.31.0'


### PR DESCRIPTION
@rlinehan @camlow325 @cprice404 @nwolfe 

So here's a revert of the BHG work I submitted earlier. This is necessary because there is an implicit dependency between beaker-hostgenerator and beaker >=2 as @camlow325 suspected earlier today.

We shouldn't need to merge this up into stable because stable branch is on a modern version of beaker.

I'll work on making beaker-hostgenerator compatible with this branch of puppetserver and verify it works on my own fork of the repo before submitting another PR to revert this revert.