### PR TITLE
(SERVER-1737) Add http client metrics to status

### DIFF
--- a/dev-resources/puppetlabs/services/master/master_service_test/confdir/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/master_service_test/confdir/puppet.conf
@@ -2,3 +2,7 @@
 certname = localhost
 node_terminus = exec
 external_nodes = "/bin/sh ./dev-resources/puppetlabs/services/master/master_service_test/enc.sh"
+reports = http
+
+# so long as the host and port are accessible, the endpoint here doesn't matter
+reporturl = https://localhost:8140/fake

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -464,11 +464,13 @@
         {:status 200
          :body (get-code-content environment code-id file-path)}))))
 
+(def MetricIdsForStatus (schema/atom [[schema/Str]]))
+
 (schema/defn http-client-metrics-summary
   :- {:metrics-data [http-client-common/MetricIdMetricData]
       :sorted-metrics-data [http-client-common/MetricIdMetricData]}
   [metric-registry :- MetricRegistry
-   metric-ids-to-select :- (schema/atom [[schema/Str]])]
+   metric-ids-to-select :- MetricIdsForStatus]
   (let [metrics-data (map #(http-client-metrics/get-client-metrics-data-by-metric-id metric-registry %)
                           @metric-ids-to-select)
         flattened-data (flatten metrics-data)]
@@ -757,13 +759,13 @@
    ["puppetdb" "resource" "search"]])
 
 (schema/defn ^:always-validate add-metric-ids-to-http-client-metrics-list!
-  [metric-id-atom :- (schema/atom [[schema/Str]])
+  [metric-id-atom :- MetricIdsForStatus
    metric-ids-to-add :- [[schema/Str]]]
   (swap! metric-id-atom concat metric-ids-to-add))
 
 (schema/defn ^:always-validate v1-status :- status-core/StatusCallbackResponse
   [http-metrics :- http-metrics/HttpMetrics
-   http-client-metric-ids-for-status :- (schema/atom [[schema/Str]])
+   http-client-metric-ids-for-status :- MetricIdsForStatus
    metric-registry :- MetricRegistry
    level :- status-core/ServiceStatusDetailLevel]
   (let [level>= (partial status-core/compare-levels >= level)]

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -3,7 +3,6 @@
            (clojure.lang IFn)
            (java.util List Map Map$Entry)
            (org.jruby RubySymbol)
-           (org.eclipse.jetty.util URIUtil)
            (com.codahale.metrics MetricRegistry Gauge)
            (java.lang.management ManagementFactory))
   (:require [me.raynes.fs :as fs]
@@ -24,6 +23,8 @@
             [puppetlabs.i18n.core :as i18n]
             [puppetlabs.metrics :as metrics]
             [puppetlabs.metrics.http :as http-metrics]
+            [puppetlabs.http.client.metrics :as http-client-metrics]
+            [puppetlabs.http.client.common :as http-client-common]
             [puppetlabs.trapperkeeper.services.status.status-core :as status-core]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -463,6 +464,16 @@
         {:status 200
          :body (get-code-content environment code-id file-path)}))))
 
+(schema/defn http-client-metrics-summary
+  :- {:metrics-data [http-client-common/MetricIdMetricData]
+      :sorted-metrics-data [http-client-common/MetricIdMetricData]}
+  [metric-registry :- MetricRegistry
+   metric-ids-to-select :- (schema/atom [[schema/Str]])]
+  (let [metrics-data (map #(http-client-metrics/get-client-metrics-data-by-metric-id metric-registry %)
+                          @metric-ids-to-select)
+        flattened-data (flatten metrics-data)]
+    {:metrics-data flattened-data
+     :sorted-metrics-data (sort-by :aggregate > flattened-data)}))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing
 
@@ -732,10 +743,28 @@
                  environment-class-cache-enabled)))
 
 (def MasterStatusV1
-  {(schema/optional-key :experimental) {:http-metrics [http-metrics/RouteSummary]}})
+  {(schema/optional-key :experimental) {:http-metrics [http-metrics/RouteSummary]
+                                        :http-client-metrics [http-client-common/MetricIdMetricData]}})
+
+(def puppet-server-http-client-metrics-for-status
+  [["puppet" "report" "http"]
+   ["puppetdb" "command" "replace_catalog"]
+   ["puppetdb" "command" "replace_facts"]
+   ["puppetdb" "command" "store_report"]
+   ["puppetdb" "facts" "find"]
+   ["puppetdb" "facts" "search"]
+   ["puppetdb" "query"]
+   ["puppetdb" "resource" "search"]])
+
+(schema/defn ^:always-validate add-metric-ids-to-http-client-metrics-list!
+  [metric-id-atom :- (schema/atom [[schema/Str]])
+   metric-ids-to-add :- [[schema/Str]]]
+  (swap! metric-id-atom concat metric-ids-to-add))
 
 (schema/defn ^:always-validate v1-status :- status-core/StatusCallbackResponse
   [http-metrics :- http-metrics/HttpMetrics
+   http-client-metric-ids-for-status :- (schema/atom [[schema/Str]])
+   metric-registry :- MetricRegistry
    level :- status-core/ServiceStatusDetailLevel]
   (let [level>= (partial status-core/compare-levels >= level)]
     {:state :running
@@ -744,7 +773,14 @@
               {}
               ;; no extra status at ':info' level yet
               (level>= :info) identity
-              (level>= :debug) (assoc-in [:experimental :http-metrics] (:sorted-routes (http-metrics/request-summary http-metrics))))}))
+              (level>= :debug) (-> (assoc-in [:experimental :http-metrics]
+                                             (:sorted-routes
+                                              (http-metrics/request-summary http-metrics)))
+                                   (assoc-in [:experimental :http-client-metrics]
+                                             (:sorted-metrics-data
+                                              (http-client-metrics-summary
+                                               metric-registry
+                                               http-client-metric-ids-for-status)))))}))
 
 (def resources-root "puppetlabs/puppetserver/public")
 (def js-resources-root (str resources-root "/js"))

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -11,7 +11,8 @@
             [puppetlabs.services.protocols.master :as master]
             [puppetlabs.i18n.core :as i18n]
             [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
-            [puppetlabs.services.master.master-core :as master-core]))
+            [puppetlabs.services.master.master-core :as master-core]
+            [clojure.string :as str]))
 
 (def master-service-status-version 1)
 
@@ -68,11 +69,16 @@
    "memory.total.max"
    "memory.total.used"])
 
+(def http-client-metrics-allowed-hists
+  (map #(format "http-client.experimental.with-metric-id.%s.full-response" (str/join "." %))
+       master-core/puppet-server-http-client-metrics-for-status))
+
 (def default-metrics-allowed
   (concat
    default-metrics-allowed-hists
    default-metrics-allowed-vals
-   default-jvm-metrics-allowed))
+   default-jvm-metrics-allowed
+   http-client-metrics-allowed-hists))
 
 (defservice master-service
   master/MasterService

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -10,7 +10,8 @@
             [puppetlabs.metrics.http :as http-metrics]
             [puppetlabs.services.protocols.master :as master]
             [puppetlabs.i18n.core :as i18n]
-            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]))
+            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
+            [puppetlabs.services.master.master-core :as master-core]))
 
 (def master-service-status-version 1)
 
@@ -123,12 +124,13 @@
          route-metadata (comidi/route-metadata routes)
          comidi-handler (comidi/routes->handler routes)
          registry (get-metrics-registry :puppetserver)
-         metrics (http-metrics/initialize-http-metrics!
-                  registry
-                  metrics-server-id
-                  route-metadata)
+         http-metrics (http-metrics/initialize-http-metrics!
+                       registry
+                       metrics-server-id
+                       route-metadata)
+         http-client-metric-ids-for-status (atom master-core/puppet-server-http-client-metrics-for-status)
          ring-handler (-> comidi-handler
-                          (http-metrics/wrap-with-request-metrics metrics)
+                          (http-metrics/wrap-with-request-metrics http-metrics)
                           (comidi/wrap-with-route-metadata routes))
          hostcrl (get-in config [:puppetserver :hostcrl])]
 
@@ -165,9 +167,18 @@
       "master"
       (status-core/get-artifact-version "puppetlabs" "puppetserver")
       master-service-status-version
-      (partial core/v1-status metrics))
-     (assoc context :http-metrics metrics)))
+      (partial core/v1-status http-metrics http-client-metric-ids-for-status registry))
+     (-> context
+         (assoc :http-metrics http-metrics)
+         (assoc :http-client-metric-ids-for-status http-client-metric-ids-for-status))))
   (start
     [this context]
     (log/info (i18n/trs "Puppet Server has successfully started and is now ready to handle requests"))
-    context))
+    context)
+
+  (add-metric-ids-to-http-client-metrics-list!
+   [this metric-ids-to-add]
+   (let [metric-ids-from-context (:http-client-metric-ids-for-status
+                                  (tk-services/service-context this))]
+     (master-core/add-metric-ids-to-http-client-metrics-list! metric-ids-from-context
+                                                              metric-ids-to-add))))

--- a/src/clj/puppetlabs/services/protocols/master.clj
+++ b/src/clj/puppetlabs/services/protocols/master.clj
@@ -1,4 +1,10 @@
 (ns puppetlabs.services.protocols.master)
 
 (defprotocol MasterService
-  "Protocol placeholder for the master service.")
+  "Protocol for the master service."
+
+  (add-metric-ids-to-http-client-metrics-list!
+    [this metric-ids-to-add]
+   "Append a list of metric-ids to the built in list (defined in
+   `master-core/puppet-server-http-client-metrics-for-status`) that gets included in the
+   `http-client-metrics` key in the status endpoint."))

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -512,9 +512,6 @@
                  (testing "only includes exact metric-ids it's supposed to have"
                    (make-request-with-metric-id "['puppetdb', 'command', 'replace_catalog', 'foonode']")
                    (let [metric-ids (map :metric-id (get-http-client-metrics-status))]
-                     (is (some #(= ["puppetdb" "command" "replace_catalog"] %) metric-ids))
-                     (is (not-any? #(= ["puppetdb" "command" "replace_catalog" "foodnode"] %)
-                                   metric-ids))
                      (is (= #{["puppetdb" "query"] ["puppetdb" "command" "replace_catalog"]}
                             (set metric-ids)))))
 
@@ -648,7 +645,7 @@
            container (:scripting-container jruby-instance)]
        (try
          ;; we don't care at all about the content of the report, just that it is valid
-         (let [report (.runScriptlet container "Puppet::Transaction::Report.new('apply').to_pson")]
+         (let [report (.runScriptlet container "Puppet::Transaction::Report.new('apply').to_json")]
            (logutils/with-test-logging
             ;; this test relies on the http report processor being configured in the puppet.conf
             ;; defined by `test-resources-puppet-conf`. We don't care whether the report is actually

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -22,7 +22,8 @@
     [puppetlabs.trapperkeeper.services.metrics.metrics-testutils :as metrics-testutils]
     [puppetlabs.trapperkeeper.services :as tk]
     [clojure.string :as str]
-    [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]))
+    [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
+    [schema.test :as schema-test]))
 
 (def test-resources-path "./dev-resources/puppetlabs/services/master/master_service_test")
 (def test-resources-code-dir (str test-resources-path "/codedir"))
@@ -31,6 +32,7 @@
 (def master-service-test-runtime-dir "target/master-service-test")
 
 (use-fixtures :once
+              schema-test/validate-schemas
               (fn [f]
                 (testutils/with-config-dirs
                  {test-resources-conf-dir

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -19,7 +19,10 @@
     [puppetlabs.services.puppet-profiler.puppet-profiler-core :as puppet-profiler-core]
     [puppetlabs.services.protocols.puppet-profiler :as profiler-protocol]
     [puppetlabs.trapperkeeper.services.metrics.metrics-core :as metrics-core]
-    [puppetlabs.trapperkeeper.services.metrics.metrics-testutils :as metrics-testutils]))
+    [puppetlabs.trapperkeeper.services.metrics.metrics-testutils :as metrics-testutils]
+    [puppetlabs.trapperkeeper.services :as tk]
+    [clojure.string :as str]
+    [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]))
 
 (def test-resources-path "./dev-resources/puppetlabs/services/master/master_service_test")
 (def test-resources-code-dir (str test-resources-path "/codedir"))
@@ -440,3 +443,160 @@
          (is (metrics-testutils/reported? @reported-metrics-atom
                                           :puppetserver
                                           "puppetlabs.localhost.uptime")))))))
+
+(defn get-http-client-metrics-status
+  []
+  (-> "/status/v1/services/master?level=debug"
+      http-get
+      :body
+      (json/parse-string true)
+      (get-in [:status :experimental :http-client-metrics])))
+
+(deftest ^:integration master-service-http-client-metrics
+  (testing "HTTP client metrics are present in the master status"
+    (bootstrap-testutils/with-puppetserver-running
+     app
+     {:jruby-puppet {:max-active-instances 1
+                     :master-code-dir test-resources-code-dir
+                     :master-conf-dir master-service-test-runtime-dir}
+      :metrics {:server-id "localhost"}}
+     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+           jruby-instance (jruby-testutils/borrow-instance jruby-service :http-client-metrics-test)
+           container (:scripting-container jruby-instance)]
+       (try
+         (.runScriptlet
+          container
+          ;; create a client and assign it to a global variable
+          (format "$c = Puppet::Server::HttpClient.new('localhost', %d, {:use_ssl => %s});"
+                  8140 true))
+         (let [make-request-with-metric-id (fn [metric-id-as-string]
+                                             (.runScriptlet
+                                              container
+                                              ;; So long as the server and port are accessible, it
+                                              ;; doesn't actually matter whether the endpoint is
+                                              ;; reachable or not - we just need to make requests
+                                              ;; with the given metric ids.
+                                              (format "$c.get('/fake', {}, {:metric_id => %s})"
+                                                      metric-id-as-string)))]
+           (testing "http-client-metrics key in master status"
+             (testing "empty array if no requests have been made"
+               (is (= [] (get-http-client-metrics-status))))
+
+             (testing "doesn't include metrics for metric-ids it is not supposed to have"
+               (make-request-with-metric-id "['fake', 'fake', 'fakery']")
+               (is (= [] (get-http-client-metrics-status))))
+
+             (testing "includes metrics for metric-ids it is supposed to have"
+               (make-request-with-metric-id "['puppetdb', 'query']")
+               (is (= [["puppetdb" "query"]] (map :metric-id (get-http-client-metrics-status)))))
+
+             (testing "only includes exact metric-ids it's supposed to have"
+               (make-request-with-metric-id "['puppetdb', 'command', 'replace_catalog', 'foonode']")
+               (let [metric-ids (map :metric-id (get-http-client-metrics-status))]
+                 (is (some #(= ["puppetdb" "command" "replace_catalog"] %) metric-ids))
+                 (is (not-any? #(= ["puppetdb" "command" "replace_catalog" "foodnode"] %)
+                               metric-ids))
+                 (is (= #{["puppetdb" "query"] ["puppetdb" "command" "replace_catalog"]}
+                        (set metric-ids)))))
+
+             (testing "includes all metrics it is supposed to have"
+               (make-request-with-metric-id "['puppet', 'report', 'http']")
+               (make-request-with-metric-id "['puppetdb', 'command', 'replace_facts', 'foonode']")
+               (make-request-with-metric-id "['puppetdb', 'command', 'store_report', 'foonode']")
+               (make-request-with-metric-id "['puppetdb', 'facts', 'find', 'foonode']")
+               (make-request-with-metric-id "['puppetdb', 'facts', 'search']")
+               (make-request-with-metric-id "['puppetdb', 'resource', 'search', 'Package']")
+               (= (set master-core/puppet-server-http-client-metrics-for-status)
+                  (set (map :metric-id (get-http-client-metrics-status)))))
+
+             (testing "all metrics contain information they are supposed to have"
+               (let [metrics (get-http-client-metrics-status)]
+                 (testing "contains correct keys"
+                   (is (every?
+                        #(= #{:metric-id :metric-name :count :mean :aggregate} (set (keys %)))
+                        metrics)))
+                 (testing "count is correct"
+                   (is (every? #(= 1 %) (map :count metrics))))
+                 (testing "mean is correct"
+                   (is (every? #(< 0 %) (map :mean metrics))))
+                 (testing "aggregate is correct"
+                   ;; since each metric-id has only been hit once, aggregate and mean should be the
+                   ;; same
+                   (is (every? (fn [{:keys [aggregate mean]}] #(= aggregate mean)) metrics)))
+                 (testing "metric-name is correct"
+                   (is (= (set (map #(str/join "." %)
+                                    master-core/puppet-server-http-client-metrics-for-status))
+                          (set (map
+                                ;; re-find returns a vector of results, the second element being the
+                                ;; capture match
+                                #(second
+                                  (re-find
+                                   #"puppetlabs.localhost.http-client.experimental.with-metric-id.(.*).full-response"
+                                   (:metric-name %)))
+                                metrics)))))))))
+         (finally
+           (jruby-testutils/return-instance jruby-service jruby-instance :http-client-metrics-test)))))))
+
+(deftest ^:integration add-metric-ids-to-http-client-metrics-list-test
+  (let [test-service (tk/service
+                      [[:MasterService add-metric-ids-to-http-client-metrics-list!]]
+                      (init [this context]
+                            (add-metric-ids-to-http-client-metrics-list! [["foo" "bar"]
+                                                                          ["hello" "cruel" "world"]])
+                            context))]
+    (testing "add-metric-ids-to-http-client-metrics-list-fn works"
+      (bootstrap-testutils/with-puppetserver-running-with-services
+       app
+       (conj bootstrap-testutils/services-from-dev-bootstrap
+             test-service)
+       {:jruby-puppet {:max-active-instances 1
+                       :master-code-dir test-resources-code-dir
+                       :master-conf-dir master-service-test-runtime-dir}
+        :metrics {:server-id "localhost"}}
+       (testing "atom has correct metric-ids"
+         (let [master-service (tk-app/get-service app :MasterService)
+               context (tk-services/service-context master-service)]
+           (is (= (set (conj master-core/puppet-server-http-client-metrics-for-status
+                             ["foo" "bar"] ["hello" "cruel" "world"]))
+                  (set @(:http-client-metric-ids-for-status context))))))
+       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+             jruby-instance (jruby-testutils/borrow-instance jruby-service :add-metric-ids-test)
+             container (:scripting-container jruby-instance)]
+         (try
+           (.runScriptlet
+            container
+            ;; create a client and assign it to a global variable
+            (format "$c = Puppet::Server::HttpClient.new('localhost', %d, {:use_ssl => %s});"
+                    8140 true))
+
+           (let [make-request-with-metric-id (fn [metric-id-as-string]
+                                               (.runScriptlet
+                                                container
+                                                ;; So long as the server and port are accessible, it
+                                                ;; doesn't actually matter whether the endpoint is
+                                                ;; reachable or not - we just need to make requests
+                                                ;; with the given metric ids.
+                                                (format "$c.get('/fake', {}, {:metric_id => %s})"
+                                                        metric-id-as-string)))]
+             (testing "http-client-metrics key in master status"
+               (make-request-with-metric-id "['foo', 'bar', 'baz']")
+               (make-request-with-metric-id "['hello', 'cruel', 'world']")
+               (make-request-with-metric-id "['puppetdb', 'query']")
+               (make-request-with-metric-id "['fake', 'fake', 'fakery']")
+               (let [metric-ids (map :metric-id (get-http-client-metrics-status))]
+
+                 (testing "has metric-ids from master service"
+                   (is (some #(= ["puppetdb" "query"] %) metric-ids)))
+
+                 (testing "has metric-ids added by `add-metric-ids-to-http-client-metrics-list`"
+                   (is (some #(= ["foo" "bar"] %) metric-ids))
+                   (is (some #(= ["hello" "cruel" "world"] %) metric-ids)))
+
+                 (testing "doesn't include metrics for metric-ids it is not supposed to have"
+                   (is (not-any? #(= ["fake" "fake" "fakery"] %) metric-ids)))
+
+                 (testing "has correct set of metric-ids"
+                   (is (= #{["foo" "bar"] ["hello" "cruel" "world"] ["puppetdb" "query"]}
+                          (set metric-ids)))))))
+           (finally
+             (jruby-testutils/return-instance jruby-service jruby-instance :add-metric-ids-test))))))))


### PR DESCRIPTION
Pull out specific http client metrics and add them to the master service
status endpoint under an `http-client-metrics` key.

Since other services (specifically, the pe-master service) may have http
client metrics that they would like to add to this list to be included in the
status, the metric ids to be included in the status are registered in an atom
in the service context, and there is a new service function
`add-metric-ids-to-http-client-metrics-list!` that will append metric ids to
this list.

Add these metrics to the list of `default-metrics-allowed` that will be exported to graphite.
