### PR TITLE
(SERVER-1761) Enable profiler by default

### DIFF
--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -76,7 +76,7 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
 * The `profiler` settings configure profiling:
 
-    * `enabled`: If this is set to `true`, Puppet Server enables profiling for the Puppet Ruby code. The default is `false`.
+    * `enabled`: If this is set to `true`, Puppet Server enables profiling for the Puppet Ruby code. The default is `true`.
 
 * The `puppet-admin` section configures Puppet Server's administrative API. (This API is unavailable with Rack or WEBrick Puppet masters.)
 

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -70,6 +70,6 @@ http-client: {
 
 # settings related to profiling the puppet Ruby code
 profiler: {
-    # enable or disable profiling for the Ruby code; defaults to 'false'.
+    # enable or disable profiling for the Ruby code; defaults to 'true'.
     #enabled: true
 }

--- a/src/clj/puppetlabs/services/puppet_profiler/puppet_profiler_core.clj
+++ b/src/clj/puppetlabs/services/puppet_profiler/puppet_profiler_core.clj
@@ -120,7 +120,9 @@
   [config :- MetricsProfilerServiceConfig
    hostname :- schema/Str
    registry :- (schema/maybe MetricRegistry)]
-  (let [enabled (ks/to-bool (:enabled config))]
-    (if-not enabled
-      {:profiler nil}
-      {:profiler (metrics-profiler hostname registry)})))
+  (let [enabled (if (some? (:enabled config))
+                  (ks/to-bool (:enabled config))
+                  true)]
+    (if enabled
+      {:profiler (metrics-profiler hostname registry)}
+      {:profiler nil})))

--- a/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
+++ b/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
@@ -3,8 +3,6 @@ package com.puppetlabs.puppetserver;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -18,8 +16,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class MetricsPuppetProfiler implements PuppetProfiler {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(MetricsPuppetProfiler.class);
 
     private final String hostname;
     private final MetricRegistry registry;
@@ -44,17 +40,12 @@ public class MetricsPuppetProfiler implements PuppetProfiler {
 
     @Override
     public void finish(Object context, String message, String[] metric_id) {
-        String metric_id_str = StringUtils.join(metric_id, ' ');
-        Long elapsed = System.currentTimeMillis() - (Long)context;
-
         if (shouldTime(metric_id)) {
+          Long elapsed = System.currentTimeMillis() - (Long)context;
             for (Timer t : getTimers(metric_id)) {
                 t.update(elapsed, TimeUnit.MILLISECONDS);
             }
         }
-
-        String msg = String.format("[%s] (%d ms) %s", metric_id_str, elapsed, message);
-        LOGGER.debug(msg);
     }
 
     public Set<String> getAllMetricIds() {

--- a/test/unit/puppetlabs/services/puppet_profiler/puppet_profiler_service_test.clj
+++ b/test/unit/puppetlabs/services/puppet_profiler/puppet_profiler_service_test.clj
@@ -32,10 +32,10 @@
 
 (deftest test-profiler-service
   (testing "get-profiler returns nil if profiling is not enabled"
-    (call-get-profiler {} nil?)
-    (call-get-profiler {:profiler {}} nil?)
     (call-get-profiler {:profiler {:enabled "false"}} nil?)
     (call-get-profiler {:profiler {:enabled false}} nil?))
   (testing "get-profiler returns a profiler if profiling is enabled"
+    (call-get-profiler {} #(instance? PuppetProfiler %))
+    (call-get-profiler {:profiler {}} #(instance? PuppetProfiler %))
     (call-get-profiler {:profiler {:enabled "true"}} #(instance? PuppetProfiler %))
     (call-get-profiler {:profiler {:enabled true}} #(instance? PuppetProfiler %))))


### PR DESCRIPTION
This commit defaults the Puppet profiler to true, and removes some
extraneous logging.

I've dropped a set of tests that seemed to be exercising the debug log statement in `MetricsPuppetProfiler.finish()`, if those need to be replaced instead of dropped let me know.