### PR TITLE
(maint) Abort dev-setup script on error

### DIFF
--- a/dev-setup
+++ b/dev-setup
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # TODO: Ultimately it'd be nice to not hard-code these paths, because it is
 # not guaranteed to match up with the paths in puppetserver.conf or used by the
 # REPL.  That said, it doesn't seem like a great ROI to sort it out right now


### PR DESCRIPTION
The dev-setup script doesn't do any error checking but a casual glance
indicates that any command failing should be a critical error. This
commit adds `set -e` which will cause the script to abort if any command
exits with a non-zero exit status.