### PR TITLE
(docs) Fix ssl-crl-path description

### DIFF
--- a/documentation/external_ca_configuration.markdown
+++ b/documentation/external_ca_configuration.markdown
@@ -45,7 +45,7 @@ use the correct SSL configuration:
 * `ssl-key`: The value of `puppet master --configprint hostprivkey`. Equivalent to the 'SSLCertificateKeyFile' Apache config setting.
 * `ssl-ca-cert`: The value of `puppet master --configprint localcacert`. Equivalent to the 'SSLCACertificateFile' Apache config setting.
 * `ssl-cert-chain`: Equivalent to the 'SSLCertificateChainFile' Apache config setting. Optional.
-* `ssl-crl-path`: Equivalent to the 'SSLCARevocationPath' Apache config setting. Optional.
+* `ssl-crl-path`: The path to the CRL file to use. Optional.
 
 An example `webserver.conf` file might look something like this:
 


### PR DESCRIPTION
Prior to this commit the ssl-crl-path config option was documented to be
equivalent to Apache's SSLCARevocationPath setting; but it is not.
Apache's config option allows you to specify a directory full of CRL
files (named via hash-value.rN).  Puppetserver supports using only one
CRL file.