### PR TITLE
(SERVER-1671) Don't log stdout from shell utils

### DIFF
--- a/dev-resources/puppetlabs/puppetserver/shell_utils_test/echo_and_warn
+++ b/dev-resources/puppetlabs/puppetserver/shell_utils_test/echo_and_warn
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+echo "to out:" $@
+echo "to err:" $@ 1>&2


### PR DESCRIPTION
Previously, when ShellUtils was configured to combine both stderr and
stdout from the executed command, the combination of the two was
logged as a warn level message.  With the changes in this commit, none
of the info written to stdout is logged.  Only the info written to
stderr, if applicable, is logged.