### PR TITLE
(MAINT) Bump puppet submodule to 1ea537

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -23,7 +23,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "1.6.2",
+                         "1.8.0.48.g549d028",
                          :string) ||
                          get_puppet_version
 
@@ -32,7 +32,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "1.6.2",
+                         "549d0283c85bc100205e9c5de251219db64ee698",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.6.2')
+      expect(subject).to eq('4.8.1')
     end
   end
 


### PR DESCRIPTION
Previously, JRuby spec tests were failing because of an inability to
install the public_suffix gem.  When the Puppet Gemfile was bundle
installed, version 2.5.0 of the addressable gem tried to pull in the
public_suffix gem, which requires Ruby 2.  JRuby spec tests, however,
run under MRI 1.9.3 compatibility mode, causing the install to fail.

This commit bumps the Puppet submodule up to 1ea537 and corresponding
puppet-agent package pin to 549d028.  This is being done in order to
pick up a change to the Puppet Gemfile, which pins the version of the
addressable gem to < 2.5.0.  Version 2.4.0 of the addressable gem can be
installed and used properly under MRI 1.9.3 compatibility mode.