### PR TITLE
(SERVER-1762) Use json in tests

### DIFF
--- a/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
+++ b/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
@@ -208,7 +208,7 @@
           http-get-no-ssl (fn [path]
                             (http-client/get
                              (str "http://localhost:8080/" path)
-                             {:headers {"Accept" "pson"
+                             {:headers {"Accept" "application/json"
                                         "X-Client-Cert" url-encoded-cert
                                         "X-Client-DN" "CN=private"
                                         "X-Client-Verify" "SUCCESS"}
@@ -345,7 +345,7 @@
               http-get-no-ssl (fn [path cert]
                                 (http-client/get
                                   (str "http://localhost:8080/" path)
-                                  {:headers {"Accept" "pson"
+                                  {:headers {"Accept" "application/json"
                                              "X-Client-Cert" cert
                                              "X-Client-DN" "CN=private"
                                              "X-Client-Verify" "SUCCESS"}
@@ -395,7 +395,7 @@
                   http-delete (fn [cert]
                                 (http-client/delete
                                   (str "http://localhost:8080/" path)
-                                  {:headers {"Accept" "pson"
+                                  {:headers {"Accept" "application/json"
                                              "X-Client-Cert" cert
                                              "X-Client-DN" "CN=private"
                                              "X-Client-Verify" "SUCCESS"}

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -73,7 +73,7 @@
 (def catalog-request-options
   (merge
    ssl-request-options
-   {:headers     {"Accept" "pson"}
+   {:headers     {"Accept" "application/json"}
     :as          :text}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -185,7 +185,7 @@
    (let [request-options (if include-ssl-certs?
                            catalog-request-options
                            {:ssl-ca-cert ca-cert
-                            :headers     {"Accept" "pson"}})]
+                            :headers     {"Accept" "application/json"}})]
      (http-client/get (str "https://localhost:8140/puppet/v3/static_file_content/" url-end)
                       (assoc request-options
                         :as :text)))))

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -50,7 +50,7 @@
                                     "/private_keys/localhost.pem")
                       :ssl-ca-cert (str master-service-test-runtime-ssl-dir
                                         "/certs/ca.pem")
-                      :headers {"Accept" "pson"}
+                      :headers {"Accept" "application/json"}
                       :as :text})))
 
 (defn http-put
@@ -65,8 +65,8 @@
                       :ssl-ca-cert (str master-service-test-runtime-ssl-dir
                                         "/certs/ca.pem")
                       :body body
-                      :headers {"Accept" "pson"
-                                "Content-type" "text/pson"}
+                      :headers {"Accept" "application/json"
+                                "Content-type" "application/json"}
                       :as :text})))
 
 (deftest ^:integration master-service-http-metrics


### PR DESCRIPTION
Many of the puppetserver tests used pson as the content type in accept headers.
This commit changes them to json.

Some tests specifically test that using pson (and json) in an accept header will
work, and these tests have been left in place