### PR TITLE
(MAINT) Drop heap size for Travis testing to 5 GB

### DIFF
--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export PUPPETSERVER_HEAP_SIZE=6G
+export PUPPETSERVER_HEAP_SIZE=5G
 
 echo "Using heap size: $PUPPETSERVER_HEAP_SIZE"
 echo "Total memory available: $(grep MemTotal /proc/meminfo | awk '{print $2}')"


### PR DESCRIPTION
This commit drops the heap size used for testing in Travis from 6 GB to
5 GB.  This is being done because JDK 8 builds under Travis are
frequently failing with a 'Cannot allocate memory' error, which may be
related to the heap size being too close to the total RAM available on
Travis CI nodes.