### PR TITLE
(SERVER-1629) Bump beaker gem dependency to custom 3.3.0+reload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.50.0')
+  gem 'beaker', :git => 'https://github.com/camlow325/beaker', :ref => '3a9f3c'
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
   gem 'uuidtools'


### PR DESCRIPTION
This commit bumps the beaker gem dependency in Puppet Server to a custom
version of beaker which is based on 3.3.0 but adds on support for
restarting the service via a `reload` action, when possible.