### PR TITLE
(MAINT) Bump lein-ezbake to 1.1.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -200,7 +200,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.1.7"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.1.8"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]]}


### PR DESCRIPTION
This commit bumps the lein-ezbake plugin version from 1.1.7 to 1.1.8.
This is being done in order to fix a build dependency problem which was
previously causing SLES 12 builds to unintentionally not contain
vendored gems.