### PR TITLE
(SERVER-1721) Add allowed metrics to master service

### DIFF
--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -113,7 +113,37 @@ profiler: {
 }
 
 metrics: {
-    server-id: "localhost"
+    # a server id that will be used as part of the namespace for metrics produced
+    # by this server
+    server-id: localhost
+    registries: {
+        puppetserver: {
+            # specify metrics to allow in addition to those in the default list
+            #metrics-allowed: ["compiler.compile.production"]
+            reporters: {
+                # enable or disable JMX metrics reporter
+                jmx: {
+                    enabled: true
+                }
+                # enable or disable Graphite metrics reporter
+                #graphite: {
+                #    enabled: true
+                #}
+            }
+        }
+    }
+    # this section is used to configure settings for reporters that will send
+    # the metrics to various destinations for external viewing
+    reporters: {
+        #graphite: {
+        #    # graphite host
+        #    host: "127.0.0.1"
+        #    # graphite metrics port
+        #    port: 2003
+        #    # how often to send metrics to graphite
+        #    update-interval-seconds: 5
+        #}
+    }
 }
 
 # authorization rules for web service endpoints

--- a/ezbake/config/conf.d/metrics.conf
+++ b/ezbake/config/conf.d/metrics.conf
@@ -2,5 +2,36 @@
 metrics: {
     # a server id that will be used as part of the namespace for metrics produced
     # by this server
-    server-id: "localhost"
+    server-id: localhost
+    registries: {
+        puppetserver: {
+            # specify metrics to allow in addition to those in the default list
+            #metrics-allowed: ["compiler.compile.production"]
+
+            reporters: {
+                # enable or disable JMX metrics reporter
+                jmx: {
+                    enabled: true
+                }
+                # enable or disable Graphite metrics reporter
+                #graphite: {
+                #    enabled: true
+                #}
+            }
+
+        }
+    }
+
+    # this section is used to configure settings for reporters that will send
+    # the metrics to various destinations for external viewing
+    reporters: {
+        #graphite: {
+        #    # graphite host
+        #    host: "127.0.0.1"
+        #    # graphite metrics port
+        #    port: 2003
+        #    # how often to send metrics to graphite
+        #    update-interval-seconds: 5
+        #}
+    }
 }

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.5.0-SNAPSHOT"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.5.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.4.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.5.0-SNAPSHOT"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                  [me.raynes/fs]
                  [liberator]
                  [org.apache.commons/commons-exec]
-                 [io.dropwizard.metrics/metrics-core "3.1.2"]
+                 [io.dropwizard.metrics/metrics-core]
 
                  ;; We do not currently use this dependency directly, but
                  ;; we have documentation that shows how users can use it to
@@ -116,6 +116,7 @@
                                    [puppetlabs/trapperkeeper-webserver-jetty9]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 nil :classifier "test"]
                                    [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
+                                   [puppetlabs/trapperkeeper-metrics :classifier "test" :scope "test"]
                                    [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
                                    [ring-basic-authentication]
                                    [ring-mock]

--- a/src/clj/puppetlabs/services/jruby/jruby_metrics_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_metrics_service.clj
@@ -10,6 +10,30 @@
 
 (def jruby-metrics-service-status-version 1)
 
+;; Default list of allowed histograms/timers
+(def default-metrics-allowed-hists
+  ["jruby.borrow-timer"
+   "jruby.free-jrubies-histo"
+   "jruby.lock-held-timer"
+   "jruby.lock-wait-timer"
+   "jruby.requested-jrubies-histo"
+   "jruby.wait-timer"])
+
+;; Default list of allowed values/counts
+(def default-metrics-allowed-vals
+  ["jruby.borrow-count"
+   "jruby.borrow-retry-count"
+   "jruby.borrow-timeout-count"
+   "jruby.num-free-jrubies"
+   "jruby.num-jrubies"
+   "jruby.request-count"
+   "jruby.return-count"])
+
+(def default-metrics-allowed
+  (concat
+   default-metrics-allowed-hists
+   default-metrics-allowed-vals))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
@@ -17,7 +41,7 @@
   jruby-metrics-protocol/JRubyMetricsService
   [[:ConfigService get-in-config]
    [:JRubyPuppetService register-event-handler]
-   [:MetricsService get-metrics-registry get-server-id]
+   [:MetricsService get-metrics-registry get-server-id update-registry-settings]
    [:SchedulerService interspaced stop-job]
    [:StatusService register-status]]
   (init
@@ -32,6 +56,8 @@
                     max-active-instances
                     (fn [] (jruby-protocol/free-instance-count jruby-service))
                     (get-metrics-registry :puppetserver))]
+      (update-registry-settings :puppetserver
+                                {:default-metrics-allowed default-metrics-allowed})
       (register-status
        "jruby-metrics"
        (status-core/get-artifact-version "puppetlabs" "puppetserver")

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -15,15 +15,7 @@
 
 ;; Default list of allowed histograms/timers
 (def default-metrics-allowed-hists
-  ["compiler"
-   "compiler.compile"
-   "compiler.find_facts"
-   "compiler.find_node"
-   "compiler.static_compile"
-   "compiler.static_compile_inlining"
-   "compiler.static_compile_postprocessing"
-   "functions"
-   "http.active-histo"
+  ["http.active-histo"
    "http.puppet-v3-catalog-/*/-requests"
    "http.puppet-v3-environment-/*/-requests"
    "http.puppet-v3-environment_classes-/*/-requests"
@@ -34,19 +26,7 @@
    "http.puppet-v3-file_metadatas-/*/-requests"
    "http.puppet-v3-node-/*/-requests"
    "http.puppet-v3-report-/*/-requests"
-   "http.puppet-v3-static_file_content-/*/-requests"
-   "jruby.borrow-timer"
-   "jruby.free-jrubies-histo"
-   "jruby.lock-held-timer"
-   "jruby.lock-wait-timer"
-   "jruby.requested-jrubies-histo"
-   "jruby.wait-timer"
-   "puppetdb.catalog.save"
-   "puppetdb.command.submit"
-   "puppetdb.facts.find"
-   "puppetdb.facts.search"
-   "puppetdb.report.process"
-   "puppetdb.resource.search"])
+   "http.puppet-v3-static_file_content-/*/-requests"])
 
 ;; Default list of allowed values/counts
 (def default-metrics-allowed-vals
@@ -66,36 +46,14 @@
    "http.puppet-v3-static_file_content-/*/-percentage"
    "http.puppet-v3-status-/*/-percentage"
    "http.total-requests"
-   "jruby.borrow-count"
-   "jruby.borrow-retry-count"
-   "jruby.borrow-timeout-count"
-   "jruby.num-free-jrubies"
-   "jruby.num-jrubies"
-   "jruby.request-count"
-   "jruby.return-count"
+   ; num-cpus is registered in trapperkeeper-comidi-metrics, see
+   ; https://github.com/puppetlabs/trapperkeeper-comidi-metrics/blob/0.1.1/src/puppetlabs/metrics/http.clj#L117-L120
    "num-cpus"])
-
-; List of allowed jvm gauges/values
-(def default-jvm-metrics-allowed
-  ["uptime"
-   "memory.heap.committed"
-   "memory.heap.init"
-   "memory.heap.max"
-   "memory.heap.used"
-   "memory.non-heap.committed"
-   "memory.non-heap.init"
-   "memory.non-heap.max"
-   "memory.non-heap.used"
-   "memory.total.committed"
-   "memory.total.init"
-   "memory.total.max"
-   "memory.total.used"])
 
 (def default-metrics-allowed
   (concat
    default-metrics-allowed-hists
-   default-metrics-allowed-vals
-   default-jvm-metrics-allowed))
+   default-metrics-allowed-vals))
 
 (defservice master-service
   master/MasterService

--- a/src/clj/puppetlabs/services/puppet_profiler/puppet_profiler_service.clj
+++ b/src/clj/puppetlabs/services/puppet_profiler/puppet_profiler_service.clj
@@ -5,9 +5,27 @@
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.trapperkeeper.services.status.status-core :as status-core]))
 
+;; Default list of allowed histograms/timers
+(def default-metrics-allowed
+  ["compiler"
+   "compiler.compile"
+   "compiler.find_facts"
+   "compiler.find_node"
+   "compiler.static_compile"
+   "compiler.static_compile_inlining"
+   "compiler.static_compile_postprocessing"
+   "functions"
+   "puppetdb.catalog.save"
+   "puppetdb.command.submit"
+   "puppetdb.facts.find"
+   "puppetdb.facts.search"
+   "puppetdb.report.process"
+   "puppetdb.resource.search"])
+
+
 (trapperkeeper/defservice puppet-profiler-service
                           profiler/PuppetProfilerService
-                          [[:MetricsService get-metrics-registry get-server-id]
+                          [[:MetricsService get-metrics-registry get-server-id update-registry-settings]
                            [:ConfigService get-in-config]
                            [:StatusService register-status]]
 
@@ -16,6 +34,8 @@
                     (get-in-config [:profiler] {})
                     (get-server-id)
                     (get-metrics-registry :puppetserver))]
+      (update-registry-settings :puppetserver
+                                {:default-metrics-allowed default-metrics-allowed})
       (register-status
         "puppet-profiler"
         (status-core/get-artifact-version "puppetlabs" "puppetserver")

--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -121,13 +121,13 @@
 
 (defmacro with-puppetserver-running
   [app config-overrides & body]
-  (let [config (load-dev-config-with-overrides config-overrides)]
-    `(let [services# (tk-bootstrap/parse-bootstrap-config! ~dev-bootstrap-file)]
+  `(let [config# (load-dev-config-with-overrides ~config-overrides)]
+     (let [services# (tk-bootstrap/parse-bootstrap-config! ~dev-bootstrap-file)]
        (tk-testutils/with-app-with-config
-         ~app
-         services#
-         ~config
-         ~@body))))
+        ~app
+        services#
+        config#
+        ~@body))))
 
 (defmacro with-puppetserver-running-with-mock-jrubies
   "This macro should be used with caution; it makes tests run much more quickly,


### PR DESCRIPTION
This commits adds a list of default allowed metrics to puppetserver's master
service.

tk-metrics 1.0.0 added the ability for graphite exporting. The metrics service
can take a list of whitelisted metrics through a call to the
update-registry-settings service function during the init phase

Can't be merged until a new clj-parent release is made