### PR TITLE
(MAINT) Loosen SSL_connect error check in reload_updated_crl test

### DIFF
--- a/acceptance/suites/tests/service_framework/reload_updated_crl.rb
+++ b/acceptance/suites/tests/service_framework/reload_updated_crl.rb
@@ -101,7 +101,7 @@ step 'Validate that noop run for revoked agent fails with SSL error after server
                     '--certname', cert_to_revoke,
                     '--noop'),
      {:acceptable_exit_codes => [1]}) do |result|
-    assert_match(/SSL_connect SYSCALL returned=5/,
+    assert_match(/SSL_connect/,
                  result.stderr,
                  "Agent run did not fail with SSL error as expected")
   end


### PR DESCRIPTION
This commit loosens the string which is checked in the
reload_updated_crl test for an SSL connection failure on a run made
from a revoked agent.  The test previously checked for 'SSL_connect
SYSCALL returned=5' but the 'SYSCALL returned=5' part may or may not
occur depending upon how the agent detects the handshake failure.
Occasionally, it just appears as a 'Connection reset by peer -
SSL_connect' message instead.  This commit just loosens the text to
'SSL_connect', which should be good enough to determine that the
connection failed even if the exact nature of the failure is a bit
less precise.