### PR TITLE
(SERVER-1585) Expose JRuby `compat-version` as an experimental option

### DIFF
--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -70,6 +70,8 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
         For more information, see the [`environment_classes` API documentation][].
 
+    * `compat-version`: Optional, experimental.  Used to control the MRI compatibility version under which JRuby runs.  The allowed values are "1.9" and "2.0".  The default value is "1.9".
+
     * `compile-mode`: Optional, experimental. Used to control JRuby's "CompileMode", which may improve performance. The default value is `off`, which is the most conservative value. A value of `jit` enables JRuby's "just-in-time" compilation of Ruby code. A value of `force` causes JRuby to attempt to pre-compile all Ruby code.
 
 * The `profiler` settings configure profiling:

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "0.3.0"]
+                 [puppetlabs/jruby-utils "0.4.0"]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-scheduler]

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -31,7 +31,7 @@
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
             [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
             [puppetlabs.trapperkeeper.config :as tk-config])
-  (:import (org.jruby RubyInstanceConfig$CompileMode)))
+  (:import (org.jruby RubyInstanceConfig$CompileMode CompatVersion)))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/jruby/jruby_pool_int_test")
@@ -273,7 +273,8 @@
 
 (deftest ^:integration settings-plumbed-into-jruby-container
   (testing "setting plumbed into jruby container for"
-    (let [jruby-puppet-config (jruby-testutils/jruby-puppet-config {:compile-mode :off})
+    (let [jruby-puppet-config (jruby-testutils/jruby-puppet-config {:compat-version "2.0"
+                                                                    :compile-mode :jit})
           config (assoc
                   (jruby-testutils/jruby-puppet-tk-config jruby-puppet-config)
                    :http-client {:connect-timeout-milliseconds 2
@@ -291,8 +292,11 @@
              jruby-instance (jruby-testutils/borrow-instance jruby-service :test)
              container (:scripting-container jruby-instance)]
          (try
-           (= RubyInstanceConfig$CompileMode/JIT
-              (.getCompileMode container))
+           (testing "compat version"
+             (is (= CompatVersion/RUBY2_0 (.getCompatVersion container))))
+           (testing "compile mode"
+             (is (= RubyInstanceConfig$CompileMode/JIT
+                    (.getCompileMode container))))
            (let [settings (into {} (.runScriptlet container
                                                   "java.util.HashMap.new
                                                      (Puppet::Server::HttpClient.settings)"))]

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -126,6 +126,7 @@
     (let [jruby-puppet-config (jruby-puppet-core/initialize-puppet-config {} {})
           unitialized-jruby-config {:gem-home "/foo"
                                     :gem-path ["/foo" "/bar"]
+                                    :compat-version 2.0
                                     :compile-mode :jit
                                     :borrow-timeout 1234
                                     :max-active-instances 4321
@@ -142,6 +143,7 @@
       (testing "jruby-config values are not overridden if provided"
         (is (= "/foo" (:gem-home initialized-jruby-config)))
         (is (= "/foo:/bar" (:gem-path initialized-jruby-config)))
+        (is (= "2.0" (:compat-version initialized-jruby-config)))
         (is (= :jit (:compile-mode initialized-jruby-config)))
         (is (= 1234 (:borrow-timeout initialized-jruby-config)))
         (is (= 4321 (:max-active-instances initialized-jruby-config)))
@@ -158,6 +160,7 @@
                                     nil)]
 
       (testing "jruby-config default values are used if not provided"
+        (is (= "1.9" (:compat-version initialized-jruby-config)))
         (is (= :off (:compile-mode initialized-jruby-config)))
         (is (= jruby-core/default-borrow-timeout (:borrow-timeout initialized-jruby-config)))
         (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:max-active-instances initialized-jruby-config)))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -18,7 +18,6 @@
 (def ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib"])
 (def gem-home "./target/jruby-gem-home")
 (def gem-path "./target/jruby-gem-home:./target/vendored-jruby-gems")
-(def compile-mode :off)
 
 (def conf-dir "./target/master-conf")
 (def code-dir "./target/master-code")


### PR DESCRIPTION
This commit exposes the JRuby MRI `compat-version` as an experimental
configurable option.  The underlying work which enables this is all in
a new version of jruby-utils, 0.4.0, and this commit bumps the
dependency to this new version.