### PR TITLE
puppetserver gem should honor JAVA_ARGS

### DIFF
--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -2,6 +2,6 @@
 
 umask 0022
 
-"${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
+"${JAVA_BIN}" $JAVA_ARGS -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"


### PR DESCRIPTION
Hi,

I bumped into the SSL issue related to SNI.

After adding -Djsse.enableSNIExtension=false to /etc/sysconfig/puppetserver, puppetserver gem install kept failing with 'handshake alert:  unrecognized_name'.

It looks like the gem wrapper script is not honoring the JAVA_ARGS defined under /etc/sysconfig/puppetserver.