### PR TITLE
(SERVER-1599) Enable Telemetry/Update check opt-out

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -450,6 +450,10 @@ msgid "Route not found for service {0}"
 msgstr ""
 
 #: src/clj/puppetlabs/services/master/master_service.clj
+msgid "Not checking for updates - opt-out setting exists"
+msgstr ""
+
+#: src/clj/puppetlabs/services/master/master_service.clj
 msgid "Master Service adding ring handlers"
 msgstr ""
 

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -40,9 +40,13 @@
          environment-class-cache-enabled (get-in config
                                                  [:jruby-puppet
                                                   :environment-class-cache-enabled]
-                                                 false)]
-     (interspaced checkin-interval-millis
-                  (fn [] (version-check/check-for-updates! {:product-name product-name} update-server-url)))
+                                                 false)
+         check-for-updates (get-in config [:product :check-for-updates])]
+     (if (or (nil? check-for-updates) check-for-updates)
+       (interspaced checkin-interval-millis
+                    (fn [] (version-check/check-for-updates!
+                             {:product-name product-name} update-server-url)))
+       (log/info (i18n/trs "Not checking for updates - opt-out setting exists")))
 
      (retrieve-ca-cert! localcacert)
      (retrieve-ca-crl! hostcrl)


### PR DESCRIPTION
Prior to this commit, there was no way to opt-out of update checking and
telemetry data collection. This commit updates puppetserver to look for
an opt-out file on disk before checking for updates and sending
telemetry data.