### PR TITLE
(docs) Add product.conf doc

### DIFF
--- a/documentation/_puppetserver_nav.html
+++ b/documentation/_puppetserver_nav.html
@@ -19,6 +19,7 @@
           <li><a href="/puppetserver/{{ server_version }}/config_file_global.html">global.conf: Trapperkeeper Settings</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_ca.html">ca.conf: CA Service Access Control (deprecated)</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_master.html">master.conf: Authorization by HTTP Header (deprecated)</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_product.html">product.conf: Configuring Product-level Interactions (optional)</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_logbackxml.html">logback.xml: Logging Level and Location</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_logging_advanced.html">Advanced Logging Configuration</a></li>
           <li><a href="/puppetserver/{{ server_version }}/bootstrap_upgrade_notes.html">Bootstrap Upgrade Notes</a></li>

--- a/documentation/config_file_product.markdown
+++ b/documentation/config_file_product.markdown
@@ -1,0 +1,34 @@
+---
+layout: default
+title: "Puppet Server Configuration Files: product.conf"
+canonical: "/puppetserver/latest/config_file_product.html"
+---
+
+The `product.conf` file contains settings that determine how Puppet Server interacts with Puppet, Inc., such as automatic update checking and analytics data collection.
+
+## Settings
+
+The `product.conf` file doesn't exist in a default Puppet Server installation; to configure its settings, you must create it in Puppet Server's `conf.d` directory (located by default at `/etc/puppetlabs/puppetserver/conf.d`). This file is a [HOCON-formatted](https://github.com/typesafehub/config/blob/master/HOCON.md) configuration file with the following settings:
+
+-   Settings in the `product` section configure update checking and analytics data collection:
+
+    -   `check-for-updates`: If set to `false`, Puppet Server will not automatically check for updates, and will not send analytics data to Puppet. 
+    
+        If this setting is unspecified (default) or set to `true`, Puppet Server checks for updates upon start or restart, and every 24 hours thereafter, by sending the following data to Puppet:
+        
+        -   Product name
+        -   Puppet Server version
+        -   IP address
+        -   Data collection timestamp 
+        
+        Puppet requests this data as one of the many ways we learn about and work with our community. The more we know about how you use Puppet, the better we can address your needs. No personally identifiable information is collected, and the data we collect is never used or shared outside of Puppet. 
+
+### Example
+
+``` hocon
+# Disabling automatic update checks and corresponding analytic data collection
+
+product: {
+    check-for-updates: false
+}
+```

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -27,6 +27,8 @@ At startup, Puppet Server reads all the `.conf` files in the `conf.d` directory.
 * [`master.conf`](./config_file_master.markdown) ([deprecated][])
 * [`ca.conf`](./config_file_ca.markdown) ([deprecated][])
 
+The [`product.conf`](./config_file_product.markdown) file is optional and is not included by default. You can create that file in the `conf.d` directory in order to configure product-related settings, such as automatic update checking and analytics data collection.
+
 ## Logging
 
 Puppet Server's logging is routed through the JVM [Logback](http://logback.qos.ch/) library. The default Logback configuration file is at `/etc/puppetserver/logback.xml` or `/etc/puppetlabs/puppetserver/logback.xml`. You can edit this file to change the logging behavior, or specify a different Logback config file in [`global.conf`](#globalconf).


### PR DESCRIPTION
-   Adds a new `config_file_product.markdown` doc for a `product.conf` file to configure/disable update checks and analytics (see discussion on #1260)
-   Adds a link to this new doc on the `configuration.markdown` doc and aux nav.

If we merge this, also merge updates to puppet-docs and either revert or don't merge #1260.