### PR TITLE
Correcting comments to use HTTPS rather than HTTP

### DIFF
--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -53,12 +53,12 @@ jruby-puppet: {
     #use-legacy-auth-conf: false
 }
 
-# settings related to HTTP client requests made by Puppet Server
+# settings related to HTTPS client requests made by Puppet Server
 http-client: {
-    # A list of acceptable protocols for making HTTP requests
+    # A list of acceptable protocols for making HTTPS requests
     #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]
 
-    # A list of acceptable cipher suites for making HTTP requests
+    # A list of acceptable cipher suites for making HTTPS requests
     #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,
     #                TLS_RSA_WITH_AES_256_CBC_SHA,
     #                TLS_RSA_WITH_AES_128_CBC_SHA256,


### PR DESCRIPTION
Puppet clients use HTTPS rather than HTTP, fixing comments.