### PR TITLE
(SERVER-1704) Support flush timeout setting for jruby pool

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "0.7.0"]
+                 [puppetlabs/jruby-utils "0.7.1-SNAPSHOT"]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-scheduler]

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "0.7.1-SNAPSHOT"]
+                 [puppetlabs/jruby-utils "0.8.0"]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-scheduler]

--- a/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
+++ b/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
@@ -10,7 +10,8 @@
             [puppetlabs.puppetserver.ring.middleware.params :as pl-ring-params]
             [puppetlabs.i18n.core :as i18n]
             [slingshot.slingshot :as sling]
-            [ring.util.response :as rr]))
+            [ring.util.response :as rr]
+            [clojure.tools.logging :as log]))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -58,6 +59,7 @@
     {:status 204}
     ; If a lock timeout occurs return a 503 Service Unavailable
     (catch [:kind :puppetlabs.services.jruby-pool-manager.impl.jruby-agents/jruby-lock-timeout] e
+      (log/error (:msg e))
       (-> (rr/response (:msg e))
           (rr/status 503)
           (rr/content-type "text/plain")))))

--- a/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
+++ b/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
@@ -6,10 +6,11 @@
             [puppetlabs.puppetserver.liberator-utils :as liberator-utils]
             [schema.core :as schema]
             [liberator.core :refer [defresource]]
-    ;[liberator.dev :as liberator-dev]
             [puppetlabs.comidi :as comidi]
             [puppetlabs.puppetserver.ring.middleware.params :as pl-ring-params]
-            [puppetlabs.i18n.core :as i18n]))
+            [puppetlabs.i18n.core :as i18n]
+            [slingshot.slingshot :as sling]
+            [ring.util.response :as rr]))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -49,33 +50,17 @@
       (jruby-puppet/mark-environment-expired! jruby-service env-name)
       (jruby-puppet/mark-all-environments-expired! jruby-service))))
 
-(defresource jruby-pool-resource
+(defn handle-jruby-pool-flush
   [jruby-service]
-  :allowed-methods [:delete]
-
-  ;; If you need to define :available-media-types, see comment below.
-  ;:available-media-types ...
-
-  :handle-exception liberator-utils/exception-handler
-
-  ;; This next line of code tells liberator to ignore any media-types
-  ;; the client has asked for.  This is necessary for this endpoint to work
-  ;; when the client sends an 'Accept: */*' header, due to the somewhat strange
-  ;; fact that this endpoint defines no 'available-media-types', since it always
-  ;; returns a '204 No Content' on success.
-  ;;
-  ;; If this resource is ever updated to define ':available-media-types' and
-  ;; return a response body, this line of code should be deleted.
-
-  :media-type-available? true
-
-  ;; Never return a '201 Created', we're not creating anything
-  :new? false
-
-  :delete!
-  (fn [context]
-    (jruby-puppet/flush-jruby-pool! jruby-service)))
-
+  (sling/try+
+    (jruby-puppet/flush-jruby-pool! jruby-service)
+    ; 204 No Content on success
+    {:status 204}
+    ; If a lock timeout occurs return a 503 Service Unavailable
+    (catch [:kind :puppetlabs.services.jruby-pool-manager.impl.jruby-agents/jruby-lock-timeout] e
+      (-> (rr/response (:msg e))
+          (rr/status 503)
+          (rr/content-type "text/plain")))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing
@@ -87,8 +72,8 @@
     (comidi/ANY "/environment-cache" request
       (environment-cache-resource jruby-service
         (get-in request [:query-params "environment"])))
-    (comidi/ANY "/jruby-pool" []
-       (jruby-pool-resource jruby-service))))
+    (comidi/DELETE "/jruby-pool" []
+      (handle-jruby-pool-flush jruby-service))))
 
 (defn versioned-routes
   [jruby-service]

--- a/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
+++ b/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
@@ -6,6 +6,7 @@
             [puppetlabs.puppetserver.liberator-utils :as liberator-utils]
             [schema.core :as schema]
             [liberator.core :refer [defresource]]
+            ;[liberator.dev :as liberator-dev]
             [puppetlabs.comidi :as comidi]
             [puppetlabs.puppetserver.ring.middleware.params :as pl-ring-params]
             [puppetlabs.i18n.core :as i18n]

--- a/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
+++ b/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
@@ -194,10 +194,10 @@
              borrowed-instance (.borrowItem pool)]
          (try
            (let [response (http-client/delete
-                           (str "https://localhost:8140/puppet-admin-api/v1/jruby-pool")
+                           "https://localhost:8140/puppet-admin-api/v1/jruby-pool"
                            ssl-request-options)]
              (is (= 503 (:status response)))
-             (is (= "Timeout limit reached before lock could be granted"
+             (is (= "An attempt to lock the JRubyPool failed with a timeout"
                     (slurp (:body response)))))
            (finally
              (.releaseItem pool borrowed-instance))))))))


### PR DESCRIPTION
**This PR goes with** a jruby-utils PR which implements the timeout functionality: https://github.com/puppetlabs/jruby-utils/pull/40

---

This commit adds support for a timeout during a jruby pool flush through the
admin api.

Modifies the admin api routes to support returning a 503 if the timeout is
exceeded.

As a bonus it nukes a liberator resource too!

This shouldn't be merged until the corresponding jruby-utils PR is merged and a new release happens