### PR TITLE
(maint) Update packaged logback for http client logging

### DIFF
--- a/ezbake/config/logback.xml
+++ b/ezbake/config/logback.xml
@@ -23,6 +23,7 @@
     </appender>
 
     <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="org.apache.http" level="INFO"/>
     <logger name="jruby" level="info"/>
 
     <root level="info">


### PR DESCRIPTION
org.apache.http logs a ton of unhelpful things at DEBUG level that
should really be at TRACE. This commit updates the packaged logback.xml so tat
if the general log level is changed to `debug`, http client will remain at
`info` so as to not spam the logs.