### PR TITLE
Merge branch 'stable' into master at 65ffe9

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -23,7 +23,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "1.8.0.48.g549d028",
+                         "1.8.0.196.g117323b",
                          :string) ||
                          get_puppet_version
 
@@ -32,7 +32,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "549d0283c85bc100205e9c5de251219db64ee698",
+                         "117323bb73e41261fb98ce957f79804e4a27dc6b",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -23,7 +23,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "1.6.2",
+                         "1.8.0.48.g549d028",
                          :string) ||
                          get_puppet_version
 
@@ -32,7 +32,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "1.6.2",
+                         "549d0283c85bc100205e9c5de251219db64ee698",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "2.7.0-stable-SNAPSHOT")
+(def ps-version "2.7.0-master-SNAPSHOT")
 
 (defn deploy-info
   [url]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "2.6.1-master-SNAPSHOT")
+(def ps-version "2.7.0-stable-SNAPSHOT")
 
 (defn deploy-info
   [url]

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.6.2')
+      expect(subject).to eq('4.8.1')
     end
   end
 


### PR DESCRIPTION
    * stable:
      (MAINT) Bump puppet submodule to 1ea537
      (MAINT) Update version to 2.7.0-stable-SNAPSHOT

Following merge-up, changed project.cj, Puppet submodule, and Puppet Agent pins to point at appropriate recent versions for the master branch.