### PR TITLE
(SERVER-1644) Use JAVA_ARGS_CLI env var for Java args in subcommands

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -84,3 +84,9 @@ end
 
 step "Verify that gem env operates"
 on(master, "#{cli} gem env", :acceptable_exit_codes => [0])
+
+step "Verify that Java cli args passed through to gem command"
+on(master, "JAVA_ARGS_CLI=-Djruby.cli.version=true #{cli} gem help") do
+  assert_match(/jruby \d\.\d\.\d.*$/, stdout,
+               'jruby version not included in gem command output')
+end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
@@ -28,3 +28,9 @@ on(master, cmd) do
   assert_match(/GOOD:/, stdout)
   assert_no_match(/error/i, stdout)
 end
+
+step "Verify that Java cli args passed through to irb command"
+on(master, "echo '' | JAVA_ARGS_CLI=-Djruby.cli.version=true #{cli} irb -f") do
+  assert_match(/jruby \d\.\d\.\d.*$/, stdout,
+               'jruby version not included in irb command output')
+end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
@@ -27,3 +27,9 @@ on(master, cmd) do
   assert_match(/GOOD:/, stdout)
   assert_no_match(/error/i, stdout)
 end
+
+step "Verify that Java cli args passed through to ruby command"
+on(master, "JAVA_ARGS_CLI=-Djruby.cli.version=true #{cli} ruby -e ''") do
+  assert_match(/jruby \d\.\d\.\d.*$/, stdout,
+               'jruby version not included in ruby command output')
+end

--- a/documentation/subcommands.markdown
+++ b/documentation/subcommands.markdown
@@ -56,6 +56,22 @@ Example:
 $ JAVA_ARGS_CLI=-Xmx8g puppetserver gem install pry --no-ri --no-rdoc
 ~~~
 
+If you prefer to have the `JAVA_ARGS_CLI` option persist for multiple command
+executions, you could set the value in the `/etc/sysconfig/puppetserver` or
+`/etc/default/puppetserver` file, depending upon your OS distribution:
+
+~~~ini
+JAVA_ARGS_CLI=-Xmx8g
+~~~
+
+With the value specified in the sysconfig or defaults file, subsequent commands
+would use the `JAVA_ARGS_CLI` variable automatically:
+
+~~~sh
+$ puppetserver gem install pry --no-ri --no-rdoc
+// Would run 'gem' with a maximum Java heap of 8g
+~~~
+
 For more information, see [Puppet Server and Gems](./gems.markdown).
 
 ## ruby
@@ -84,6 +100,22 @@ Example:
 
 ~~~sh
 $ JAVA_ARGS_CLI=-Xmx8g puppetserver ruby -e "require 'puppet'; puts Puppet[:certname]"
+~~~
+
+If you prefer to have the `JAVA_ARGS_CLI` option persist for multiple command
+executions, you could set the value in the `/etc/sysconfig/puppetserver` or
+`/etc/default/puppetserver` file, depending upon your OS distribution:
+
+~~~ini
+JAVA_ARGS_CLI=-Xmx8g
+~~~
+
+With the value specified in the sysconfig or defaults file, subsequent commands
+would use the `JAVA_ARGS_CLI` variable automatically:
+
+~~~sh
+$ puppetserver ruby -e "require 'puppet'; puts Puppet[:certname]"
+// Would run 'ruby' with a maximum Java heap of 8g
 ~~~
 
 ## irb
@@ -119,6 +151,22 @@ Example:
 
 ~~~sh
 $ JAVA_ARGS_CLI=-Xmx8g puppetserver irb
+~~~
+
+If you prefer to have the `JAVA_ARGS_CLI` option persist for multiple command
+executions, you could set the value in the `/etc/sysconfig/puppetserver` or
+`/etc/default/puppetserver` file, depending upon your OS distribution:
+
+~~~ini
+JAVA_ARGS_CLI=-Xmx8g
+~~~
+
+With the value specified in the sysconfig or defaults file, subsequent commands
+would use the `JAVA_ARGS_CLI` variable automatically:
+
+~~~sh
+$ puppetserver irb
+// Would run 'irb' with a maximum Java heap of 8g
 ~~~
 
 ## foreground

--- a/documentation/subcommands.markdown
+++ b/documentation/subcommands.markdown
@@ -47,6 +47,15 @@ $ puppetserver gem install pry --no-ri --no-rdoc
 $ lein gem -c /path/to/puppetserver.conf -- install pry --no-ri --no-rdoc
 ~~~
 
+If needed, you also can use the `JAVA_ARGS_CLI` environment variable to pass
+along custom arguments to the Java process that the `gem` command is run within.
+ 
+Example:
+
+~~~sh
+$ JAVA_ARGS_CLI=-Xmx8g puppetserver gem install pry --no-ri --no-rdoc
+~~~
+
 For more information, see [Puppet Server and Gems](./gems.markdown).
 
 ## ruby
@@ -66,6 +75,15 @@ $ puppetserver ruby -e "require 'puppet'; puts Puppet[:certname]"
 
 ~~~sh
 $ lein ruby -c /path/to/puppetserver.conf -- -e "require 'puppet'; puts Puppet[:certname]"
+~~~
+
+If needed, you also can use the `JAVA_ARGS_CLI` environment variable to pass
+along custom arguments to the Java process that the `ruby` command is run within.
+ 
+Example:
+
+~~~sh
+$ JAVA_ARGS_CLI=-Xmx8g puppetserver ruby -e "require 'puppet'; puts Puppet[:certname]"
 ~~~
 
 ## irb
@@ -92,6 +110,15 @@ centos6-64.localdomain
 ~~~sh
 $ lein irb -c /path/to/puppetserver.conf -- --version
 irb 0.9.6(09/06/30)
+~~~
+
+If needed, you also can use the `JAVA_ARGS_CLI` environment variable to pass
+along custom arguments to the Java process that the `irb` command is run within.
+ 
+Example:
+
+~~~sh
+$ JAVA_ARGS_CLI=-Xmx8g puppetserver irb
 ~~~
 
 ## foreground

--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -2,6 +2,7 @@
 
 umask 0022
 
-"${JAVA_BIN}" $JAVA_ARGS -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
+"${JAVA_BIN}" $JAVA_ARGS_CLI \
+    -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/irb.erb
+++ b/resources/ext/cli/irb.erb
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-"${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
+"${JAVA_BIN}" $JAVA_ARGS_CLI \
+    -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.irb \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/ruby.erb
+++ b/resources/ext/cli/ruby.erb
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-"${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
+"${JAVA_BIN}" $JAVA_ARGS_CLI \
+    -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.ruby \
     --config "${CONFIG}" -- "$@"


### PR DESCRIPTION
Previously, the value of the JAVA_ARGS environment variable, as a result
of work done for the Puppet Server 2.7.0 release, was passed along as
arguments to the Java process running the `gem` subcommand.  This was
problematic for cases where the JAVA_ARGS had been specifically tuned
with arguments for use when running the puppetserver service but
inappropriate for the `gem` command.  For example, Java args that enable
debug logging when included in the `gem` command could break the ability
to perform basic `gem` installs.

This commit changes the `gem` subcommand to source custom Java arguments
from a separate environment variable, `JAVA_ARGS_CLI`.  This commit also
adds the use of the `JAVA_ARGS_CLI` args to the ruby and irb subcommands,
which previously provided no mechanism for specifying custom Java args.