### PR TITLE
(MAINT) Explicitly set GEM_HOME/PATH and avoid extra/dev gem install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,6 +48,7 @@ namespace :spec do
       ## Line 1 launches the JRuby that we depend on via leiningen
       ## Line 2 programmatically runs 'gem install bundler' via the gem command that comes with JRuby
       gem_install_bundler = <<-CMD
+      GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
       lein run -m org.jruby.Main \
       -e 'load "META-INF/jruby.home/bin/gem"' install -i '#{TEST_GEMS_DIR}' --no-rdoc --no-ri bundler -v '#{BUNDLER_VER}'
       CMD
@@ -66,7 +67,7 @@ namespace :spec do
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
       PUPPET_LOADED=true \
       lein run -m org.jruby.Main \
-        -S bundle install --path='#{TEST_BUNDLE_DIR}'
+        -S bundle install --without extra development --path='#{TEST_BUNDLE_DIR}'
       CMD
       sh bundle_install
     end


### PR DESCRIPTION
Previously, the GEM_HOME and GEM_PATH variables for installing the
bundler gem from the Rakefile for JRuby spec tests were not set.
This could cause gem content from the default system Ruby to be
pulled in during installation, leading to some odd error messages
at best or possibly failure at worst.  This commit sets the GEM_HOME and
GEM_PATH variables to the local ./vendor directory to avoid potential
collisions with a system MRI Ruby, just as is done for the later bundle
install of gems from the Puppet submodule's Gemfile for the spec run.

This commit also avoids installing the 'extra' and 'development' gems
from the Puppet Gemfile since these are unnecessary for running the
JRuby spec tests.