### PR TITLE
(maint) Link project_data.yaml to build_data.yaml

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -1,0 +1,1 @@
+build_defaults.yaml


### PR DESCRIPTION
Our ship automation that links in with the packaging repo requires both
project_data.yaml and build_data.yaml to exist in the ext directory. It
doesn't matter if these files have duplicate content, as long as they're
both there. This commit simply links project_data.yaml to
build_data.yaml so that the automation can execute successfully.