### PR TITLE
(PDB-2640) Add `:compress` option to Ruby http_client post

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.4.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.4.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/ruby/puppetserver-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/http_client.rb
@@ -7,6 +7,7 @@ require 'base64'
 require 'java'
 java_import com.puppetlabs.http.client.RequestOptions
 java_import com.puppetlabs.http.client.ClientOptions
+java_import com.puppetlabs.http.client.CompressType
 java_import com.puppetlabs.http.client.ResponseBodyType
 SyncHttpClient = com.puppetlabs.http.client.Sync
 
@@ -73,6 +74,17 @@ class Puppet::Server::HttpClient
     request_options.set_headers(headers)
     request_options.set_as(ResponseBodyType::TEXT)
     request_options.set_body(body)
+
+    compress = options[:compress]
+    if compress
+      compress_as_sym = compress.to_sym
+      if compress_as_sym == :gzip
+        request_options.set_compress_request_body(CompressType::GZIP)
+      else
+        raise ArgumentError, "Unsupported compression specified for request: #{compress}"
+      end
+    end
+
     response = self.class.client_post(request_options)
     ruby_response(response)
   end


### PR DESCRIPTION
This commit adds an option to the http_client Ruby post method for
specifying compression that should be applied to the request payload.
The only supported compression mode is `gzip`.  The new option, if
specified, is passed on through to the underlying http-client library.