### PR TITLE
(SERVER-1743) Move check-for-updates call into analytics service

### DIFF
--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -14,6 +14,7 @@ puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
 puppetlabs.services.jruby.jruby-metrics-service/jruby-metrics-service
+puppetlabs.services.analytics.analytics-service/analytics-service
 
 # To enable the CA service, leave the following line uncommented
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service

--- a/ezbake/system-config/services.d/bootstrap.cfg
+++ b/ezbake/system-config/services.d/bootstrap.cfg
@@ -14,3 +14,4 @@ puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
 puppetlabs.services.jruby.jruby-metrics-service/jruby-metrics-service
+puppetlabs.services.analytics.analytics-service/analytics-service

--- a/src/clj/puppetlabs/services/analytics/analytics_service.clj
+++ b/src/clj/puppetlabs/services/analytics/analytics_service.clj
@@ -26,5 +26,5 @@
                     (fn [] (version-check/check-for-updates!
                             {:product-name product-name} update-server-url)))
        (log/info (i18n/trs "Not checking for updates - opt-out setting exists"))))
-   (log/info (i18n/trs "Puppet Server Analytics has successfully started and will run in the background"))
+   (log/info (i18n/trs "Puppet Server Update Service has successfully started and will run in the background"))
    context))

--- a/src/clj/puppetlabs/services/analytics/analytics_service.clj
+++ b/src/clj/puppetlabs/services/analytics/analytics_service.clj
@@ -1,0 +1,30 @@
+(ns puppetlabs.services.analytics.analytics-service
+  (:require [clojure.tools.logging :as log]
+            [puppetlabs.trapperkeeper.core :refer [defservice]]
+            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.dujour.version-check :as version-check]))
+
+(defprotocol AnalyticsService
+  "Protocol placeholder for the analytics service.")
+
+(defservice analytics-service
+  AnalyticsService
+  [[:PuppetServerConfigService get-config]
+   [:SchedulerService interspaced]]
+
+  (start
+   [this context]
+   (let [config (get-config)
+         product-name (or (get-in config [:product :name])
+                          {:group-id "puppetlabs"
+                           :artifact-id "puppetserver"})
+         checkin-interval-millis (* 1000 60 60 24) ; once per day
+         update-server-url (get-in config [:product :update-server-url])
+         check-for-updates (get-in config [:product :check-for-updates] true)]
+     (if check-for-updates
+       (interspaced checkin-interval-millis
+                    (fn [] (version-check/check-for-updates!
+                            {:product-name product-name} update-server-url)))
+       (log/info (i18n/trs "Not checking for updates - opt-out setting exists"))))
+   (log/info (i18n/trs "Puppet Server Analytics has successfully started and will run in the background"))
+   context))

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -62,20 +62,7 @@
          ring-handler (-> comidi-handler
                           (http-metrics/wrap-with-request-metrics metrics)
                           (comidi/wrap-with-route-metadata routes))
-         product-name (or (get-in config [:product :name])
-                          {:group-id    "puppetlabs"
-                           :artifact-id "puppetserver"})
-         checkin-interval-millis (* 1000 60 60 24) ; once per day
-         update-server-url (get-in config [:product :update-server-url])
-
-         check-for-updates (get-in config [:product :check-for-updates])
          hostcrl (get-in config [:puppetserver :hostcrl])]
-
-     (if (or (nil? check-for-updates) check-for-updates)
-       (interspaced checkin-interval-millis
-                    (fn [] (version-check/check-for-updates!
-                             {:product-name product-name} update-server-url)))
-       (log/info (i18n/trs "Not checking for updates - opt-out setting exists")))
 
      (retrieve-ca-cert! localcacert)
      (retrieve-ca-crl! hostcrl)

--- a/test/integration/puppetlabs/services/analytics/analytics_service_test.clj
+++ b/test/integration/puppetlabs/services/analytics/analytics_service_test.clj
@@ -7,13 +7,14 @@
 
 (deftest ^:integration version-check-test
   (testing "master calls into the dujour version check library using the correct values"
-    ; This atom will store the parameters passed to the version-check-test-fn, which allows us to keep the
+    ; This promise will store the parameters passed to the version-check-test-fn, which allows us to keep the
     ; assertions about their values inside the version-check-test and will also ensure failures will appear if
     ; the master stops calling the check-for-updates! function
-    (let [version-check-params (atom {})
+    (let [version-check-params (promise)
           version-check-test-fn (fn [request-values update-server-url]
-                                  (swap! version-check-params #(assoc % :request-values request-values
-                                                                        :update-server-url update-server-url)))]
+                                  (deliver version-check-params
+                                           {:request-values request-values
+                                            :update-server-url update-server-url}))]
       (with-redefs
        [version-check/check-for-updates! version-check-test-fn]
         (logutils/with-test-logging
@@ -26,18 +27,26 @@
            :product {:update-server-url "http://notarealurl/"
                      :name {:group-id "puppets"
                             :artifact-id "yoda"}}}
-          (is (= {:group-id "puppets" :artifact-id "yoda"}
-                 (get-in @version-check-params [:request-values :product-name])))
-          (is (= "http://notarealurl/" (:update-server-url @version-check-params))))))))
+          (let [params-received (deref version-check-params 30000
+                                       {:request-values
+                                        {:product-name
+                                         :no-product-name-received-before-time-out-reached}
+                                        :update-server-url
+                                        :no-update-server-url-received-before-time-out-reached})]
+            (is (= {:group-id "puppets" :artifact-id "yoda"}
+                   (get-in params-received [:request-values :product-name])))
+            (is (= "http://notarealurl/"
+                   (:update-server-url params-received)))))))))
 
   (testing "master does not make an analytics call to dujour if opt-out exists"
-    ; This atom will store the parameters passed to the version-check-test-fn, which allows us to keep the
+    ; This promise will store the parameters passed to the version-check-test-fn, which allows us to keep the
     ; assertions about their values inside the version-check-test and will also ensure failures will appear if
     ; the master stops calling the check-for-updates! function
-    (let [version-check-params  (atom {})
+    (let [version-check-params  (promise)
           version-check-test-fn (fn [request-values update-server-url]
-                                  (swap! version-check-params #(assoc % :request-values request-values
-                                                                        :update-server-url update-server-url)))]
+                                  (deliver version-check-params
+                                           {:request-values request-values
+                                            :update-server-url update-server-url}))]
       (with-redefs
        [version-check/check-for-updates! version-check-test-fn]
         (logutils/with-test-logging
@@ -51,5 +60,8 @@
                      :name {:group-id "puppets"
                             :artifact-id "yoda"}
                      :check-for-updates false}}
-          (is (= nil (get-in @version-check-params [:request-values :product-name])))
-          (is (= nil (:update-server-url @version-check-params)))))))))
+          (is (logutils/logged?
+               #"Not checking for updates - opt-out setting exists" :info))
+          (let [params-received (deref version-check-params 100
+                                       :no-params-received-before-time-out-reached)]
+            (is (= :no-params-received-before-time-out-reached params-received)))))))))

--- a/test/integration/puppetlabs/services/analytics/analytics_service_test.clj
+++ b/test/integration/puppetlabs/services/analytics/analytics_service_test.clj
@@ -1,0 +1,55 @@
+(ns puppetlabs.services.analytics.analytics-service-test
+  (:require
+    [clojure.test :refer :all]
+    [puppetlabs.dujour.version-check :as version-check]
+    [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap-testutils]
+    [puppetlabs.trapperkeeper.testutils.logging :as logutils]))
+
+(deftest ^:integration version-check-test
+  (testing "master calls into the dujour version check library using the correct values"
+    ; This atom will store the parameters passed to the version-check-test-fn, which allows us to keep the
+    ; assertions about their values inside the version-check-test and will also ensure failures will appear if
+    ; the master stops calling the check-for-updates! function
+    (let [version-check-params (atom {})
+          version-check-test-fn (fn [request-values update-server-url]
+                                  (swap! version-check-params #(assoc % :request-values request-values
+                                                                        :update-server-url update-server-url)))]
+      (with-redefs
+       [version-check/check-for-updates! version-check-test-fn]
+        (logutils/with-test-logging
+         (bootstrap-testutils/with-puppetserver-running-with-mock-jrubies
+          "Mocking is safe here because we're not doing anything with JRubies, just making sure
+          the service starts and makes the right dujour calls"
+          app
+          {:jruby-puppet {:max-active-instances 1}
+           :webserver {:port 8081}
+           :product {:update-server-url "http://notarealurl/"
+                     :name {:group-id "puppets"
+                            :artifact-id "yoda"}}}
+          (is (= {:group-id "puppets" :artifact-id "yoda"}
+                 (get-in @version-check-params [:request-values :product-name])))
+          (is (= "http://notarealurl/" (:update-server-url @version-check-params))))))))
+
+  (testing "master does not make an analytics call to dujour if opt-out exists"
+    ; This atom will store the parameters passed to the version-check-test-fn, which allows us to keep the
+    ; assertions about their values inside the version-check-test and will also ensure failures will appear if
+    ; the master stops calling the check-for-updates! function
+    (let [version-check-params  (atom {})
+          version-check-test-fn (fn [request-values update-server-url]
+                                  (swap! version-check-params #(assoc % :request-values request-values
+                                                                        :update-server-url update-server-url)))]
+      (with-redefs
+       [version-check/check-for-updates! version-check-test-fn]
+        (logutils/with-test-logging
+         (bootstrap-testutils/with-puppetserver-running-with-mock-jrubies
+          "Mocking is safe here because we're not doing anything with JRubies, just making sure
+          the service starts and makes the right dujour calls"
+          app
+          {:jruby-puppet {:max-active-instances 1}
+           :webserver {:port 8081}
+           :product {:update-server-url "http://notarealurl/"
+                     :name {:group-id "puppets"
+                            :artifact-id "yoda"}
+                     :check-for-updates false}}
+          (is (= nil (get-in @version-check-params [:request-values :product-name])))
+          (is (= nil (:update-server-url @version-check-params)))))))))


### PR DESCRIPTION
This commit moves the check-for-updates call to dujour out into a
separate analytics service.  This would hopefully allow for the OSS
master service to be reusable directly in PE Puppet Server once all of
the metrics-related work is ported down into OSS.

![](https://i.ytimg.com/vi/iog6pHsr2n0/maxresdefault.jpg)