### PR TITLE
(SERVER-1629) Bump beaker pin to 3.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.50.0')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.5.0')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
   gem 'uuidtools'


### PR DESCRIPTION
This commit bumps the beaker pin for puppetserver acceptance testing to
~>3.5.0.  This allows us to utilize the 'reload' capability in
puppetserver for performance improvements when running acceptance tests.