### PR TITLE
(MAINT) Bump beaker version to 3.15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.5.0')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.15.0')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
   gem 'uuidtools'


### PR DESCRIPTION
This commit bumps the beaker version used in the Gemfile from 3.5 to
3.15.  This is being done in order to pick up the updated platform code
name -> version matrix used in various beaker helpers, needed for use
with running tests for yakkety.