### PR TITLE
(SERVER-1251) remove resource types endpoint

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -476,8 +476,6 @@ module PuppetServerExtensions
       http.puppet-v3-file_metadatas-.*.-percentage
       http.puppet-v3-node-.*.-percentage
       http.puppet-v3-report-.*.-percentage
-      http.puppet-v3-resource_type-.*.-percentage
-      http.puppet-v3-resource_types-.*.-percentage
       http.puppet-v3-static_file_content-.*.-percentage
       http.puppet-v3-status-.*.-percentage
       num-cpus

--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_core.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_core.clj
@@ -151,10 +151,6 @@
       (master-request-handler request))
     (comidi/PUT ["/report/" [#".*" :rest]] request
       (master-request-handler request))
-    (comidi/GET ["/resource_type/" [#".*" :rest]] request
-      (master-request-handler request))
-    (comidi/GET ["/resource_types/" [#".*" :rest]] request
-      (master-request-handler request))
     (comidi/GET ["/status/" [#".*" :rest]] request
       (master-request-handler request))))
 

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -515,10 +515,6 @@
                 (request-handler (assoc request :include-code-id? true)))
    (comidi/PUT ["/report/" [#".*" :rest]] request
                (request-handler request))
-   (comidi/GET ["/resource_type/" [#".*" :rest]] request
-               (request-handler request))
-   (comidi/GET ["/resource_types/" [#".*" :rest]] request
-               (request-handler request))
    (comidi/GET ["/environment/" [#".*" :environment]] request
                (request-handler (assoc request :include-code-id? true)))
    (comidi/GET "/environments" request

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -44,8 +44,6 @@
    "http.puppet-v3-file_metadatas-/*/-percentage"
    "http.puppet-v3-node-/*/-percentage"
    "http.puppet-v3-report-/*/-percentage"
-   "http.puppet-v3-resource_type-/*/-percentage"
-   "http.puppet-v3-resource_types-/*/-percentage"
    "http.puppet-v3-static_file_content-/*/-percentage"
    "http.puppet-v3-status-/*/-percentage"
    "http.total-requests"

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -16,19 +16,16 @@
   {schema/Str (schema/pred (some-fn string? #(instance? File %) #(instance? URL %)))})
 
 (def PuppetResource
-  "Schema for a Puppet resource. Based on
-  https://github.com/puppetlabs/puppet/blob/master/api/schemas/resource_type.json
-  which seems a little out of date and incomplete."
+  "Schema for a Puppet resource. Based on the resource within the catalog schema."
   {(schema/required-key "type") schema/Str
    (schema/required-key "title") schema/Str
-   (schema/optional-key "name") schema/Str
-   (schema/optional-key "tags") [schema/Str]
-   (schema/optional-key "exported") schema/Bool
-   (schema/optional-key "parameters") {schema/Str schema/Str}
    (schema/optional-key "line") schema/Int
    (schema/optional-key "file") schema/Str
-   (schema/optional-key "parent") schema/Str
-   (schema/optional-key "doc") schema/Str
+   (schema/required-key "exported") schema/Bool
+   (schema/optional-key "sensitive_parameters") [schema/Str]
+   (schema/required-key "tags") [schema/Str]
+   (schema/optional-key "parameters") {schema/Str schema/Str}
+   (schema/optional-key "ext_parameters") {schema/Str schema/Str}
    schema/Str schema/Str})
 
 (def PuppetCatalog

--- a/test/unit/puppetlabs/services/legacy_routes/legacy_routes_core_test.clj
+++ b/test/unit/puppetlabs/services/legacy_routes/legacy_routes_core_test.clj
@@ -91,9 +91,7 @@
                                     "file_metadatas"
                                     "file_metadata"
                                     "file_bucket_file"
-                                    "catalog"
-                                    "resource_type"
-                                    "resource_types"]
+                                    "catalog"]
                               :put ["report"]
                               :head ["file_bucket_file"]
                               :post ["catalog"]}

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -51,8 +51,6 @@
                    "file_metadatas"
                    "file_metadata"
                    "file_bucket_file"
-                   "resource_type"
-                   "resource_types"
                    "status"]
              :put ["file_bucket_file"
                    "report"]
@@ -294,8 +292,6 @@
                      "file_metadatas"
                      "file_metadata"
                      "file_bucket_file"
-                     "resource_type"
-                     "resource_types"
                      "status"]
                :put ["file_bucket_file"
                      "report"]


### PR DESCRIPTION
The `/puppet/v3/resource_types` endpoint was deprecated in Server 2.3.0 and is being
removed in Server 5. This commit removes it from the route tree, and removes
associated tests.

Also update the `PuppetResource` test schema which was out of date.