### PR TITLE
(SERVER-1630) Exclude jruby-deps only for ezbake

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -70,6 +70,8 @@
                                 org.jruby/jruby-stdlib
                                 com.github.jnr/jffi
                                 com.github.jnr/jnr-x86asm]]
+                 [puppetlabs/jruby-deps ~jruby-1_7-version]
+
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-comidi-metrics]
@@ -138,8 +140,7 @@
                                         :main "puppetlabs.puppetserver.dashboard.production"}}}}
   :hooks [leiningen.cljsbuild]
 
-  :profiles {:provided {:dependencies [[puppetlabs/jruby-deps ~jruby-1_7-version]]}
-             :dev {:source-paths  ["dev"]
+  :profiles {:dev {:source-paths  ["dev"]
                    :dependencies  [[org.clojure/tools.namespace]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-ws-jetty9-version]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-ws-jetty9-version :classifier "test"]
@@ -207,7 +208,7 @@
                                                ;; brings in its own version, and older versions of
                                                ;; lein depend on clojure 1.6.
                                                [org.clojure/clojure nil]
-                                               [puppetlabs/puppetserver ~ps-version]
+                                               [puppetlabs/puppetserver ~ps-version :exclusions [puppetlabs/jruby-deps]]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-ws-jetty9-version]
                                                [org.clojure/tools.nrepl nil]]
                       :plugins [[puppetlabs/lein-ezbake "1.3.0"]]


### PR DESCRIPTION
Previously, Puppet Server's JRuby dependencies were excluded from
jruby-utils and moved into profiles only (provided and jruby9k) in order
to avoid having the default dependencies from jruby-utils be included in
the puppet-server-release uberjar for ezbake packages.  This, however,
would be problematic for any consumer of the immediate puppetserver
artifact since those consumers would have to explicitly include/manage
the JRuby dependencies themselves.

In this commit, the jruby-deps for JRuby 1.7 are re-added as a standard
dependency but excluded in the ezbake profile.  This should allow the
standard puppetserver artifact to have reasonable JRuby 1.7 dependencies
by default again while still preserving the ability during an ezbake
build to separate JRuby dependencies for 1.7 and 9k into separate
uberjars from the puppet-server-release.jar.