### PR TITLE
(SERVER-1264) Add beaker graphite metrics tests

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -1,4 +1,6 @@
 require 'beaker/dsl/install_utils'
+require 'net/http'
+require 'json'
 
 module PuppetServerExtensions
 
@@ -413,7 +415,177 @@ module PuppetServerExtensions
     modify_tk_config(host, authconf_file, authconf_hash, true)
   end
 
+  # parses text into json if possible
+  def parse_json(text)
+    begin
+      json = JSON.parse(text)
+    rescue JSON::ParserError => e
+      fail_test "Response body is not parseable JSON\n" +
+                    "Exception message: #{e.message}\n" +
+                    "Text to parse: #{text}\n"
+    end
+    return json
+  end
 
+  ###############################################################################
+  # Metrics Helpers
+  ###############################################################################
+  # returns the list of standard metrics fields
+  def metrics_fields
+    %w( count max min mean stddev p50 p75 p95 )
+  end
+
+  def standard_metrics
+    %w(
+      compiler
+      compiler.find_facts
+      compiler.find_node
+      functions
+      http.active-histo
+      http.puppet-v3-catalog-.*.-requests
+      http.puppet-v3-environment-.*.-requests
+      http.puppet-v3-environment_classes-.*.-requests
+      http.puppet-v3-environments-requests
+      http.puppet-v3-file_bucket_file-.*.-requests
+      http.puppet-v3-file_content-.*.-requests
+      http.puppet-v3-file_metadata-.*.-requests
+      http.puppet-v3-file_metadatas-.*.-requests
+      http.puppet-v3-node-.*.-requests
+      http.puppet-v3-report-.*.-requests
+      http.puppet-v3-static_file_content-.*.-requests
+      http.total-requests
+      jruby.borrow-timer
+      jruby.free-jrubies-histo
+      jruby.lock-held-timer
+      jruby.lock-wait-timer
+      jruby.requested-jrubies-histo
+      jruby.wait-timer
+    )
+  end
+
+  def single_field_metrics
+    %w(
+      http.active-requests.count
+      http.puppet-v3-catalog-.*.-percentage
+      http.puppet-v3-environment-.*.-percentage
+      http.puppet-v3-environment_classes-.*.-percentage
+      http.puppet-v3-environments-percentage
+      http.puppet-v3-file_bucket_file-.*.-percentage
+      http.puppet-v3-file_content-.*.-percentage
+      http.puppet-v3-file_metadata-.*.-percentage
+      http.puppet-v3-file_metadatas-.*.-percentage
+      http.puppet-v3-node-.*.-percentage
+      http.puppet-v3-report-.*.-percentage
+      http.puppet-v3-resource_type-.*.-percentage
+      http.puppet-v3-resource_types-.*.-percentage
+      http.puppet-v3-static_file_content-.*.-percentage
+      http.puppet-v3-status-.*.-percentage
+      num-cpus
+      uptime
+      jruby.borrow-count.count
+      jruby.borrow-retry-count.count
+      jruby.borrow-timeout-count.count
+      jruby.request-count.count
+      jruby.return-count.count
+      jruby.num-free-jrubies
+      jruby.num-jrubies
+    )
+  end
+
+  # returns an array of default metrics by building the standard field based
+  # metrics, then appending the single field metrics
+  def build_default_metrics
+    default_metrics = Array.new
+    standard_metrics.each do |sm|
+      metrics_fields.each do |f|
+        default_metrics << "#{sm}.#{f}"
+      end
+    end
+    default_metrics = default_metrics + single_field_metrics
+    return default_metrics
+  end
+
+  # Strips the nils recorded by the graphite system that occur when the
+  # graphite system is recording on a faster cadence than the puppetserver
+  # system
+  def strip_nils(json)
+    json.each do |json_member|
+      json_member['datapoints'].each_index do |i|
+        while ( json_member['datapoints'][i] != nil &&
+            json_member['datapoints'][i][0] == nil ) do
+          json_member['datapoints'].delete_at(i)
+        end
+      end
+    end
+  end
+
+  def metrics_target(master_hostname, metric_name)
+    return_string = "puppetlabs.#{master_hostname}.#{metric_name}"
+  end
+
+  def build_metrics_url(master, graphite_host, metrics, minutes)
+    url = "http://#{graphite_host}/render?"
+    url += "from=-#{minutes}minutes"
+    if metrics.is_a?(String)
+      url += '&target=' << metrics_target(master, metrics)
+    elsif metrics.is_a?(Array)
+      metrics.each do |m|
+        url += '&target=' << metrics_target(master, m)
+      end
+    end
+    url += '&format=json'
+  end
+
+  # returns a hash of metrics results
+  def query_metrics(master_hostname, graphite_hostname, metrics, minutes=10)
+    sleep_between_queries = 5
+    seconds_remaining = minutes * 60
+    full_results = Hash.new
+    metrics.each do |m|
+      url       = build_metrics_url(master_hostname, graphite_hostname, m, minutes)
+      uri       = URI.parse(url)
+      cont = true
+      loop do
+        response = Net::HTTP.get_response(uri)
+        assert_equal("200", response.code, 'Expected response code 200')
+        json = parse_json(response.body)
+        loop_results = strip_nils(json)
+        case
+          when (loop_results.size != 0 &&
+              loop_results[0]['datapoints'].size != 0)
+            full_results["#{master_hostname}.#{m}"] =
+                loop_results[0]['datapoints']
+            cont = false
+          when seconds_remaining > 0
+            logger.info "#{m} metric not found in graphite, waiting " \
+              "#{sleep_between_queries} seconds before trying to get it again"
+            sleep sleep_between_queries
+            seconds_remaining -= sleep_between_queries
+          else
+            cont = false
+        end
+        break if !cont
+      end
+    end
+    return full_results
+  end
+
+  # builds and returns an array of missing metrics names.
+  # expected metrics is an array of metric names, typically generated with
+  # the build_default_metrics method
+  # actual_metrics_results is an array of arrays, typically generated with the
+  # query_metrics method.
+  def build_missing_metrics_list(master_hostname, expected_metrics, actual_metrics_results)
+    missing_metrics = Array.new
+    expected_metrics.each do |m|
+      if ( !actual_metrics_results.include?("#{master_hostname}.#{m}") ||
+          !actual_metrics_results["#{master_hostname}.#{m}"].class == Array ||
+          actual_metrics_results["#{master_hostname}.#{m}"].empty? )
+        missing_metrics << "#{master_hostname}.#{m}"
+      end
+    end
+    return missing_metrics
+  end
 end
 
 Beaker::TestCase.send(:include, PuppetServerExtensions)

--- a/acceptance/suites/tests/metrics/collect_default_metrics.rb
+++ b/acceptance/suites/tests/metrics/collect_default_metrics.rb
@@ -24,6 +24,15 @@ teardown do
   bounce_service(master, puppetservice)
 end
 
+# This test assumes that at least some function metrics will be exported by
+# the server.  For OSS, we create a manifest with a function in it, generate(),
+# which should provoke the use of some function metrics during catalog
+# compilation for an agent.  For PE, we shouldn't need to create a special
+# manifest since any PE agent run should automatically have some functions
+# exercised as part of its catalog compilation.  This test avoids putting the
+# special manifest in place for PE in order to avoid unnecessarily dirtying up
+# the code directory before any downstream tests are run, e.g., in the event
+# that file sync is enabled.
 if !master.is_pe?
   step 'Configuring manifest for exercising function metrics in agent run' do
     on master, "mkdir -p #{manifests_dir}"

--- a/acceptance/suites/tests/metrics/collect_default_metrics.rb
+++ b/acceptance/suites/tests/metrics/collect_default_metrics.rb
@@ -41,6 +41,18 @@ step 'Install graphite (and grafana)' do
 
   on(graphite, "puppet module install cprice404-grafanadash --codedir #{tmp_module_dir}")
   on(graphite, "puppet apply -e \"include grafanadash::dev\" --codedir #{tmp_module_dir}")
+
+  # Set max_creates_per_minute to 'inf' (in place of smaller default) in order
+  # to speed up how quickly Graphite makes newly-created metrics available to
+  # be queried - and, therefore, hopefully make this test run much more quickly.
+  graphitepp = "#{tmp_module_dir}/graphite.pp"
+  create_remote_file(master, graphitepp, <<GRAPHITEPP)
+class { 'graphite':
+  gr_web_cors_allow_from_all => true,
+  gr_max_creates_per_minute => inf,
+}
+GRAPHITEPP
+  on(graphite, "puppet apply #{graphitepp} --codedir #{tmp_module_dir}")
 end
 
 step 'Enable graphite and profiler metrics in puppetserver configuration' do

--- a/acceptance/suites/tests/metrics/collect_default_metrics.rb
+++ b/acceptance/suites/tests/metrics/collect_default_metrics.rb
@@ -11,8 +11,8 @@ manifests_dir = "#{environments_dir}/production/manifests"
 sitepp = "#{manifests_dir}/site.pp"
 
 step 'Backup puppetserver config files' do
-  on master, "cp -f #{puppetserver_conf_file} #{puppetserver_conf_file}.bak"
-  on master, "cp -f #{metrics_conf_file} #{metrics_conf_file}.bak"
+  on master, "cp -pf #{puppetserver_conf_file} #{puppetserver_conf_file}.bak"
+  on master, "cp -pf #{metrics_conf_file} #{metrics_conf_file}.bak"
 end
 
 teardown do

--- a/acceptance/suites/tests/metrics/collect_default_metrics.rb
+++ b/acceptance/suites/tests/metrics/collect_default_metrics.rb
@@ -1,0 +1,96 @@
+test_name 'Default metrics are exported to graphite server'
+
+graphite = agents.find { |agent| agent['platform'] =~ /el-6-x86_64/ }
+skip_test 'This test requires an el6 agent' unless graphite
+
+puppetserver_conf_file = options['puppetserver-config']
+metrics_conf_file = "#{options['puppetserver-confdir']}/metrics.conf"
+puppetservice = options['puppetservice']
+environments_dir = "/etc/puppetlabs/code/environments"
+manifests_dir = "#{environments_dir}/production/manifests"
+sitepp = "#{manifests_dir}/site.pp"
+
+step 'Backup puppetserver config files' do
+  on master, "cp -f #{puppetserver_conf_file} #{puppetserver_conf_file}.bak"
+  on master, "cp -f #{metrics_conf_file} #{metrics_conf_file}.bak"
+end
+
+teardown do
+  on master, "mv -f #{puppetserver_conf_file}.bak #{puppetserver_conf_file}"
+  on master, "mv #{metrics_conf_file}.bak #{metrics_conf_file}"
+  if !master.is_pe?
+    on master, "rm -f #{sitepp}"
+  end
+  bounce_service(master, puppetservice)
+end
+
+if !master.is_pe?
+  step 'Configuring manifest for exercising function metrics in agent run' do
+    on master, "mkdir -p #{manifests_dir}"
+    create_remote_file(master, sitepp, <<SITEPP)
+notify { 'hello':
+  message => generate("/bin/echo", "world")
+}
+SITEPP
+    on(master, "chown -R puppet #{environments_dir}")
+  end
+end
+
+step 'Install graphite (and grafana)' do
+  tmp_module_dir = agent.tmpdir('collect_default_metrics')
+
+  on(graphite, "puppet module install cprice404-grafanadash --codedir #{tmp_module_dir}")
+  on(graphite, "puppet apply -e \"include grafanadash::dev\" --codedir #{tmp_module_dir}")
+end
+
+step 'Enable graphite and profiler metrics in puppetserver configuration' do
+  metrics_config =
+      {"metrics" =>
+           {"server-id" => master.hostname,
+            "registries" =>
+                {"puppetserver" =>
+                     {"reporters" =>
+                          {"graphite" =>
+                               {"enabled" => true,
+                                "update-interval-seconds" => 1}}}},
+            "reporters" =>
+                {"graphite" =>
+                     {"host" => agent.hostname,
+                      "port" => 2003,
+                      "update-interval-seconds" => 1}}}};
+
+  modify_tk_config(master, metrics_conf_file, metrics_config)
+
+  profiler_config = {"profiler" => {"enabled" => true}}
+  modify_tk_config(master, puppetserver_conf_file, profiler_config)
+
+  bounce_service(master, puppetservice)
+end
+
+step 'Generate some metrics by performing an agent run' do
+  on(graphite, puppet("agent -t --no-use_cached_catalog --server #{master}"),
+                       :acceptable_exit_codes => [0, 2])
+end
+
+default_metrics = build_default_metrics
+full_results = Hash.new
+
+step 'Query the graphite system for the default list of metrics' do
+  full_results = query_metrics(master.hostname, graphite, default_metrics)
+
+  puts "List of collected metrics:"
+  full_results.each do |key, val|
+    logger.info "#{key} => #{val[-1]}"
+  end
+end
+
+step 'Validate that all metrics expected to be exported are in graphite server' do
+  missing_metrics = build_missing_metrics_list(master, default_metrics, full_results)
+
+  if missing_metrics.size != 0
+    missing_metrics.each do |mm|
+      logger.error "Expected to find a value for missing metric #{mm}"
+    end
+    assert(false, "FAIL: There are missing metrics.")
+  end
+end


### PR DESCRIPTION
This commit adds a beaker acceptance test, collect_default_metrics,
which sets up a Graphite server, configures Puppet Server to export
metrics to it, and confirms that the default set of metrics that the
server should export are actually exported.  This test is configured to
run on el-6 only because the underlying Puppet module used to setup the
Graphite server, cprice404/grafanadash, only supports el-6 at present.

I copied the bulk of this over from the Graphite beaker tests that we've
been running in PE Puppet Server.  See:

* ![collect_default_metrics test](https://github.com/puppetlabs/pe-puppet-server-extensions/blob/2017.2.0.1/acceptance/suites/tests/file_sync/x-collect_default_metrics.rb)
* ![metrics helpers](https://github.com/puppetlabs/pe-puppet-server-extensions/blob/2017.2.0.1/acceptance/lib/helper.rb#L338-L551)
* ![graphite setup](https://github.com/puppetlabs/pe-puppet-server-extensions/blob/2017.2.0.1/acceptance/suites/pre_suite/file_sync/65_enable_metrics.rb#L39-L40)

I left out the verification of the `puppetdb.*` metrics which was being
done in the PE version of the test.  I did this because, even though we
have a separate [beaker test which sets up puppetdb](https://github.com/puppetlabs/puppetserver/blob/2.7.2/acceptance/suites/tests/00_smoke/puppetdb_integration.rb), I didn't
want to require a specific execution order among the tests.