### PR TITLE
(QENG-4310) Add beaker-abs dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :test do
   gem 'rspec'
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.50.0')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
   gem 'uuidtools'
   gem 'httparty'
   gem 'master_manipulator'


### PR DESCRIPTION
beaker-abs provides a custom hypervisor in support of the always-be-scheduling
backend resource allocator, which is necessary for the CI.Next job migration
work.