### PR TITLE
(SERVER-1744) Move metrics configuration into metrics.conf file

### DIFF
--- a/ezbake/config/conf.d/metrics.conf
+++ b/ezbake/config/conf.d/metrics.conf
@@ -1,0 +1,6 @@
+# settings related to metrics
+metrics: {
+    # a server id that will be used as part of the namespace for metrics produced
+    # by this server
+    server-id: "localhost"
+}

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -68,13 +68,6 @@ http-client: {
     #metrics-enabled: true
 }
 
-# settings related to metrics
-metrics: {
-    # a server id that will be used as part of the namespace for metrics produced
-    # by this server
-    server-id: "localhost"
-}
-
 # settings related to profiling the puppet Ruby code
 profiler: {
     # enable or disable profiling for the Ruby code; defaults to 'false'.


### PR DESCRIPTION
Previously, if a user had modified the puppetserver.conf file after
install of an older package, the new metrics section would not end up
being populated in the puppetserver.conf file after upgrade.  Because
the required server-id key would not be found in the metrics section,
puppetserver would error out on startup.

This commit moves the new metrics configuration from the
puppetserver.conf file to a metrics.conf file in packaging.  This is
being done both for consistency with PE Puppet Server in how the
metrics configuration is presented to users and to allow the required
server-id setting to be populated by default on a package install or
upgrade.