### PR TITLE
(SERVER-377) Add tests for proxy-related environment variables

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
@@ -3,6 +3,8 @@ require 'json'
 
 test_name "Puppetserver subcommand consolidated ENV handling tests."
 
+proxy_env_vars = "HTTP_PROXY=foo http_proxy=foo HTTPS_PROXY=foo https_proxy=foo NO_PROXY=foo no_proxy=foo"
+
 step "ruby: Check that PATH, HOME, GEM_HOME JARS_REQUIRE and JARS_NO_REQUIRE are present"
 on(master, "puppetserver ruby -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'") do
   env = JSON.parse(stdout)
@@ -13,6 +15,18 @@ on(master, "puppetserver ruby -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'
   assert(env['JARS_NO_REQUIRE'], "JARS_NO_REQUIRE missing")
 end
 
+step "ruby: Check that proxy env-variables are present"
+on(master, "#{proxy_env_vars} puppetserver ruby -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'") do
+  env = JSON.parse(stdout)
+  assert(env['HTTP_PROXY'], "HTTP_PROXY is missing")
+  assert(env['http_proxy'], "http_proxy is missing")
+  assert(env['HTTPS_PROXY'], "HTTPS_PROXY is missing")
+  assert(env['https_proxy'], "https_proxy is missing")
+  assert(env['NO_PROXY'], "NO_PROXY is missing")
+  assert(env['no_proxy'], "no_proxy is missing")
+  assert_nil(env['RANDOM_VARIABLE'], "RANDOM_VARIABLE is present and should not be")
+end
+
 step "irb: Check that PATH, HOME, GEM_HOME JARS_REQUIRE and JARS_NO_REQUIRE are present"
 on(master, "echo 'puts JSON.pretty_generate(ENV.to_hash)' | puppetserver irb -f -rjson") do
   assert_match(/\bPATH\b/, stdout, "PATH missing")
@@ -20,4 +34,14 @@ on(master, "echo 'puts JSON.pretty_generate(ENV.to_hash)' | puppetserver irb -f 
   assert_match(/\bGEM_HOME\b/, stdout, "GEM_HOME missing")
   assert_match(/\bJARS_REQUIRE\b/, stdout, "JARS_REQUIRE missing")
   assert_match(/\bJARS_NO_REQUIRE\b/, stdout, "JARS_NO_REQUIRE missing")
+end
+
+step "irb: Check that proxy env-variables are present"
+on(master, "echo 'puts JSON.pretty_generate(ENV.to_hash)' | #{proxy_env_vars} puppetserver irb -f -rjson") do
+  assert_match(/\bHTTP_PROXY\b/, stdout, "HTTP_PROXY missing")
+  assert_match(/\bhttp_proxy\b/, stdout, "http_proxy missing")
+  assert_match(/\bHTTPS_PROXY\b/, stdout, "HTTPS_PROXY missing")
+  assert_match(/\bhttps_proxy\b/, stdout, "https_proxy missing")
+  assert_match(/\bNO_PROXY\b/, stdout, "NO_PROXY missing")
+  assert_match(/\bno_proxy\b/, stdout, "no_proxy missing")
 end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
@@ -18,13 +18,18 @@ end
 step "ruby: Check that proxy env-variables are present"
 on(master, "#{proxy_env_vars} puppetserver ruby -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'") do
   env = JSON.parse(stdout)
-  assert(env['HTTP_PROXY'], "HTTP_PROXY is missing")
-  assert(env['http_proxy'], "http_proxy is missing")
-  assert(env['HTTPS_PROXY'], "HTTPS_PROXY is missing")
-  assert(env['https_proxy'], "https_proxy is missing")
-  assert(env['NO_PROXY'], "NO_PROXY is missing")
-  assert(env['no_proxy'], "no_proxy is missing")
-  assert_nil(env['RANDOM_VARIABLE'], "RANDOM_VARIABLE is present and should not be")
+  assert_equal(env['HTTP_PROXY'], "foo",
+               "HTTP_PROXY is missing or has wrong value: '#{env['HTTP_PROXY']}'")
+  assert_equal(env['http_proxy'], "foo",
+               "http_proxy is missing or has wrong value: '#{env['http_proxy']}'")
+  assert_equal(env['HTTPS_PROXY'], "foo",
+               "HTTPS_PROXY is missing or has wrong value: '#{env['HTTPS_PROXY']}'")
+  assert_equal(env['https_proxy'], "foo",
+               "https_proxy is missing or has wrong value: '#{env['https_proxy']}'")
+  assert_equal(env['NO_PROXY'], "foo",
+               "NO_PROXY is missing or has wrong value: '#{env['NO_PROXY']}'")
+  assert_equal(env['no_proxy'], "foo",
+               "no_proxy is missing or has wrong value: '#{env['no_proxy']}'")
 end
 
 step "irb: Check that PATH, HOME, GEM_HOME JARS_REQUIRE and JARS_NO_REQUIRE are present"
@@ -38,10 +43,10 @@ end
 
 step "irb: Check that proxy env-variables are present"
 on(master, "echo 'puts JSON.pretty_generate(ENV.to_hash)' | #{proxy_env_vars} puppetserver irb -f -rjson") do
-  assert_match(/\bHTTP_PROXY\b/, stdout, "HTTP_PROXY missing")
-  assert_match(/\bhttp_proxy\b/, stdout, "http_proxy missing")
-  assert_match(/\bHTTPS_PROXY\b/, stdout, "HTTPS_PROXY missing")
-  assert_match(/\bhttps_proxy\b/, stdout, "https_proxy missing")
-  assert_match(/\bNO_PROXY\b/, stdout, "NO_PROXY missing")
-  assert_match(/\bno_proxy\b/, stdout, "no_proxy missing")
+  assert_match(/\bHTTP_PROXY\b\W\W\s\W\bfoo\b/, stdout, "HTTP_PROXY missing or has wrong value")
+  assert_match(/\bhttp_proxy\b\W\W\s\W\bfoo\b/, stdout, "http_proxy missing or has wrong value")
+  assert_match(/\bHTTPS_PROXY\b\W\W\s\W\bfoo\b/, stdout, "HTTPS_PROXY missing or has wrong value")
+  assert_match(/\bhttps_proxy\b\W\W\s\W\bfoo\b/, stdout, "https_proxy missing or has wrong value")
+  assert_match(/\bNO_PROXY\b\W\W\s\W\bfoo\b/, stdout, "NO_PROXY missing or has wrong value")
+  assert_match(/\bno_proxy\b\W\W\s\W\bfoo\b/, stdout, "no_proxy missing or has wrong value")
 end

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "0.4.2-SNAPSHOT"]
+                 [puppetlabs/jruby-utils "0.5.0"]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-scheduler]

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "0.4.1"]
+                 [puppetlabs/jruby-utils "0.4.2-SNAPSHOT"]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-scheduler]

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -28,6 +28,7 @@
             [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-utils]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
             [puppetlabs.trapperkeeper.config :as tk-config])
   (:import (org.jruby RubyInstanceConfig$CompileMode CompatVersion)))
@@ -450,12 +451,14 @@
             jruby-scripting-container (:scripting-container jruby-instance)
             jruby-env (.runScriptlet jruby-scripting-container "ENV")]
         (try
-         ;; Note that if this test is run in an environment where the
-         ;; variables HTTP_PROXY, HTTPS_PROXY, NO_PROXY, or their lowercase
-         ;; variants are set, this will fail.
+         ;; Note that other environment variables are allowed through
+         ;; (HTTP_PROXY, HTTPS_PROXY, NO_PROXY, or their lowercase
+         ;; variants) but are not expected to be set in most environments.
+         ;; However, in order to make this test more robust, these variables
+         ;; are always filtered out.
           (is (= #{"HOME" "PATH" "GEM_HOME" "GEM_PATH"
                    "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY" "FOO"}
-                 (set (keys jruby-env))))
+                 (set (remove (set jruby-core/proxy-vars-allowed-list) (keys jruby-env)))))
           (is (= (.get jruby-env "FOO") (System/getenv "HOME")))
           (finally
             (jruby-testutils/return-instance jruby-service jruby-instance :test)))))))

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -450,6 +450,9 @@
             jruby-scripting-container (:scripting-container jruby-instance)
             jruby-env (.runScriptlet jruby-scripting-container "ENV")]
         (try
+         ;; Note that if this test is run in an environment where the
+         ;; variables HTTP_PROXY, HTTPS_PROXY, NO_PROXY, or their lowercase
+         ;; variants are set, this will fail.
           (is (= #{"HOME" "PATH" "GEM_HOME" "GEM_PATH"
                    "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY" "FOO"}
                  (set (keys jruby-env))))


### PR DESCRIPTION
Changes to jruby-utils make it so that the environment variables `HTTP_PROXY`,
`http_proxy`, `HTTPS_PROXY`, `https_proxy`, `NO_PROXY`, and `no_proxy` are now
passed through to the jruby scripting container, so that gems can be installed
in scenarios where a proxy is set.

This commit adds acceptance tests ensuring that when set those variables are
available when running `puppetserver ruby` and `puppetserver irb` (and thus
will also be available when running `puppetserver gem`).


Note that this cannot be merged until https://github.com/puppetlabs/jruby-utils/pull/32 has been merged and a new version of jruby-utils released.