### PR TITLE
(MAINT) Adjust collect_data helper to use journal for Debian 8

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -153,6 +153,10 @@ module PuppetServerExtensions
       if version.to_i >= 7
         use_journalctl = true
       end
+    when /^debian$/
+      if version.to_i >= 8
+        use_journalctl = true
+      end
     when /^ubuntu$/
       if version.to_i >= 15
         use_journalctl = true


### PR DESCRIPTION
Previously, the `puppet_server_collect_data` helper would, for Debian 8,
try to get stdout/stderr puppetserver log data from the
puppetserver-daemon.log file.  With the recent EZBake bump to 1.1.4,
Debian 8 now uses systemd.  For systemd-based packages, stdout/stderr
log data is directed to the system journal rather than the
puppetserver-daemon.log file.  This causes the helper to fail on Debian
8 when it tries to get the non-existent puppetserver-daemon.log file.

This commit changes the `puppet_server_collect_data` helper to get
stdout/stderr puppetserver log data from the journal instead of the
puppetserver-daemon.log file.