### PR TITLE
(MAINT) Bump to lein-ezbake 1.2.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -200,7 +200,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.2.0"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.2.1"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]]}


### PR DESCRIPTION
This commit bumps our lein-ezbake dependency from 1.2.0 to 1.2.1.  1.2.1
has a fix in it which should allow for the proper java 1.8 package
dependency to be resolved when we're building packages for SLES 12.