### PR TITLE
(MAINT) bump to 2.7.2 snapshot after release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "2.7.1")
+(def ps-version "2.7.2-stable-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
DO NOT MERGE!

This should go in after our packages are all built and tested for the 2.7.1 release.