### PR TITLE
(SERVER-1753) Add metrics webservice to configuration

### DIFF
--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -164,4 +164,13 @@ with_puppet_running_on(master, {}) do
     curl_unauthenticated('/puppet-ca/v1/certificate_request/foo?environment=production')
     assert_allowed(404)
   end
+
+  step 'metrics endpoint' do
+    # The metrics endpoint endpoint isn't currently expected to be controlled
+    # by tk-auth and so there is no rule written to the auth.conf for it explicitly.
+    # This test is basically just confirming that authentication is not required to
+    # in order to hit it.
+    curl_unauthenticated('/metrics/v1/mbeans')
+    assert_allowed
+  end
 end

--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -13,6 +13,7 @@ puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
+puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice
 puppetlabs.services.jruby.jruby-metrics-service/jruby-metrics-service
 puppetlabs.services.analytics.analytics-service/analytics-service
 

--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -36,6 +36,9 @@ web-router-service: {
 
     # This controls the mount point for the status API
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
+
+    # This controls the mount point for the metrics API
+    "puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice": "/metrics"
 }
 
 # configuration for the JRuby interpreters

--- a/ezbake/config/conf.d/web-routes.conf
+++ b/ezbake/config/conf.d/web-routes.conf
@@ -10,4 +10,7 @@ web-router-service: {
 
     # This controls the mount point for the status API
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
+
+    # This controls the mount point for the metrics API
+    "puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice": "/metrics"
 }

--- a/ezbake/system-config/services.d/bootstrap.cfg
+++ b/ezbake/system-config/services.d/bootstrap.cfg
@@ -13,5 +13,6 @@ puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
 puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
+puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice
 puppetlabs.services.jruby.jruby-metrics-service/jruby-metrics-service
 puppetlabs.services.analytics.analytics-service/analytics-service


### PR DESCRIPTION
This commit adds the metrics webservice to the bootstrap and web routing
configs for both dev and packaging.  This commit includes a simple
beaker test which just confirms that a successful response is received
when the metrics endpoint is queried - basically just ensuring that the
endpoint is registered and that requests aren't being denied by
insufficent authentication.