### PR TITLE
(SERVER-1775) Add support for running JRuby 9k in CI

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -194,6 +194,7 @@ module PuppetServerExtensions
     else
       abort("Invalid install type: " + test_config[:puppetserver_install_type])
     end
+    maybe_configure_jruby9k
   end
 
   def install_puppet_server_deps
@@ -203,6 +204,28 @@ module PuppetServerExtensions
       create_remote_file(master, "/etc/apt/sources.list.d/jessie-backports.list", "deb http://ftp.debian.org/debian jessie-backports main")
       on master, 'apt-get update'
       master.install_package("openjdk-8-jre-headless", "-t jessie-backports")
+    end
+  end
+
+  def maybe_configure_jruby9k
+    puppetservice = options['puppetservice']
+    defaults_file = get_defaults_file
+    use_jruby_9k = ENV['USE_JRUBY_9K']
+
+    if use_jruby_9k.to_s.empty? || use_jruby_9k[0].casecmp('y') != 0
+      logger.info("USE_JRUBY_9K not set to 'Y' so using default JRuby")
+    else
+      step 'Enable JRuby 9k and restart puppetserver' do
+        on(master, "echo 'JRUBY_JAR=${INSTALL_DIR}/jruby-9k.jar' >> #{defaults_file}")
+        on(master, "service #{puppetservice} restart")
+
+        puppet_server_pid=on(master, "pgrep -f puppet-server-release.jar").stdout.chomp
+        jruby_9k_pid=on(master, "pgrep -f jruby-9k.jar").stdout.chomp
+
+        refute_empty(puppet_server_pid, 'Unable to get puppetserver pid')
+        assert_equal(puppet_server_pid, jruby_9k_pid,
+                     'puppetserver process does not appear to be using JRuby 9k')
+      end
     end
   end
 

--- a/ext/jenkins/spec-jruby9k.sh
+++ b/ext/jenkins/spec-jruby9k.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -x
+set -e
+
+lein with-profile +jruby9k run -m org.jruby.Main -e 'load "META-INF/jruby.home/bin/rake"' spec

--- a/ext/jenkins/unit-clj-jruby9k.sh
+++ b/ext/jenkins/unit-clj-jruby9k.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x
+set -e
+
+lein version
+
+lein with-profile +jruby9k -U test


### PR DESCRIPTION
This commit contains two changes for use in running JRuby 9k in CI:

1) Add Jenkins scripts for running Clojure unit and JRuby spec tests
   under 9k.

2) Add a beaker pre-suite step for configuring the Puppet Server service
   to run with JRuby 9k based on the configuration of a new environment
   variable, USE_JRUBY_9K.  A value of "y" or "Y" for the variable would
   enable 9K whereas any other value would lead to the default JRuby at
   installation, 1.7.x, being used.