### PR TITLE
(SERVER-1670) Bump lein-ezbake to fix dependency issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -143,7 +143,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.1.3"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.1.5"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]]}


### PR DESCRIPTION
This should pull in the resolution to SERVER-1670 (autorequires causing system ruby to be an rpm dependency).