### PR TITLE
Merge branch 'stable' into master at 8564f98

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', :git => 'https://github.com/camlow325/beaker', :ref => '3a9f3c'
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.5.0')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
   gem 'uuidtools'

--- a/project.clj
+++ b/project.clj
@@ -143,7 +143,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.1.4"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.1.5"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]]}

--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -3,5 +3,5 @@ hocon 1.1.3
 text 1.3.1
 locale 2.1.2
 gettext 3.2.2
-gettext-setup 0.6
+gettext-setup 0.8
 fast_gettext 1.1.0


### PR DESCRIPTION
    * stable:
      (SERVER-1593) Update gettext-setup gem to 0.8
      (SERVER-1629) Bump beaker pin to 3.5.0
      (SERVER-1670) Bump lein-ezbake to fix dependency issues

    Conflicts:
    - project.clj - Kept most dependency versions already on master since
      they were newer than the ones on stable.  Only exception was bumping
      to the newer lein-ezbake from stable (1.1.5) vs. the one previously in
      master (1.1.4).