### PR TITLE
(MAINT) Remove 'test/unit/assertions' requires from subcommand tests

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
@@ -1,4 +1,3 @@
-require 'test/unit/assertions'
 require 'json'
 
 test_name "Puppetserver subcommand consolidated ENV handling tests."

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -1,4 +1,3 @@
-require 'test/unit/assertions'
 require 'puppetserver/acceptance/gem_utils'
 
 test_name "Puppetserver 'gem' subcommand tests."

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
@@ -1,5 +1,3 @@
-require 'test/unit/assertions'
-
 test_name "Puppetserver 'irb' subcommand tests."
 
 # --------------------------------------------------------------------------

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
@@ -1,5 +1,3 @@
-require 'test/unit/assertions'
-
 test_name "Puppetserver 'ruby' subcommand tests."
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Previously, many of the subcommand acceptance tests explicitly required
the 'test/unit/assertions' path.  When running under Ruby 2.3.1 with
only the minitest gem (and not the test-unit gem) installed, this
path does not exist.  This causes the require and, therefore, the tests
to fail.

The minitest gem is pulled in by the beaker gem and defines the
assert_* functions that the tests use.  Rather than either adding the
'test-unit' gem to the Gemfile or changing the tests to require a valid
path in minitest instead, this commit just removes the
'test/unit/assertions' requires since the path should have already been
loaded when running under beaker anyway.  No other tests include require
statements to locate the assert_* functions, so this commit allows the
subcommand tests to follow the same pattern.