### PR TITLE
(SERVER-1600) add gettext-related gems required for ruby i18n

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -164,13 +164,23 @@ namespace :test do
       Open3.popen3("lein with-profile ezbake ezbake build 2>&1") do |stdin, stdout, stderr, thread|
         # sleep 5
         # puts "STDOUT IS: #{stdout}"
+        success = true
         stdout.each do |line|
           if match = line.match(%r|^Your packages will be available at http://builds.delivery.puppetlabs.net/puppetserver/(.*)$|)
             package_version = match[1]
+          elsif line =~ /^Packaging FAILURE\s*$/
+            success = false
           end
           puts line
         end
-        puts "PACKAGE VERSION IS #{package_version}"
+        exit_code = thread.value
+        if success == true
+          puts "PACKAGE VERSION IS #{package_version}"
+        else
+          puts "\n\nPACKAGING FAILED!  exit code is '#{exit_code}'.  STDERR IS:"
+          puts stderr.read
+          exit 1
+        end
       end
 
       begin

--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -1,2 +1,7 @@
 semantic_puppet 0.1.3
 hocon 1.1.3
+text 1.3.1
+locale 2.1.2
+gettext 3.2.2
+gettext-setup 0.6
+fast_gettext 1.1.0


### PR DESCRIPTION
This PR has two commits:

* First one just adds a fail fast to bakeNBeak so that it won't try to run the beaker tests if the packaging job fails.
* Second one adds the gems that @branan suggested that we will need for the puppet-agent ruby code to be able to handle i18n in the server.

I was able to build one set of packages and manually check the gem list via `puppetserver gem list` - it looked fine.  Most of my package runs are failing due to mirror/network issues, though.