### PR TITLE
(MAINT) Allow stderr/out in combined output test to be in either order

### DIFF
--- a/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
@@ -47,7 +47,14 @@
                                                  " baz")
                                             options)]
      (testing "combined info echoed to stdout and stderr captured as output"
-       (is (= "to out: baz\nto err: baz\n" (.getOutput results))))
+       (let [output (.getOutput results)]
+         ;; Allow stdout and stderr messages to come in either order since
+         ;; the order in which they are read from the different stream
+         ;; consuming threads is not reliable.
+         (is (or (= "to out: baz\nto err: baz\n" output)
+                 (= "to err: baz\nto out: baz\n" output))
+             (format "Output produced, '%s', did not match expected output"
+                     output))))
      (testing "only info echoed to stderr captured as error"
        (is (= "to err: baz\n" (.getError results))))
      (testing "only stderr info (and not stdout info) is logged"


### PR DESCRIPTION
Previously, the `combines-stderr-and-stdout-correctly` test expected the
output order in which stderr and stdout was captured to match the order
in which the spawned executable wrote to each stream.  The order in
which the Java process receives content from the streams, however, is
not guaranteed to match the order in which the content was originally
written.  For this reason, the test was changed to allow the content
from the streams to arrive in either order.