### PR TITLE
(MAINT) Pin tests to puppet-agent 1.8.1

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -23,7 +23,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "1.8.0.48.g549d028",
+                         "1.8.1",
                          :string) ||
                          get_puppet_version
 

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -32,7 +32,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "549d0283c85bc100205e9c5de251219db64ee698",
+                         "1.8.1",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:


### PR DESCRIPTION
CI has begun failing because the sha we were previously pinned to no longer
has artifacts on the builds server. 1.8.1 contains the changes we needed from the old sha