### PR TITLE
(maint) Upgrade to ezbake 0.2.15

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -112,7 +112,7 @@
                                                [ch.qos.logback/logback-access "1.1.7"]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.2.13"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.2.15"]]
                       :name "puppetserver"}
 
              :uberjar {:aot [puppetlabs.trapperkeeper.main]}


### PR DESCRIPTION
... which removes Fedora 21 as a build target platform.  lein-ezbake is
currently red in CI on the 1.x branch and this patch should fix it.