### PR TITLE
(SERVER-1723) Use /dev/urandom for gem, ruby, and irb subcommands

### DIFF
--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -2,7 +2,7 @@
 
 umask 0022
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI \
+"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=/dev/urandom \
     -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/irb.erb
+++ b/resources/ext/cli/irb.erb
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI \
+"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=/dev/urandom \
     -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.irb \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/ruby.erb
+++ b/resources/ext/cli/ruby.erb
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI \
+"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=/dev/urandom \
     -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.ruby \
     --config "${CONFIG}" -- "$@"


### PR DESCRIPTION
This commit adds -Djava.security.egd=/dev/urandom as an argument to the
Java command line for the gem, ruby, and irb subcommands.  This argument
was already being used in the Java command line for when puppetserver
runs as a service.  Performance for some operations like gem installs
appears to be significantly faster with this option in place.