### PR TITLE
(SERVER-1758) Add environment_modules endpoint

### DIFF
--- a/documentation/puppet-api/v3/environment_modules.json
+++ b/documentation/puppet-api/v3/environment_modules.json
@@ -16,7 +16,7 @@
           },
           "version": {
             "description": "The version of the puppet module",
-            "type": "string"
+            "type": ["string","null"]
           }
         },
         "required": ["name", "version"],

--- a/documentation/puppet-api/v3/environment_modules.markdown
+++ b/documentation/puppet-api/v3/environment_modules.markdown
@@ -16,10 +16,55 @@ on Ruby Puppet masters, such as the [deprecated WEBrick Puppet master][]. It als
 the Ruby-based Puppet master's authorization methods and configuration. See the
 [Authorization section](#authorization) for more information.
 
-## `GET /puppet/v3/environment_modules?environment=:environment`
+## `GET /puppet/v3/environment_modules`
 
-Making a request with no query parameters is not supported and returns an HTTP 400 (Bad
-Request) response.
+### Supported HTTP Methods
+
+GET
+
+### Supported Formats
+
+JSON
+
+### Responses
+
+#### GET request with results
+
+```
+GET /puppet/v3/environment_modules
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[{
+    "modules": [
+        {
+            "name": "puppetlabs/ntp",
+            "version": "6.0.0"
+        },
+        {
+            "name": "puppetlabs/stdlib",
+            "version": "4.14.0"
+        }
+    ],
+    "name": "env"
+},
+{
+    "modules": [
+        {
+            "name": "puppetlabs/stdlib",
+            "version": "4.14.0"
+        },
+        {
+            "name": "puppetlabs/azure",
+            "version": "1.1.0"
+        }
+    ],
+    "name": "production"
+}]
+```
+
+## `GET /puppet/v3/environment_modules?environment=:environment`
 
 ### Supported HTTP Methods
 
@@ -107,10 +152,68 @@ HTTP/1.1 400 Bad Request
 The environment must be purely alphanumeric, not 'bog|us'
 ```
 
+### No metadata.json file
+
+If your modules do not have a [metadata.json](https://docs.puppet.com/puppet/latest/modules_metadata.html)
+file, puppetserver will not be able to determine the version of your module. In
+this case, puppetserver will return a null value for `version` in the response
+body.
+
 ### Schema
 
 An environment modules response body conforms to the
 [environment modules schema](./environment_modules.json).
+
+#### Validating your json
+
+If you have a response body that you'd like to validate against the
+[environment_modules.json](./environment_modules.json) schema, you can do so using the ruby library
+[json-schema](https://github.com/ruby-json-schema/json-schema).
+
+First, install the ruby gem to be used:
+
+```bash
+gem install json-schema
+```
+
+Next, given a json file, you can validate its schema.
+
+Here is a basic json file called _example.json_:
+
+```json
+{
+    "modules": [
+        {
+            "name": "puppetlabs/ntp",
+            "version": "6.0.0"
+        },
+        {
+            "name": "puppetlabs/stdlib",
+            "version": "4.16.0"
+        }
+    ],
+    "name": "production"
+}
+```
+
+Run this command from the root dir of the puppetserver project (or update the
+path to the json schema file in the command below):
+
+```bash
+ruby -rjson-schema -e "puts JSON::Validator.validate!('./documentation/puppet-api/v3/environment_modules.json','example.json')"
+```
+
+If the json is a valid schema, the command should output `true`. Otherwise, the
+library will print a schema validation error detailing which key or keys validate
+the schema.
+
+If you have a response that is the entire list of environment modules (i.e. the
+environment_modules endpoint), you will need to use this command to validate
+the json schema:
+
+```bash
+ruby -rjson-schema -e "puts JSON::Validator.validate!('./documentation/puppet-api/v3/environment_modules.json','all.json', :list=>true)"
+```
 
 ### Authorization
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -73,6 +73,10 @@
     [this jruby-instance env-name]
     (.getModuleInfoForEnvironment jruby-instance env-name))
 
+  (get-all-environment-module-info
+    [this jruby-instance]
+    (.getModuleInfoForAllEnvironments jruby-instance))
+
   (get-environment-class-info-tag
    [this env-name]
    (let [environment-class-info (:environment-class-info-tags

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -54,6 +54,10 @@
     [this jruby-instance env-name]
     "Get module information for a specific environment")
 
+  (get-all-environment-module-info
+    [this jruby-instance]
+    "Get all module information for all environments")
+
   (flush-jruby-pool!
     [this]
     "Flush all the current JRuby instances and repopulate the pool.")

--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -18,6 +18,7 @@ import java.util.List;
 public interface JRubyPuppet {
     Map getClassInfoForEnvironment(String environment);
     List getModuleInfoForEnvironment(String environment);
+    Map getModuleInfoForAllEnvironments();
     JRubyPuppetResponse handleRequest(Map request);
     Object getSetting(String setting);
     String puppetVersion();

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -77,6 +77,15 @@ class Puppet::Server::Master
     end
   end
 
+  def getModuleInfoForAllEnvironments()
+    all_envs = @env_loader.list
+    all_mod_data = {}
+    all_envs.each { |env|
+      all_mod_data[env.name] = self.class.getModules(env)
+    }
+    all_mod_data
+  end
+
   def getSetting(setting)
     Puppet[setting]
   end
@@ -97,15 +106,11 @@ class Puppet::Server::Master
 
   def self.getModules(env)
     env.modules.collect do |mod|
-      module_data = {}
-
       # NOTE: If in the future we want to collect more
       #       Module settings, this should be more programatic
       #       rather than getting these settings one by one
-      module_data[:name] = mod.forge_name
-      module_data[:version] = mod.version
-
-      module_data
+      {:name    => mod.forge_name ||= mod.name,
+       :version => mod.version}
     end
   end
 


### PR DESCRIPTION
This commit adds new functionality to the environment_modules endpoint.
It now allows users to not specify a query param for the endpoint. If
one is not provided, puppetserver will return all modules for all
environments in a single request.

__TODO__:

- [x] update the integration tests for the new endpoint, hopefully testing that multiple modules are returned for multiple environments
- [x] update the docs with information on the new endpoint