### PR TITLE
(SERVER-1262) Wrap http metrics for comidi routes

### DIFF
--- a/dev-resources/puppetlabs/services/master/master_service_test/ca_files_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/master_service_test/ca_files_test/puppet.conf
@@ -1,0 +1,19 @@
+[main]
+certname = localhost
+
+vardir = target/master-service-test/ca-files-test/var
+ssldir = target/master-service-test/ca-files-test/ssl
+
+capub = target/master-service-test/ca-files-test/ca/ca_pub.pem
+cakey = target/master-service-test/ca-files-test/ca/ca_key.pem
+cacert = target/master-service-test/ca-files-test/ca/ca_crt.pem
+localcacert = target/master-service-test/ca-files-test/ca/ca.pem
+cacrl = target/master-service-test/ca-files-test/ca/ca_crl.pem
+hostcrl = target/master-service-test/ca-files-test/ca/crl.pem
+
+hostpubkey = target/master-service-test/ca-files-test/public_keys/localhost.pem
+hostprivkey = target/master-service-test/ca-files-test/private_keys/localhost.pem
+hostcert = target/master-service-test/ca-files-test/certs/localhost.pem
+
+serial = target/master-service-test/ca-files-test/certs/serial
+cert_inventory = target/master-service-test/ca-files-test/inventory.txt

--- a/dev-resources/puppetlabs/services/master/master_service_test/conf/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/master_service_test/conf/puppet.conf
@@ -1,19 +1,2 @@
 [main]
 certname = localhost
-
-vardir = target/master-service-test/var
-ssldir = target/master-service-test/ssl
-
-capub = target/master-service-test/ca/ca_pub.pem
-cakey = target/master-service-test/ca/ca_key.pem
-cacert = target/master-service-test/ca/ca_crt.pem
-localcacert = target/master-service-test/ca/ca.pem
-cacrl = target/master-service-test/ca/ca_crl.pem
-hostcrl = target/master-service-test/ca/crl.pem
-
-hostpubkey = target/master-service-test/public_keys/localhost.pem
-hostprivkey = target/master-service-test/private_keys/localhost.pem
-hostcert = target/master-service-test/certs/localhost.pem
-
-serial = target/master-service-test/certs/serial
-cert_inventory = target/master-service-test/inventory.txt

--- a/project.clj
+++ b/project.clj
@@ -61,6 +61,7 @@
                  [puppetlabs/jruby-utils "0.7.0"]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
+                 [puppetlabs/trapperkeeper-comidi-metrics]
                  [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-scheduler]
                  [puppetlabs/trapperkeeper-status]

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -27,25 +27,48 @@
    [this context]
    (core/validate-memory-requirements!)
    (let [config (get-config)
+         route-config (core/get-master-route-config ::master-service config)
+         path (core/get-master-mount ::master-service route-config)
          certname (get-in config [:puppetserver :certname])
          localcacert (get-in config [:puppetserver :localcacert])
          puppet-version (get-in config [:puppetserver :puppet-version])
-         hostcrl (get-in config [:puppetserver :hostcrl])
          settings (ca/config->master-settings config)
+         metrics-server-id (get-in config [:metrics :server-id])
+         jruby-service (tk-services/get-service this :JRubyPuppetService)
+         use-legacy-auth-conf (get-in config
+                                      [:jruby-puppet :use-legacy-auth-conf]
+                                      true)
+         environment-class-cache-enabled (get-in config
+                                                 [:jruby-puppet
+                                                  :environment-class-cache-enabled]
+                                                 false)
+         ring-app (core/construct-root-routes puppet-version
+                                              use-legacy-auth-conf
+                                              jruby-service
+                                              get-code-content
+                                              handle-request
+                                              (get-auth-handler)
+                                              environment-class-cache-enabled)
+         routes (comidi/context path ring-app)
+         route-metadata (comidi/route-metadata routes)
+         comidi-handler (comidi/routes->handler routes)
+         registry (get-metrics-registry :puppetserver)
+         metrics (http-metrics/initialize-http-metrics!
+                  registry
+                  metrics-server-id
+                  route-metadata)
+         ring-handler (-> comidi-handler
+                          (http-metrics/wrap-with-request-metrics metrics)
+                          (comidi/wrap-with-route-metadata routes))
          product-name (or (get-in config [:product :name])
                           {:group-id    "puppetlabs"
                            :artifact-id "puppetserver"})
          checkin-interval-millis (* 1000 60 60 24) ; once per day
          update-server-url (get-in config [:product :update-server-url])
-         use-legacy-auth-conf (get-in config
-                                      [:jruby-puppet :use-legacy-auth-conf]
-                                      true)
-         jruby-service (tk-services/get-service this :JRubyPuppetService)
-         environment-class-cache-enabled (get-in config
-                                                 [:jruby-puppet
-                                                  :environment-class-cache-enabled]
-                                                 false)
-         check-for-updates (get-in config [:product :check-for-updates])]
+
+         check-for-updates (get-in config [:product :check-for-updates])
+         hostcrl (get-in config [:puppetserver :hostcrl])]
+
      (if (or (nil? check-for-updates) check-for-updates)
        (interspaced checkin-interval-millis
                     (fn [] (version-check/check-for-updates!
@@ -57,53 +80,31 @@
      (initialize-master-ssl! settings certname)
 
      (log/info (i18n/trs "Master Service adding ring handlers"))
-     (let [route-config (core/get-master-route-config ::master-service config)
-           path (core/get-master-mount ::master-service route-config)
-           ring-app (core/construct-root-routes puppet-version
-                                                use-legacy-auth-conf
-                                                jruby-service
-                                                get-code-content
-                                                handle-request
-                                                (get-auth-handler)
-                                                environment-class-cache-enabled)
-           routes (comidi/context path ring-app)
-           route-metadata (comidi/route-metadata routes)
-           comidi-handler (comidi/routes->handler routes)
-           registry (get-metrics-registry :puppetserver)
-           metrics-server-id (get-in config [:metrics :server-id])
-           metrics (http-metrics/initialize-http-metrics!
-                    registry
-                    metrics-server-id
-                    route-metadata)
-           ring-handler (-> comidi-handler
-                            (http-metrics/wrap-with-request-metrics metrics)
-                            (comidi/wrap-with-route-metadata routes))]
 
-       ;; if the webrouting config uses the old-style config where
-       ;; there is a single key with a route-id, we need to deal with that
-       ;; for backward compat.  We have a hard-coded assumption that this route-id
-       ;; must be `master-routes`.  In Puppet Server 2.0, we also supported a
-       ;; key called `invalid-in-puppet-4` in the same route config, even though
-       ;; that key is no longer used for Puppet Server 2.1 and later.  We
-       ;; should be able to remove this hack as soon as we are able to get rid
-       ;; of the legacy routes.
-       (if (and (map? route-config)
-                (contains? route-config :master-routes))
-         (add-ring-handler this
-                           ring-handler
-                           {:route-id :master-routes
-                            :normalize-request-uri true})
-         (add-ring-handler this
-                           ring-handler
-                           {:normalize-request-uri true}))
+     ;; if the webrouting config uses the old-style config where
+     ;; there is a single key with a route-id, we need to deal with that
+     ;; for backward compat.  We have a hard-coded assumption that this route-id
+     ;; must be `master-routes`.  In Puppet Server 2.0, we also supported a
+     ;; key called `invalid-in-puppet-4` in the same route config, even though
+     ;; that key is no longer used for Puppet Server 2.1 and later.  We
+     ;; should be able to remove this hack as soon as we are able to get rid
+     ;; of the legacy routes.
+     (if (and (map? route-config)
+              (contains? route-config :master-routes))
+       (add-ring-handler this
+                         ring-handler
+                         {:route-id :master-routes
+                          :normalize-request-uri true})
+       (add-ring-handler this
+                         ring-handler
+                         {:normalize-request-uri true}))
 
-       (register-status
-        "master"
-        (status-core/get-artifact-version "puppetlabs" "puppetserver")
-        1
-        (partial core/v1-status metrics))
-
-       (assoc context :http-metrics metrics))))
+     (register-status
+      "master"
+      (status-core/get-artifact-version "puppetlabs" "puppetserver")
+      1
+      (partial core/v1-status metrics))
+     (assoc context :http-metrics metrics)))
   (start
     [this context]
     (log/info (i18n/trs "Puppet Server has successfully started and is now ready to handle requests"))

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -44,8 +44,8 @@
                       :headers {"Accept" "pson"}
                       :as :text})))
 
-(deftest ^:integration master-service-metrics
-  (testing "Metrics computed via use of the master service are correct"
+(deftest ^:integration master-service-http-metrics
+  (testing "HTTP metrics computed via use of the master service are correct"
     (bootstrap-testutils/with-puppetserver-running
      app
      {:jruby-puppet {:max-active-instances 1
@@ -124,8 +124,16 @@
                (is (every? #(= 0 %) (map :count
                                          (filter
                                           #(not (hit-routes (:route-id %)))
-                                          http-metrics)))))))))
+                                          http-metrics))))))))))))
 
+(deftest ^:integration master-service-jruby-metrics
+  (testing "JRuby metrics computed via use of the master service actions are correct"
+    (bootstrap-testutils/with-puppetserver-running
+     app
+     {:jruby-puppet {:max-active-instances 1
+                     :master-code-dir test-resources-code-dir
+                     :master-conf-dir master-service-test-runtime-dir}
+      :metrics {:server-id "localhost"}}
      (let [jruby-metrics-service (tk-app/get-service app :JRubyMetricsService)
            svc-context (tk-services/service-context jruby-metrics-service)
            jruby-metrics (:metrics svc-context)

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -25,6 +25,7 @@
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as routing-service]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization-service]
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :as metrics]
+            [puppetlabs.trapperkeeper.services.status.status-service :as status-service]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
@@ -324,7 +325,8 @@
                      routing-service/webrouting-service
                      custom-vcs
                      tk-scheduler/scheduler-service
-                     metrics/metrics-service]]
+                     metrics/metrics-service
+                     status-service/status-service]]
        (jruby-bootstrap/with-puppetserver-running-with-services-and-mock-jruby-puppet-fn
         "For this test we're basically just validating that a JRuby is reserved
          before a code-id is calculated.  A JRuby mock is safe here in that


### PR DESCRIPTION
This PR imports work done in pe-puppet-server-extensions for
wrapping the comidi routes for the master and legacy-routes services
with http-metrics.