### PR TITLE
(SERVER-1696) Add new environment_modules v3 route

### DIFF
--- a/dev-resources/puppetlabs/services/master/environment_modules_int_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/environment_modules_int_test/puppet.conf
@@ -1,0 +1,5 @@
+[main]
+
+certname = localhost
+environmentpath = $confdir/environments
+environment_timeout = unlimited

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -41,6 +41,7 @@ Puppet Server is the next-generation application for managing Puppet agents.
     * [JRuby pool](./admin-api/v1/jruby-pool.markdown)
 * **Server-specific Puppet API endpoints**
     * [Environment classes](./puppet-api/v3/environment_classes.markdown)
+    * [Environment modules](./puppet-api/v3/environment_modules.markdown)
     * [Static file content](./puppet-api/v3/static_file_content.markdown)
 * **Status API endpoints**
     * [Status services](./status-api/v1/services.markdown)

--- a/documentation/puppet-api/v3/environment_modules.json
+++ b/documentation/puppet-api/v3/environment_modules.json
@@ -1,0 +1,33 @@
+{
+  "$schema":     "http://json-schema.org/draft-04/schema#",
+  "title":       "Environment Modules",
+  "description": "Information about the modules in a Puppet code environment",
+  "type":        "object",
+  "properties": {
+    "modules": {
+      "description": "The array of modules which exist in an environment.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the puppet module",
+            "type": "string"
+          },
+          "version": {
+            "description": "The version of the puppet module",
+            "type": "string"
+          }
+        },
+        "required": ["name", "version"],
+        "additionalProperties": false
+      }
+    },
+    "name": {
+      "description": "Name of the environment",
+      "type": "string"
+    }
+  },
+  "required": ["modules", "name"],
+  "additionalProperties": false
+}

--- a/documentation/puppet-api/v3/environment_modules.markdown
+++ b/documentation/puppet-api/v3/environment_modules.markdown
@@ -1,0 +1,127 @@
+---
+layout: default
+title: "Puppet Server: Puppet API: Environment Modules"
+canonical: "/puppetserver/latest/puppet-api/v3/environment_modules.html"
+---
+
+[deprecated WEBrick Puppet master]: https://docs.puppet.com/puppet/latest/reference/services_master_webrick.html
+[`auth.conf`]: ../../config_file_auth.markdown
+[`puppetserver.conf`]: ../../config_file_puppetserver.markdown
+
+The environment modules API will return information about what modules are
+installed for the requested environment.
+
+This endpoint is available only when the Puppet master is running Puppet Server, not
+on Ruby Puppet masters, such as the [deprecated WEBrick Puppet master][]. It also ignores
+the Ruby-based Puppet master's authorization methods and configuration. See the
+[Authorization section](#authorization) for more information.
+
+## `GET /puppet/v3/environment_modules?environment=:environment`
+
+Making a request with no query parameters is not supported and returns an HTTP 400 (Bad
+Request) response.
+
+### Supported HTTP Methods
+
+GET
+
+### Supported Formats
+
+JSON
+
+### Query Parameters
+
+Provide one parameter to the GET request:
+
+* `environment`: Request information about modules pertaining to the specified
+environment only.
+
+### Responses
+
+#### GET request with results
+
+```
+GET /puppet/v3/environment_modules?environment=env
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "modules": [
+        {
+            "name": "puppetlabs/ntp",
+            "version": "6.0.0"
+        },
+        {
+            "name": "puppetlabs/stdlib",
+            "version": "4.14.0"
+        }
+    ],
+    "name": "env"
+}
+```
+
+#### Environment does not exist
+
+If you send a request with an environment parameter that doesn't correspond to the name of a
+directory environment on the server, the server returns an HTTP 404 (Not Found) error:
+
+```
+GET /puppet/v3/environment_modules?environment=doesnotexist
+
+HTTP/1.1 404 Not Found
+
+Could not find environment 'doesnotexist'
+```
+
+#### No environment given
+
+```
+GET /puppet/v3/environment_modules
+
+HTTP/1.1 400 Bad Request
+
+An environment parameter must be specified
+```
+
+#### Environment parameter specified with no value
+
+```
+GET /puppet/v3/environment_modules?environment=
+
+HTTP/1.1 400 Bad Request
+
+The environment must be purely alphanumeric, not ''
+```
+
+#### Environment includes non-alphanumeric characters
+
+If the environment parameter in your request includes any characters that are
+not `A-Z`, `a-z`, `0-9`, or `_` (underscore), the server returns an HTTP 400 (Bad Request) error:
+
+```
+GET /puppet/v3/environment_modules?environment=bog|us
+
+HTTP/1.1 400 Bad Request
+
+The environment must be purely alphanumeric, not 'bog|us'
+```
+
+### Schema
+
+An environment modules response body conforms to the
+[environment modules schema](./environment_modules.json).
+
+### Authorization
+
+Unlike other Puppet master service-based API endpoints, the environment modules API is
+provided exclusively by Puppet Server. All requests made to the environment
+modules API are authorized using the Trapperkeeper-based [`auth.conf`][] feature
+introduced in Puppet Server 2.2.0, and ignores the older Ruby-based authorization process
+and configuration. The value of the `use-legacy-auth-conf` setting in the `jruby-puppet`
+configuration section of [`puppetserver.conf`][] is ignored for requests
+to the environment modules API, because the Ruby-based authorization process is not equipped to
+authorize these requests.
+
+For more information about the Puppet Server authorization process and configuration
+settings, see the [`auth.conf` documentation][`auth.conf`].

--- a/documentation/services_master_puppetserver.markdown
+++ b/documentation/services_master_puppetserver.markdown
@@ -56,6 +56,7 @@ provides some additional APIs that the Rack and WEBrick Puppet masters do not.
 - For docs on the Puppet Server-specific APIs hosted by the master service, see:
 
     - [The `environment_classes` endpoint](./puppet-api/v3/environment_classes.markdown)
+    - [The `environment_modules` endpoint](./puppet-api/v3/environment_modules.markdown)
 
 ### Certificate Authority Service
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -64,6 +64,10 @@
     [this jruby-instance env-name]
     (.getClassInfoForEnvironment jruby-instance env-name))
 
+  (get-environment-module-info
+    [this jruby-instance env-name]
+    (.getModuleInfoForEnvironment jruby-instance env-name))
+
   (get-environment-class-info-tag
    [this env-name]
    (let [environment-class-info (:environment-class-info-tags

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -50,6 +50,10 @@
     'cache-generation-id' value stored in the cache for the environment, the
     cache will remain unchanged as a result of this call.")
 
+  (get-environment-module-info
+    [this jruby-instance env-name]
+    "Get module information for a specific environment")
+
   (flush-jruby-pool!
     [this]
     "Flush all the current JRuby instances and repopulate the pool.")

--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -1,6 +1,7 @@
 package com.puppetlabs.puppetserver;
 
 import java.util.Map;
+import java.util.List;
 
 /**
  *
@@ -16,6 +17,7 @@ import java.util.Map;
  */
 public interface JRubyPuppet {
     Map getClassInfoForEnvironment(String environment);
+    List getModuleInfoForEnvironment(String environment);
     JRubyPuppetResponse handleRequest(Map request);
     Object getSetting(String setting);
     String puppetVersion();

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -70,6 +70,13 @@ class Puppet::Server::Master
     end
   end
 
+  def getModuleInfoForEnvironment(env)
+    environment = @env_loader.get(env)
+    unless environment.nil?
+      self.class.getModules(environment)
+    end
+  end
+
   def getSetting(setting)
     Puppet[setting]
   end
@@ -87,6 +94,20 @@ class Puppet::Server::Master
   end
 
   private
+
+  def self.getModules(env)
+    env.modules.collect do |mod|
+      module_data = {}
+
+      # NOTE: If in the future we want to collect more
+      #       Module settings, this should be more programatic
+      #       rather than getting these settings one by one
+      module_data[:name] = mod.forge_name
+      module_data[:version] = mod.version
+
+      module_data
+    end
+  end
 
   def self.getManifests(env)
     manifests =

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -134,15 +134,34 @@
     module-name :- schema/Str
     pp-name :- schema/Str
     env-name :- schema/Str]
+   (write-pp-file pp-contents module-name pp-name env-name "1.0.0"))
+  ([pp-contents :- schema/Str
+    module-name :- schema/Str
+    pp-name :- schema/Str
+    env-name :- schema/Str
+    module-version :- schema/Str]
    (let [pp-file (fs/file conf-dir
                           "environments"
                           env-name
                           "modules"
                           module-name
                           "manifests"
-                          (str pp-name ".pp"))]
+                          (str pp-name ".pp"))
+         module-dir (fs/file conf-dir
+                             "environments"
+                             env-name
+                             "modules"
+                             module-name)
+         metadata-json {"name" module-name
+                        "version" module-version
+                        "author" "Puppet"
+                        "license" "apache"
+                        "dependencies" []
+                        "source" "https://github.com/puppetlabs"}]
      (fs/mkdirs (fs/parent pp-file))
      (spit pp-file pp-contents)
+     (spit (fs/file module-dir "metadata.json")
+           (json/generate-string metadata-json))
      (.getCanonicalPath pp-file))))
 
 (schema/defn ^:always-validate write-foo-pp-file :- schema/Str

--- a/test/integration/puppetlabs/services/jruby/module_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/module_info_test.clj
@@ -1,0 +1,85 @@
+(ns puppetlabs.services.jruby.module-info-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
+            [puppetlabs.services.jruby.jruby-puppet-service :refer [jruby-puppet-pooled-service]]
+            [puppetlabs.services.puppet-profiler.puppet-profiler-service :refer [puppet-profiler-service]]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
+            [me.raynes.fs :as fs]
+            [cheshire.core :as cheshire]
+            [puppetlabs.puppetserver.testutils :as testutils]
+            [puppetlabs.trapperkeeper.app :as tk-app]
+            [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap]))
+
+(defn gen-modules
+  [[mod-dir manifests]]
+  (let [modules-dir (fs/file mod-dir "modules")]
+    (ks/mkdirs! modules-dir)
+    (doseq [manifest manifests]
+      (let [module-dir (fs/file modules-dir manifest)
+            metadata-json {"name" manifest
+                           "version" "1.0.0"
+                           "author" "Puppet"
+                           "license" "apache"
+                           "dependencies" []
+                           "source" "https://github.com/puppetlabs"}]
+        (ks/mkdirs! (fs/file module-dir))
+        (spit (fs/file module-dir "metadata.json")
+              (cheshire/generate-string metadata-json))))))
+
+(defn create-env
+  [[env-dir manifests]]
+  (testutils/create-env-conf env-dir "")
+  (gen-modules [env-dir manifests]))
+
+(defn roundtrip-via-json
+  [obj]
+  (-> obj
+      (cheshire/generate-string)
+      (cheshire/parse-string)))
+
+(deftest ^:integration module-info-test
+  (testing "module info properly enumerated for"
+    (let [code-dir (ks/temp-dir)
+          conf-dir (ks/temp-dir)
+          config (jruby-testutils/jruby-puppet-tk-config
+                  (jruby-testutils/jruby-puppet-config
+                   {:master-code-dir (.getAbsolutePath code-dir)
+                    :master-conf-dir (.getAbsolutePath conf-dir)}))]
+
+      (tk-bootstrap/with-app-with-config
+       app
+       [jruby-puppet-pooled-service
+        puppet-profiler-service
+        jruby-pool-manager-service]
+       config
+       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+             instance (jruby-testutils/borrow-instance jruby-service :test)
+             jruby-puppet (:jruby-puppet instance)
+             env-registry (:environment-registry instance)
+
+             _ (testutils/create-file (fs/file conf-dir "puppet.conf")
+                                      "[main]\nenvironment_timeout=unlimited\nbasemodulepath=$codedir/modules\n")
+
+             env-dir (fn [env-name]
+                       (fs/file code-dir "environments" env-name))
+             env-1-dir (env-dir "env1")
+             env-1-dir-and-manifests [env-1-dir ["foo" "bar"]]
+             _ (create-env env-1-dir-and-manifests)
+
+             get-module-info-for-env (fn [env]
+                                       (-> (.getModuleInfoForEnvironment jruby-puppet
+                                                                         env)
+                                           (roundtrip-via-json)))]
+         (try
+           (testing "retrieves basic module information about installed modules"
+             (let [env-1-module-info #{{"name" "foo", "version" "1.0.0"}
+                                       {"name" "bar", "version" "1.0.0"}}]
+               (is (= env-1-module-info
+                      (set (get-module-info-for-env "env1")))
+                   "Unexpected info retrieved for 'env1'")))
+
+           (testing "returns nothing if a fake env is given"
+             (is (= nil (get-module-info-for-env "bogus_env"))))
+           (finally
+             (jruby-testutils/return-instance jruby-service instance :test))))))))

--- a/test/integration/puppetlabs/services/master/environment_modules_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_modules_int_test.clj
@@ -1,0 +1,83 @@
+(ns puppetlabs.services.master.environment-modules-int-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils]
+            [puppetlabs.puppetserver.testutils :as testutils]
+            [cheshire.core :as cheshire]
+            [me.raynes.fs :as fs]))
+
+(def test-resources-dir
+  "./dev-resources/puppetlabs/services/master/environment_modules_int_test")
+
+(defn purge-env-dir
+  []
+  (-> testutils/conf-dir
+      (fs/file "environments")
+      fs/delete-dir))
+
+(use-fixtures :once
+              (testutils/with-puppet-conf
+               (fs/file test-resources-dir "puppet.conf")))
+
+(use-fixtures :each
+              (fn [f]
+                (purge-env-dir)
+                (try
+                  (f)
+                  (finally
+                    (purge-env-dir)))))
+
+(defn get-env-modules
+  ([env-name]
+   (try
+       (http-client/get
+        (str "https://localhost:8140/puppet/v3/"
+             "environment_modules?"
+             "environment="
+             env-name)
+        (merge
+         testutils/ssl-request-options
+         {:as :text}))
+       (catch Exception e
+         (throw (Exception. "environment_modules http get failed" e))))))
+
+(defn response->module-info-map
+  [response]
+  (-> response :body cheshire/parse-string))
+
+(deftest ^:integration environment-modules-integration-cache-disabled-test
+  (testing "when environment modules cache is disabled for a module request"
+    (bootstrap/with-puppetserver-running-with-config
+     app
+     (-> {:jruby-puppet {:max-active-instances 1}}
+         (bootstrap/load-dev-config-with-overrides)
+         (ks/dissoc-in [:jruby-puppet
+                        :environment-class-cache-enabled]))
+     (logutils/with-test-logging
+       (let [foo-file (testutils/write-foo-pp-file
+                        "class foo (String $foo_1 = \"is foo\"){}")
+             expected-response {"modules" [{"name" "foo", "version" "1.0.0"}]
+                                "name" "production"}
+             response (get-env-modules "production")
+             emptyenv-response (get-env-modules "")
+             notreal-response (get-env-modules "notreal")]
+         (testing "a successful status code is returned"
+           (is (= 200 (:status response))
+               (str
+                 "unexpected status code for response, response: "
+                 (ks/pprint-to-string response))))
+         (testing "a failed status code is returned"
+           (is (= 404 (:status notreal-response))
+               (str
+                 "unexpected status code for response, response: "
+                 (ks/pprint-to-string response))))
+         (testing "a failed status code is returned"
+           (is (= 400 (:status emptyenv-response))
+               (str
+                 "unexpected status code for response, response: "
+                 (ks/pprint-to-string response))))
+         (testing "the expected response body is returned"
+           (is (= expected-response
+                  (response->module-info-map response)))))))))


### PR DESCRIPTION
This commit adds new endpoint into puppet-server: environment_modules
When a user makes a request against this endpoint with a given
envirnoment, puppet-server will use JRuby to determine what modules are
installed within puppet.