### PR TITLE
Merge branch 'stable' into master at 535508

### DIFF
--- a/documentation/_puppetserver_nav.html
+++ b/documentation/_puppetserver_nav.html
@@ -19,6 +19,7 @@
           <li><a href="/puppetserver/{{ server_version }}/config_file_global.html">global.conf: Trapperkeeper Settings</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_ca.html">ca.conf: CA Service Access Control (deprecated)</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_master.html">master.conf: Authorization by HTTP Header (deprecated)</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_product.html">product.conf: Configuring Product-level Interactions (optional)</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_logbackxml.html">logback.xml: Logging Level and Location</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_logging_advanced.html">Advanced Logging Configuration</a></li>
           <li><a href="/puppetserver/{{ server_version }}/bootstrap_upgrade_notes.html">Bootstrap Upgrade Notes</a></li>

--- a/documentation/config_file_product.markdown
+++ b/documentation/config_file_product.markdown
@@ -1,0 +1,34 @@
+---
+layout: default
+title: "Puppet Server Configuration Files: product.conf"
+canonical: "/puppetserver/latest/config_file_product.html"
+---
+
+The `product.conf` file contains settings that determine how Puppet Server interacts with Puppet, Inc., such as automatic update checking and analytics data collection.
+
+## Settings
+
+The `product.conf` file doesn't exist in a default Puppet Server installation; to configure its settings, you must create it in Puppet Server's `conf.d` directory (located by default at `/etc/puppetlabs/puppetserver/conf.d`). This file is a [HOCON-formatted](https://github.com/typesafehub/config/blob/master/HOCON.md) configuration file with the following settings:
+
+-   Settings in the `product` section configure update checking and analytics data collection:
+
+    -   `check-for-updates`: If set to `false`, Puppet Server will not automatically check for updates, and will not send analytics data to Puppet. 
+    
+        If this setting is unspecified (default) or set to `true`, Puppet Server checks for updates upon start or restart, and every 24 hours thereafter, by sending the following data to Puppet:
+        
+        -   Product name
+        -   Puppet Server version
+        -   IP address
+        -   Data collection timestamp 
+        
+        Puppet requests this data as one of the many ways we learn about and work with our community. The more we know about how you use Puppet, the better we can address your needs. No personally identifiable information is collected, and the data we collect is never used or shared outside of Puppet. 
+
+### Example
+
+``` hocon
+# Disabling automatic update checks and corresponding analytic data collection
+
+product: {
+    check-for-updates: false
+}
+```

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -27,6 +27,8 @@ At startup, Puppet Server reads all the `.conf` files in the `conf.d` directory.
 * [`master.conf`](./config_file_master.markdown) ([deprecated][])
 * [`ca.conf`](./config_file_ca.markdown) ([deprecated][])
 
+The [`product.conf`](./config_file_product.markdown) file is optional and is not included by default. You can create that file in the `conf.d` directory in order to configure product-related settings, such as automatic update checking and analytics data collection.
+
 ## Logging
 
 Puppet Server's logging is routed through the JVM [Logback](http://logback.qos.ch/) library. The default Logback configuration file is at `/etc/puppetserver/logback.xml` or `/etc/puppetlabs/puppetserver/logback.xml`. You can edit this file to change the logging behavior, or specify a different Logback config file in [`global.conf`](#globalconf).

--- a/documentation/restarting.markdown
+++ b/documentation/restarting.markdown
@@ -17,13 +17,13 @@ There are several ways to send a HUP signal to the Puppet Server process, but th
 
     kill -HUP `pgrep -f puppet-server`
 
-Starting in version 2.7.0, you can also reload Puppet Server by running the "reload" action via the operating system's service framework.  This is analogous to sending a hangup signal but with the benefit of having the "reload" command pause until the server has been completely reloaded, similar to how the "restart" command pauses until the service process has been fully restarted.  Advantages to using the "reload" action as opposed to just sending a "HUP" signal include:
+Starting in version 2.7.0, you can also reload Puppet Server by running the "reload" action via the operating system's service framework. This is analogous to sending a hangup signal but with the benefit of having the "reload" command pause until the server has been completely reloaded, similar to how the "restart" command pauses until the service process has been fully restarted. Advantages to using the "reload" action as opposed to just sending a HUP signal include:
 
-1) Unlike with the "HUP signal" approach, you do not have to determine the process ID of the puppetserver process to be reloaded.
+1.  Unlike with the HUP signal approach, you do not have to determine the process ID of the puppetserver process to be reloaded.
 
-2) When using the "HUP signal" with an automated script (or Puppet code), it is possible that any additional commands in the script might behave improperly if performed while the server is still reloading.  With the "reload" command, though, the server should be up and using its latest configuration before any subsequent script commands are performed.
+2.  When using the HUP signal with an automated script (or Puppet code), it is possible that any additional commands in the script might behave improperly if performed while the server is still reloading. With the "reload" command, though, the server should be up and using its latest configuration before any subsequent script commands are performed.
 
-3) Even if the server fails to reload and shuts down - for example, due to a configuration error - the `kill -HUP` command might still return a 0 (success) exit code.  With the "reload" command, however, any configuration change which causes the server to shut down will produce a non-0 (failure) exit code.  The "reload" command, therefore, would allow you to more reliably determine if the server failed to reload properly.
+3.  Even if the server fails to reload and shuts down --- for example, due to a configuration error --- the `kill -HUP` command might still return a 0 (success) exit code. With the "reload" command, however, any configuration change which causes the server to shut down will produce a non-0 (failure) exit code. The "reload" command, therefore, would allow you to more reliably determine if the server failed to reload properly.
 
 Use the following commands to perform the "reload" action for Puppet Server.
 

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export PUPPETSERVER_HEAP_SIZE=6G
+export PUPPETSERVER_HEAP_SIZE=5G
 
 echo "Using heap size: $PUPPETSERVER_HEAP_SIZE"
 echo "Total memory available: $(grep MemTotal /proc/meminfo | awk '{print $2}')"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "2.7.0-master-SNAPSHOT")
+(def ps-version "2.7.1-master-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
    * stable:
      (docs) Add Server 2.7 release notes.
      (docs) Add to aux nav.
      (docs) Add product.conf docs, note in configuration.markdown
      (MAINT) Bump to 2.7.1-stable-SNAPSHOT
      (MAINT) Drop heap size for Travis testing to 5 GB
      (MAINT) Bump to 2.7.0 for release

    Conflicts:
     - project.clj: stable is using an older version of jruby-utils,
       0.4.0.  Kept the newer version, 0.4.1, already on master.
       Also changed ps-version in the project.clj file to
       '2.7.1-master-SNAPSHOT'.