### PR TITLE
(maint) drop -XX:MaxPermSize

### DIFF
--- a/documentation/dev_trace_func.markdown
+++ b/documentation/dev_trace_func.markdown
@@ -17,7 +17,7 @@ calls into C code, the `jruby.debug.fullTrace` Java property must be set to
 adding the option to the `project.clj` file:
 
 ~~~ini
-:jvm-opts ["-XX:MaxPermSize=256m" "-Djruby.debug.fullTrace=true"]
+:jvm-opts ["-Djruby.debug.fullTrace=true"]
 ~~~
 
 If you are running Puppet Server from a package, this can be done by adding the
@@ -25,7 +25,7 @@ option to the `puppetserver` file in `/etc/sysconfig` or `/etc/default`,
 depending upon your OS distribution:
 
 ~~~ini
-JAVA_ARGS="-Xms2g -Xmx2g -XX:MaxPermSize=256m -Djruby.debug.fullTrace=true"
+JAVA_ARGS="-Xms2g -Xmx2g -Djruby.debug.fullTrace=true"
 ~~~
 
 A call to the `set_trace_func` function can be done in one of the Ruby files in

--- a/project.clj
+++ b/project.clj
@@ -102,7 +102,7 @@
   :lein-ezbake {:vars {:user "puppet"
                        :group "puppet"
                        :build-type "foss"
-                       :java-args ~(str "-Xms2g -Xmx2g -XX:MaxPermSize=256m "
+                       :java-args ~(str "-Xms2g -Xmx2g "
                                      "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger")
                        :repo-target "PC1"
                        :bootstrap-source :services-d
@@ -215,8 +215,7 @@
             "irb" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.irb" "--config" "./dev/puppetserver.conf" "--"]}
 
   ; tests use a lot of PermGen (jruby instances)
-  :jvm-opts ["-XX:MaxPermSize=256m"
-             "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
+  :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
              ~(str "-Xms" (heap-size "1G" "min"))
              ~(str "-Xmx" (heap-size "2G" "max"))]
 


### PR DESCRIPTION
MaxPermSize was made a noop JVM argument in JDK8; since we no longer
support JDK7 we can omit this option entirely.