### PR TITLE
(MAINT) Bump puppet and puppet-agent versions 12-apr-2017

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -25,7 +25,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "1.9.3.293.g54c44c8",
+                         "1.9.3.371.g7f71e72",
                          :string) ||
                          get_puppet_version
 
@@ -34,7 +34,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "54c44c82772df892db327183619464bf4fdd87b7",
+                         "7f71e72e936f460e136b25880c6792d9a20decdf",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:


### PR DESCRIPTION
This commit bumps the puppet-agent pin to 7f71e72 and related puppet
submodule to 4b09fbc.