### PR TITLE
(SERVER-1601) Set umask for gem subcommand to 0022

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -46,6 +46,22 @@ gems.each do |gem_name, gem_version|
     assert(/^#{gem_name}/.match(stdout), "#{gem_name} was not found after installation.")
   end
 
+  if gem_name == 'excon'
+    step "SERVER-1601: Validate use of excon gem successful as puppet user" do
+      if options[:type] == 'pe'
+        runuser = 'pe-puppet'
+      else
+        runuser = 'puppet'
+      end
+      on(master, "su #{runuser} -s /bin/bash -c "\
+        "'/opt/puppetlabs/bin/puppetserver ruby "\
+        "-rexcon -e \"puts Excon::VERSION\"'") do
+        assert_equal(gems['excon'], stdout.strip,
+                     "Unexpected output for excon version")
+      end
+    end
+  end
+
   step "Uninstall test gem."
   on(master, "#{gem_uninstall} #{gem_name}")
 

--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+umask 0022
+
 "${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"


### PR DESCRIPTION
The bump to EZBake 1.0+ causes cli subcommands to run with a default
umask of 027.  Previously, gems installed via the puppetserver gem
subcommand would have the world read bits for their gemspec files masked
out by this umask even though the gemspec files could be owned by the
root user.  This could cause puppetserver service, running as user
'puppet', to fail to load gems properly.

This commit sets the umask for the gem subcommand to 0022.  This should
allow gemspec files to be world-readable and, therefore, loadable by the
puppetserver service.