### PR TITLE
(maint) don't use legacy auth.conf for acceptance

### DIFF
--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -91,9 +91,4 @@ else
     }
 
     install_puppet_server master, make_env
-
-
-    step 'Use puppetserver legacy auth.conf' do
-      modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
-    end
 end


### PR DESCRIPTION
The `use-legacy-auth-conf` was added to the Puppet installation steps to
prevent breakage while we changed the default value. At this point we
should have fixed all of the acceptance tests that were relying on that
setting so this commit removes the setting shim.