### PR TITLE
(SERVER-1800) Remove openjdk-7-jre-headless as debian build dependency

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -36,7 +36,7 @@ ezbake: {
              }
 
       debian: { dependencies: ["puppet-agent (>= 1.6.0)"],
-                build-dependencies: ["openjdk-7-jre-headless | openjdk-8-jre-headless"],
+                build-dependencies: ["openjdk-8-jre-headless"],
                 # Install some gems
                 install: [
                   "bash ./ext/build-scripts/install-vendored-gems.sh"


### PR DESCRIPTION
Previously, both openjdk-7-jre-headless and openjdk-8-jre-headless were
listed as build dependencies for Debian.  Since we'll no longer need to
be building for JDK 7 for Puppet 5+, this commit removes the
openjdk-7-jre-headless dependency.