### PR TITLE
(maint) install jdk8 for debian 8 for puppet3 compat

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -182,6 +182,7 @@ module PuppetServerExtensions
   end
 
   def install_puppet_server (host, make_env={})
+    install_puppet_server_deps
     case test_config[:puppetserver_install_type]
     when :package
       install_package host, 'puppetserver'
@@ -192,6 +193,16 @@ module PuppetServerExtensions
       install_from_ezbake host, 'puppetserver', project_version, make_env
     else
       abort("Invalid install type: " + test_config[:puppetserver_install_type])
+    end
+  end
+
+  def install_puppet_server_deps
+    variant = master['platform'].variant
+    version = master['platform'].version
+    if variant == 'debian' && version == "8"
+      create_remote_file(master, "/etc/apt/sources.list.d/jessie-backports.list", "deb http://ftp.debian.org/debian jessie-backports main")
+      on master, 'apt-get update'
+      master.install_package("openjdk-8-jre-headless", "-t jessie-backports")
     end
   end
 

--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -90,14 +90,6 @@ else
       "initdir" => "/etc/init.d",
     }
 
-    variant = master['platform'].variant
-    version = master['platform'].version
-    if variant == 'debian' && version == "8"
-      create_remote_file(master, "/etc/apt/sources.list.d/jessie-backports.list", "deb http://ftp.debian.org/debian jessie-backports main")
-      on master, 'apt-get update'
-      master.install_package("openjdk-8-jre-headless", "-t jessie-backports")
-    end
-
     install_puppet_server master, make_env
 
 

--- a/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
@@ -9,13 +9,5 @@ end
 
 install_puppet_on(nonmaster_agents, {:version => puppet_version})
 
-variant = master['platform'].variant
-version = master['platform'].version
-if variant == 'debian' && version == "8"
-  create_remote_file(master, "/etc/apt/sources.list.d/jessie-backports.list", "deb http://ftp.debian.org/debian jessie-backports main")
-  on master, 'apt-get update'
-  master.install_package("openjdk-8-jre-headless", "-t jessie-backports")
-end
-
 step "Install Puppet Server."
 install_puppet_server master

--- a/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
@@ -9,5 +9,13 @@ end
 
 install_puppet_on(nonmaster_agents, {:version => puppet_version})
 
+variant = master['platform'].variant
+version = master['platform'].version
+if variant == 'debian' && version == "8"
+  create_remote_file(master, "/etc/apt/sources.list.d/jessie-backports.list", "deb http://ftp.debian.org/debian jessie-backports main")
+  on master, 'apt-get update'
+  master.install_package("openjdk-8-jre-headless", "-t jessie-backports")
+end
+
 step "Install Puppet Server."
 install_puppet_server master


### PR DESCRIPTION
This is kinda gross because it's copy/paste, but I've done many worse things.

/cc @camlow325