### PR TITLE
(PE-18345) Pass metric-id setting through to http client

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/http_client.rb
@@ -97,28 +97,28 @@ class Puppet::Server::HttpClient
 
   private
 
-  def self.configure_timeouts(request_options)
+  def self.configure_timeouts(client_options)
     settings = self.settings
 
     if settings.has_key?("http_connect_timeout_milliseconds")
-      request_options.set_connect_timeout_milliseconds(settings["http_connect_timeout_milliseconds"])
+      client_options.set_connect_timeout_milliseconds(settings["http_connect_timeout_milliseconds"])
     end
 
     if settings.has_key?("http_idle_timeout_milliseconds")
-      request_options.set_socket_timeout_milliseconds(settings["http_idle_timeout_milliseconds"])
+      client_options.set_socket_timeout_milliseconds(settings["http_idle_timeout_milliseconds"])
     end
   end
 
-  def self.configure_ssl(request_options)
-    request_options.set_ssl_context(Puppet::Server::Config.ssl_context)
+  def self.configure_ssl(client_options)
+    client_options.set_ssl_context(Puppet::Server::Config.ssl_context)
 
     settings = self.settings
 
     if settings.has_key?("ssl_protocols")
-      request_options.set_ssl_protocols(settings["ssl_protocols"])
+      client_options.set_ssl_protocols(settings["ssl_protocols"])
     end
     if settings.has_key?("cipher_suites")
-      request_options.set_ssl_cipher_suites(settings["cipher_suites"])
+      client_options.set_ssl_cipher_suites(settings["cipher_suites"])
     end
   end
 

--- a/src/ruby/puppetserver-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/http_client.rb
@@ -66,26 +66,28 @@ class Puppet::Server::HttpClient
       headers["Authorization"] = "Basic #{encoded}"
     end
 
-    # Ensure multiple requests are not made on the same connection
-    headers["Connection"] = "close"
-
-    request_options = RequestOptions.new(build_url(url))
-    request_options.set_headers(headers)
-    request_options.set_as(ResponseBodyType::TEXT)
+    request_options = create_common_request_options(url, headers, options)
     request_options.set_body(body)
     response = self.class.client_post(request_options)
     ruby_response(response)
   end
 
-  def get(url, headers)
-    # Ensure multiple requests are not made on the same connection
-    headers["Connection"] = "close"
+  def get(url, headers, options={})
 
-    request_options = RequestOptions.new(build_url(url))
-    request_options.set_headers(headers)
-    request_options.set_as(ResponseBodyType::TEXT)
+    request_options = create_common_request_options(url, headers, options)
     response = self.class.client_get(request_options)
     ruby_response(response)
+  end
+
+  def create_common_request_options(url, headers, options)
+    # Ensure multiple requests are not made on the same connection
+    headers["Connection"] = "close"
+    request_options = RequestOptions.new(build_url(url))
+    if options[:metric_id]
+      request_options.set_metric_id(options[:metric_id])
+    end
+    request_options.set_headers(headers)
+    request_options.set_as(ResponseBodyType::TEXT)
   end
 
   def self.terminate

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -374,7 +374,7 @@
        jruby-testutils/jruby-service-and-dependencies
        config
        (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
-             jruby-instance (jruby-testutils/borrow-instance jruby-service :no-metrics-test)
+             jruby-instance (jruby-testutils/borrow-instance jruby-service :metrics-test)
              container (:scripting-container jruby-instance)]
          (try
            (let [client (.runScriptlet container "Puppet::Server::HttpClient.client")]
@@ -384,7 +384,7 @@
                (is (= "puppetlabs.localhost.http-client.experimental"
                       (.getMetricNamespace client)))))
            (finally
-             (jruby-testutils/return-instance jruby-service jruby-instance :no-metrics-test))))))))
+             (jruby-testutils/return-instance jruby-service jruby-instance :metrics-test))))))))
 
 (tk/defservice test-metric-web-service
                [[:WebserverService add-ring-handler]]
@@ -468,7 +468,7 @@
                  (is (= 1 (:count (first (metrics/get-client-metrics-data-by-metric-id
                                           metric-registry ["foo" "post"]))))))))
            (finally
-             (jruby-testutils/return-instance jruby-service jruby-instance :no-metrics-test))))))))
+             (jruby-testutils/return-instance jruby-service jruby-instance :http-client-metrics-test))))))))
 
 (deftest create-jruby-instance-test
   (testing "Directories can be configured programatically


### PR DESCRIPTION
This makes it so that if a `metric-id` request option is set for a GET
or POST request (the only two request types we support), it is passed through
to the http client's request options. Doing this also meant a small refactor
of some common logic between the `get` and `post` methods, as they both shared
most of the same logic for creating `RequestOptions`.