### PR TITLE
(MAINT) Bump version to 2.7.1 for release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "2.7.1-stable-SNAPSHOT")
+(def ps-version "2.7.1")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
DO NOT MERGE THIS YET.

This is the release commit for when we are ready to bump the version to 2.7.1.  Waiting for a green CI run before we merge, and I'll update the PR accordingly when we're ready.