### PR TITLE
(SERVER-1593) Update gettext-setup gem to 0.8

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -3,5 +3,5 @@ hocon 1.1.3
 text 1.3.1
 locale 2.1.2
 gettext 3.2.2
-gettext-setup 0.6
+gettext-setup 0.8
 fast_gettext 1.1.0


### PR DESCRIPTION
This bumps the gettext-setup gem version to 0.8, which allows the gem
user to specify which file format to expect for translation files.