### PR TITLE
(SERVER-1630) Remove jruby exclusions from jruby-utils dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -65,11 +65,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "0.9.0"
-                   :exclusions [org.jruby/jruby-core
-                                org.jruby/jruby-stdlib
-                                com.github.jnr/jffi
-                                com.github.jnr/jnr-x86asm]]
+                 [puppetlabs/jruby-utils "0.9.0"]
                  [puppetlabs/jruby-deps ~jruby-1_7-version]
 
                  [puppetlabs/trapperkeeper]


### PR DESCRIPTION
Previously, for the jruby-utils dependency, explicit exclusions were
included for various jruby-related dependencies - jruby-core,
jruby-stdlib, jffi, and jnr.  jruby-utils itself, though, no longer has
any explicit dependencies for any of these.  Instead, the jruby-deps
dependency controls which/whether any of the jruby-related dependencies
are pulled in.  This commit removes the exclusions for these
dependencies from the jruby-utils dependency since they are no longer
needed.