### PR TITLE
(MAINT) merge up from stable

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -23,7 +23,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "1.8.0.196.g117323b",
+                         "1.8.1",
                          :string) ||
                          get_puppet_version
 
@@ -32,7 +32,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "117323bb73e41261fb98ce957f79804e4a27dc6b",
+                         "1.8.1",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:

--- a/documentation/gems.markdown
+++ b/documentation/gems.markdown
@@ -4,15 +4,23 @@ title: "Puppet Server: Using Ruby Gems"
 canonical: "/puppetserver/latest/gems.html"
 ---
 
-
 If you have server-side Ruby code in your modules, Puppet Server will run it
 via JRuby. Generally speaking, this only affects custom parser functions,
 types, and report processors. For the vast majority of cases this shouldn't
 pose any problems because JRuby is highly compatible with vanilla Ruby.
 
-Puppet server will not load gems from user specified `GEM_HOME` and `GEM_PATH`
+Puppet Server will not load gems from user specified `GEM_HOME` and `GEM_PATH`
 environment variables because `puppetserver` unsets `GEM_PATH` and manages
 `GEM_HOME`.
+
+> **Note:** Starting with Puppet Server 2.7.1, you can set custom Java
+> arguments for the `puppetserver gem` command via the `JAVA_ARGS_CLI`
+> environment variable, either temporarily on the command line or persistently
+> by adding it to the sysconfig/default file. The `JAVA_ARGS_CLI` environment
+> variable also controls the arguments used when running the `puppetserver ruby`
+> and `puppetserver irb` [subcommands](./subcommands.markdown). See the
+> [Server 2.7.1 release notes](https://docs.puppet.com/puppetserver/2.7.1/release_notes.html)
+> for details.
 
 ### Gems with packaged versions of Puppet Server
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -12,7 +12,23 @@ canonical: "/puppetserver/latest/release_notes.html"
 
 For release notes on versions of Puppet Server prior to Puppet Server 2.5, see [docs.puppet.com](https://docs.puppet.com/puppetserver/2.4/release_notes.html).
 
-## Puppet Server 2.7
+## Puppet Server 2.7.1
+
+Released November 21, 2016.
+
+This is a bug-fix release of Puppet Server.
+
+> **Warning:** If you're upgrading from Puppet Server 2.4 or earlier and have modified `bootstrap.cfg`, `/etc/sysconfig/puppetserver`, or `/etc/default/puppetserver`, see the [Puppet Server 2.5 release notes first](#potential-breaking-issues-when-upgrading-with-a-modified-bootstrapcfg) **before upgrading** for instructions on avoiding potential failures.
+
+### Bug Fix: Set `puppetserver gem` Java arguments separately from the Server service
+
+In Puppet Server 2.7.0, the `JAVA_ARGS` from Puppet Server's sysconfig/default file (typically located at `/etc/sysconfig/puppetserver` or `/etc/defaults/puppetserver`) were passed along to the Java process started when running the [`puppetserver gem`](./gems.markdown) command. This could lead to arguments that are intended only for use when running the full puppetserver service --- for example, debug arguments or large memory heap settings --- being used when running `gem` commands, which could cause the `gem` commands to fail.
+
+In Puppet Server 2.7.1, you can set custom arguments to be passed into the Java process for the `gem` command via the new `JAVA_ARGS_CLI` environment variable, either temporarily on the command line or persistently by adding it to the sysconfig/default file. The `JAVA_ARGS_CLI` environment variable also controls the arguments used when running the `puppetserver ruby` and `puppetserver irb` [subcommands](./subcommands.markdown).
+
+-   [SERVER-1644](https://tickets.puppetlabs.com/browse/SERVER-1644)
+
+## Puppet Server 2.7.0
 
 Released November 8, 2016.
 

--- a/documentation/services_master_puppetserver.markdown
+++ b/documentation/services_master_puppetserver.markdown
@@ -89,6 +89,8 @@ Since we don't use the system Ruby, you can't use the system `gem` command to in
 
 Additionally, if you need to test or debug code that will be used by Puppet Server, we include `puppetserver ruby` and `puppetserver irb` commands that will execute Ruby code in a JRuby environment identical to what the Puppet master application uses.
 
+> **Note:** In Puppet Server 2.7.1, you can set custom arguments to be passed into the Java process for the `puppetserver ruby` command via the new `JAVA_ARGS_CLI` environment variable, either temporarily on the command line or persistently by adding it to the sysconfig/default file (typically located at `/etc/sysconfig/puppetserver` or `/etc/defaults/puppetserver`). The `JAVA_ARGS_CLI` environment variable also controls the arguments used when running the `puppetserver gem` and `puppetserver irb` [subcommands](./subcommands.markdown). See the [Server 2.7.1 release notes](https://docs.puppet.com/puppetserver/2.7.1/release_notes.html) for details.
+
 To handle parallel requests from agent nodes, Puppet Server maintains several separate JRuby interpreters, all independently running Puppet's application code, and distributes agent requests among them. Today, agent requests are distributed more or less randomly, without regard to their environment; this may change in the future.
 
 You can configure the JRuby interpreters in the `jruby-puppet` section of [the `puppetserver.conf` file.](./config_file_puppetserver.markdown)


### PR DESCRIPTION
Conflicts:
  `acceptance/lib/helper.rb` - Updated puppet-agent versions to 1.8.1
  `ruby/puppet` - updated puppet version to sha for 4.8.1