### PR TITLE
(SERVER-1412) Minor clean-ups based on PR review

### DIFF
--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -26,7 +26,7 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
     * `gem-home`: The location where JRuby looks for gems. It is also used by the `puppetserver gem` command line tool. If nothing is specified, JRuby uses the Puppet default `/opt/puppetlabs/server/data/puppetserver/jruby-gems`.
 
-    * `gem-path`: The complete "GEM_PATH" for jruby.  If set, it should include the `gem-home` directory, as well as any other directories that gems can be loaded from (including the vendored gems directory for gems that ship with puppetserver).  The default value is  `/opt/puppetlabs/server/data/puppetserver/jruby-gems:/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems`.
+    * `gem-path`: The complete "GEM_PATH" for jruby.  If set, it should include the `gem-home` directory, as well as any other directories that gems can be loaded from (including the vendored gems directory for gems that ship with puppetserver).  The default value is  `["/opt/puppetlabs/server/data/puppetserver/jruby-gems", "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"]`.
 
     * `environment-vars:` Optional. A map of environment variables which are made visible to Ruby code running within JRuby, for example, via the Ruby `ENV` class.
 
@@ -104,7 +104,7 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 jruby-puppet: {
     ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
     gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems
-    gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems:/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems
+    gem-path: [/opt/puppetlabs/server/data/puppetserver/jruby-gems, /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems]
     environment-vars: { "FOO" : ${FOO}
                         "LANG" : "de_DE.UTF-8" }
     master-conf-dir: /etc/puppetlabs/puppet

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -9,14 +9,6 @@
 
 (use-fixtures :once schema-test/validate-schemas)
 
-(def min-config
-  {:product
-   {:name "puppetserver", :update-server-url "http://localhost:11111"},
-   :jruby-puppet
-   {:gem-home "./target/jruby-gem-home",
-    :gem-path "./target/jruby-gem-home:./target/vendored-jruby-gems"
-    :ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib"]}})
-
 (defmacro capture-out
   "capture System.out and return it as the value of :out in the return map.
   The return value of body is available as :return in the return map.


### PR DESCRIPTION
This commit fixes a few docs/examples, and removes
an unused var in one of the jruby test namespaces.