### PR TITLE
(maint) Change beaker pin to 3.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.15.0')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.11.0')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
   gem 'uuidtools'


### PR DESCRIPTION
Beaker 3.12.0 is causing problems for installing Puppet for the Puppet 3
compatibility tests on el 6. This commit changes the Beaker pin to 3.11.0
until we can get around the issue.