### PR TITLE
(MAINT) Skip agent_run_before_ssl_files_inited test on PE

### DIFF
--- a/acceptance/suites/tests/00_smoke/master_starts_if_agent_run_before_ssl_files_inited.rb
+++ b/acceptance/suites/tests/00_smoke/master_starts_if_agent_run_before_ssl_files_inited.rb
@@ -1,5 +1,9 @@
 test_name "Master can startup even if agent run before ssl files inited"
 
+skip_test 'Skipping for PE since it pre-configures a CRL file and Puppet ' \
+  'Server does not yet update it at startup - SERVER-346 and SERVER-911' \
+  if options[:type] == 'pe'
+
 puppetservice=options['puppetservice']
 ssldir = master.puppet['ssldir']
 backup_ssldir = master.tmpdir("agent_run_before_master_init_ssldir_backup")


### PR DESCRIPTION
Previously, the `master_starts_if_agent_run_before_ssl_files_inited`
acceptance test was configured to run both for OSS and PE Puppet Server.
The test nukes the ssl directory so that an agent run can reconfigure
just the public and private key before the server is started up.  For
PE, the `ssl_crl_path` is configured at installation time.  The absence
of the CRL file after the test nukes it causes the server to fail to
startup.  Work to be done for SERVER-346 and SERVER-911 would allow for
the CRL file to properly be replaced at startup time during this
scenario.  Since that work has not yet been done, though, this commit
just skips the test when run under PE for now.