### PR TITLE
(MAINT) Bump to clj-parent 0.3.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.3.2"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.3.3"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -84,7 +84,7 @@
                  ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
 
   :plugins [[lein-parent "0.3.1"]
-            [puppetlabs/i18n "0.5.1"]]
+            [puppetlabs/i18n "0.6.0"]]
 
   :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"


### PR DESCRIPTION
This commit bumps the clj-parent version from 0.3.2 to 0.3.3 in order to
pick up the `request-body-max-size` feature in
trapperkeeper-webserver-jetty9 1.7.0.  This commit also updates the
clj-i18n plugin dependency version to 0.6.0 for consistency with the
version of clj-i18n pulled in from the new clj-parent version.