### PR TITLE
(SERVER-1767) Limit concurrent requests to Puppet API

### DIFF
--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -54,6 +54,10 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
         JRuby flushing can be useful for working around buggy module code that would otherwise cause memory leaks, but it slightly reduces performance whenever a new JRuby instance reloads all of the Puppet Ruby code. If memory leaks from module code are not an issue in your deployment, the default value of 0 performs best.
 
+    * `max-queued-requests`: Optional. The maximum number of requests that may be queued waiting to borrow a JRuby from the pool. Once this limit is exceeded, a 503 "Service Unavailable" response will be returned for all new requests until the queue drops below the limit. If `max-retry-delay` is set to a positive value, then the 503 responses will include a `Retry-After` header indicating a random sleep time after which the client may retry the request. The default is 0, which disables the queue limit.
+
+    * `max-retry-delay`: Optional. Sets the upper limit for the random sleep set as a `Retry-After` header on 503 responses returned when `max-queued-requests` is enabled. A value of 0 will cause the `Retry-After` header to be omitted. Default is 1800 seconds which corresponds to the default run interval of the Puppet daemon.
+
     * `borrow-timeout`: Optional. The timeout in milliseconds, when attempting to borrow an instance from the JRuby pool. The default is 1200000.
 
     * `use-legacy-auth-conf`: Optional. The method to be used for authorizing access to the HTTP endpoints served by the master service. The applicable endpoints are listed in [Puppet v3 HTTP API](https://docs.puppet.com/puppet/latest/reference/http_api/http_api_index.html#puppet-v3-http-api). As of Puppet Server 5.0, this setting's default value is false.

--- a/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
@@ -2,6 +2,7 @@
   (:require [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.services.protocols.request-handler :as handler]
             [puppetlabs.services.request-handler.request-handler-core :as request-handler-core]
+            [puppetlabs.puppetserver.jruby-request :as jruby-request]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [clojure.tools.logging :as log]
             [puppetlabs.i18n.core :as i18n]))
@@ -9,11 +10,21 @@
 (tk/defservice request-handler-service
   handler/RequestHandlerService
   [[:PuppetServerConfigService get-config]
+   [:ConfigService get-in-config]
    [:VersionedCodeService current-code-id]
-   [:JRubyPuppetService]]
+   [:JRubyPuppetService]
+   [:JRubyMetricsService]]
   (init [this context]
-    (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
-          config (get-config)]
+    (let [config (get-config)
+          max-queued-requests (get-in-config [:jruby-puppet :max-queued-requests] 0)
+          max-retry-delay (get-in-config [:jruby-puppet :max-retry-delay] 1800)
+          jruby-service (tk-services/get-service this :JRubyPuppetService)
+          metrics-service (tk-services/get-service this :JRubyMetricsService)
+          request-handler (request-handler-core/build-request-handler
+                            jruby-service
+                            (request-handler-core/config->request-handler-settings
+                              config)
+                            current-code-id)]
       (when (contains? (:master config) :allow-header-cert-info)
         (if (true? (get-in config [:jruby-puppet :use-legacy-auth-conf]))
           (log/warn (format "%s %s"
@@ -22,12 +33,14 @@
           (log/warn (format "%s %s"
                             (i18n/trs "The ''master.allow-header-cert-info'' setting is deprecated and will be ignored in favor of the ''authorization.allow-header-cert-info'' setting because the ''jruby-puppet.use-legacy-auth-conf'' setting is ''false''.")
                             (i18n/trs "Remove the ''master.allow-header-cert-info'' setting.")))))
-      (assoc context :request-handler
-                     (request-handler-core/build-request-handler
-                      jruby-service
-                      (request-handler-core/config->request-handler-settings
-                       config)
-                      current-code-id))))
+      (assoc context :request-handler (if (pos? max-queued-requests)
+                                        (jruby-request/wrap-with-request-queue-limit
+                                          request-handler
+                                          metrics-service
+                                          max-queued-requests
+                                          max-retry-delay)
+                                        request-handler))))
+
   (handle-request
     [this request]
     (let [handler (:request-handler (tk-services/service-context this))]

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -11,6 +11,7 @@
             [me.raynes.fs :as fs]
             [puppetlabs.trapperkeeper.internal :as tk-internal]
             [puppetlabs.trapperkeeper.core :as tk]
+            [puppetlabs.services.jruby.jruby-metrics-service :as jruby-metrics-service]
             [puppetlabs.services.request-handler.request-handler-service :as handler-service]
             [puppetlabs.services.versioned-code-service.versioned-code-service :as vcs]
             [puppetlabs.services.config.puppet-server-config-service :as ps-config]
@@ -228,6 +229,7 @@
                                       "test knows the webserver is still running"))
            services (jruby-testutils/add-mock-jruby-pool-manager-service
                      (conj jruby-testutils/jruby-service-and-dependencies
+                           jruby-metrics-service/jruby-metrics-service
                            handler-service/request-handler-service
                            ps-config/puppet-server-config-service
                            vcs/versioned-code-service)

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -25,6 +25,7 @@
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as routing-service]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization-service]
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :as metrics]
+            [puppetlabs.services.jruby.jruby-metrics-service :as jruby-metrics-service]
             [puppetlabs.trapperkeeper.services.status.status-service :as status-service]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.puppetserver.testutils :as testutils]
@@ -326,6 +327,7 @@
                      custom-vcs
                      tk-scheduler/scheduler-service
                      metrics/metrics-service
+                     jruby-metrics-service/jruby-metrics-service
                      status-service/status-service]]
        (jruby-bootstrap/with-puppetserver-running-with-services-and-mock-jruby-puppet-fn
         "For this test we're basically just validating that a JRuby is reserved


### PR DESCRIPTION
This patch implements a ring handler that rejects incoming requests to the
Puppet API with a 503 status code when the backlog of outstanding requests
exceeds a given limit. The handler can also be configured with a splay limit,
a random fraction of which is set as the value of a Retry-After header that is
returned with the 503 error.