### PR TITLE
(SERVER-1490) Bump lein-ezbake dep to 1.1.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -123,7 +123,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.1.2"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.1.3"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]]}


### PR DESCRIPTION
This commit bumps the lein-ezbake plugin dependency from 1.1.2 to 1.1.3.
This change re-adds the XXOutOfMemoryError java command line arg which
had unintentionally been dropped as part of the ezbake bump for service
reload functionality done for SERVER-1490.