### PR TITLE
(SERVER-1752) Port memory metrics from PE

### DIFF
--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -50,10 +50,27 @@
    ; https://github.com/puppetlabs/trapperkeeper-comidi-metrics/blob/0.1.1/src/puppetlabs/metrics/http.clj#L117-L120
    "num-cpus"])
 
+;; List of allowed jvm gauges/values
+(def default-jvm-metrics-allowed
+  ["uptime"
+   "memory.heap.committed"
+   "memory.heap.init"
+   "memory.heap.max"
+   "memory.heap.used"
+   "memory.non-heap.committed"
+   "memory.non-heap.init"
+   "memory.non-heap.max"
+   "memory.non-heap.used"
+   "memory.total.committed"
+   "memory.total.init"
+   "memory.total.max"
+   "memory.total.used"])
+
 (def default-metrics-allowed
   (concat
    default-metrics-allowed-hists
-   default-metrics-allowed-vals))
+   default-metrics-allowed-vals
+   default-jvm-metrics-allowed))
 
 (defservice master-service
   master/MasterService
@@ -109,6 +126,8 @@
      (retrieve-ca-cert! localcacert)
      (retrieve-ca-crl! hostcrl)
      (initialize-master-ssl! settings certname)
+
+     (core/register-jvm-metrics! registry metrics-server-id)
 
      (update-registry-settings :puppetserver
                                {:default-metrics-allowed default-metrics-allowed})

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -349,3 +349,82 @@
                     @reported-metrics-atom
                     :puppetserver
                     "puppetlabs.localhost.compiler.compile.production.mean")))))))))
+
+(deftest jvm-metrics-sent-to-graphite-test
+  (let [reported-metrics-atom (atom {})]
+    (with-redefs [metrics-core/build-graphite-sender
+                  (fn [_ domain]
+                    (metrics-testutils/make-graphite-sender reported-metrics-atom domain))]
+      (logutils/with-test-logging
+       (bootstrap-testutils/with-puppetserver-running
+        app
+        graphite-enabled-config
+        (let [registry (:registry (get-puppetserver-registry-context app))
+              get-memory-map
+              (fn [mem-type]
+                (ks/mapvals #(.getValue %)
+                            (filter #(.matches (key %) (format "puppetlabs.localhost.memory.%s.*" mem-type))
+                                    (.getMetrics registry))))
+              heap-memory-map (get-memory-map "heap")
+              non-heap-memory-map (get-memory-map "non-heap")
+              total-memory-map (get-memory-map "total")]
+          (testing "heap memory metrics work"
+            (= #{"puppetlabs.localhost.memory.heap.committed"
+                 "puppetlabs.localhost.memory.heap.init"
+                 "puppetlabs.localhost.memory.heap.max"
+                 "puppetlabs.localhost.memory.heap.used"} (ks/keyset heap-memory-map))
+            (is (every? #(< 0 %) (vals heap-memory-map))))
+
+          (testing "non-heap memory metrics work"
+            (= #{"puppetlabs.localhost.memory.non-heap.committed"
+                 "puppetlabs.localhost.memory.non-heap.init"
+                 "puppetlabs.localhost.memory.non-heap.max"
+                 "puppetlabs.localhost.memory.non-heap.used"}
+               (ks/keyset non-heap-memory-map))
+            ;; Some of the memory metrics don't propagate correctly on OS X, which can result in a
+            ;; value of -1. This is here so that these tests will pass when run in developers local
+            ;; environments.
+            (is (every? #(or (< 0 %) (= -1 %)) (vals non-heap-memory-map))))
+
+          (testing "total memory metrics work"
+            (= #{"puppetlabs.localhost.memory.total.committed"
+                 "puppetlabs.localhost.memory.total.init"
+                 "puppetlabs.localhost.memory.total.max"
+                 "puppetlabs.localhost.memory.total.used"}
+               (ks/keyset total-memory-map))
+            (is (every? #(< 0 %) (vals total-memory-map))))
+
+          (testing "uptime metric works"
+            (let [get-uptime (fn [] (-> registry
+                                        .getMetrics
+                                        (get "puppetlabs.localhost.uptime")
+                                        .getValue))
+                  uptime (get-uptime)]
+              (is (< 0 uptime))
+              ;; Make sure uptime can be updated after initialization.
+              (Thread/sleep 1)
+              (is (not= uptime (get-uptime))))))
+
+        (.report (get-puppetserver-graphite-reporter app))
+
+        (testing "jvm metrics are reported to graphite"
+          (is (every? #(metrics-testutils/reported? @reported-metrics-atom
+                                                    :puppetserver
+                                                    %)
+                      (map #(format "puppetlabs.localhost.memory.%s" %)
+                           ["heap.committed"
+                            "heap.init"
+                            "heap.max"
+                            "heap.used"
+                            "non-heap.committed"
+                            "non-heap.init"
+                            "non-heap.max"
+                            "non-heap.used"
+                            "total.committed"
+                            "total.init"
+                            "total.max"
+                            "total.used"])))
+
+          (is (metrics-testutils/reported? @reported-metrics-atom
+                                           :puppetserver
+                                           "puppetlabs.localhost.uptime"))))))))


### PR DESCRIPTION
This commit ports the jvm memory metrics and related tests from
pe-puppet-server-extensions

These metrics are a little redundant with the jvm metrics in the status
service, but they are documented and so we're porting them over to maintain
backwards compatibility