### PR TITLE
(maint) Update methods in http client to match Ruby version

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/http_client.rb
@@ -53,7 +53,7 @@ class Puppet::Server::HttpClient
     @protocol = @use_ssl ? "https" : "http"
   end
 
-  def post(url, body, headers, options = {})
+  def post(url, body, headers = {}, options = {})
     # If credentials were supplied for HTTP basic auth, add them into the headers.
     # This is based on the code in lib/puppet/reports/http.rb.
     credentials = options[:basic_auth]
@@ -84,7 +84,7 @@ class Puppet::Server::HttpClient
     ruby_response(response)
   end
 
-  def get(url, headers, options={})
+  def get(url, headers={}, options={})
 
     request_options = create_common_request_options(url, headers, options)
     response = self.class.client_get(request_options)


### PR DESCRIPTION
Prior to Server 5, the `get` method of Puppet Server's http client class took
two required arguments. It was then updated to accept a third, optional
argument. However, Puppet's implementation of this class has a `get` method
that takes one required argument and two optional arguments. This commit
updates Puppet Server's implementation of this method to have the same
signature as Ruby Puppet's.

Similarly, the `post` method of Puppet Server's http client class had two
required arguments and one optional argument, but Puppet's implementation has
one required arguments and two optional arguments. This commit updates
Puppet Server's `post` method to make `headers` optional, to match Puppet's
implementation.