### PR TITLE
(maint) Don't run puppetdb acceptance tests on yakkety

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -70,7 +70,7 @@ module PuppetServerExtensions
       /el/, # includes cent6,7 and redhat6,7
       /ubuntu-12/,
       /ubuntu-14/,
-      /ubuntu-16/,
+      /ubuntu-1604/,
     ]
   end
 


### PR DESCRIPTION
Update `puppetdb_supported_platforms` acceptance test helper to exclude
yakkety from the platforms we run PuppetDB smoke tests agains, since PuppetDB
doesn't support yakkety.