### PR TITLE
(SERVER-1264) Use proper server when updating graphite in beaker test

### DIFF
--- a/acceptance/suites/tests/metrics/collect_default_metrics.rb
+++ b/acceptance/suites/tests/metrics/collect_default_metrics.rb
@@ -55,7 +55,7 @@ step 'Install graphite (and grafana)' do
   # to speed up how quickly Graphite makes newly-created metrics available to
   # be queried - and, therefore, hopefully make this test run much more quickly.
   graphitepp = "#{tmp_module_dir}/graphite.pp"
-  create_remote_file(master, graphitepp, <<GRAPHITEPP)
+  create_remote_file(graphite, graphitepp, <<GRAPHITEPP)
 class { 'graphite':
   gr_web_cors_allow_from_all => true,
   gr_max_creates_per_minute => inf,


### PR DESCRIPTION
This commit corrects the server on which the graphite.pp manifest is
updated for the collect_default_metrics.rb test.  The test needs to
upload the manifest to the server where graphite is being installed but
was errantly uploading it to the master.  In a split configuration, the
master and graphite servers are different and so the test would
previously fail when attempting to upload the file to the wrong server.