### PR TITLE
(maint) Clean up acceptance puppet repo setup

### DIFF
--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -1,23 +1,19 @@
-install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
+if test_config[:puppetserver_install_type] == :package
+  package_build_version = ENV['PACKAGE_BUILD_VERSION']
+  if package_build_version.nil?
+    abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
+  end
 
-case test_config[:puppetserver_install_type]
-when :package
-  step "Setup Puppet Server repositories." do
-    package_build_version = ENV['PACKAGE_BUILD_VERSION']
-    if package_build_version
-      install_puppetlabs_dev_repo(master, 'puppetserver', package_build_version,
-                                  nil, install_opts)
-    else
-      abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
-    end
+  step "Setup Puppet Server dev repository on the master." do
+    install_opts = options.merge({ :dev_builds_repos => ["PC1"]})
+    install_puppetlabs_dev_repo(master, 'puppetserver', package_build_version, nil, install_opts)
   end
 end
 
 confine_block :except, :platform => ['windows'] do
   step "Setup Puppet Labs Dev Repositories." do
     hosts.each do |host|
-      install_puppetlabs_dev_repo(host, 'puppet-agent', test_config[:puppet_build_version],
-                                    nil, install_opts)
+      install_puppet_agent_dev_repo_on(host, {:puppet_agent_version => test_config[:puppet_build_version]})
     end
   end
 end

--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -1,13 +1,12 @@
 install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
-repo_config_dir = 'tmp/repo_configs'
 
 case test_config[:puppetserver_install_type]
 when :package
   step "Setup Puppet Server repositories." do
     package_build_version = ENV['PACKAGE_BUILD_VERSION']
     if package_build_version
-      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version,
-                                  repo_config_dir, install_opts
+      install_puppetlabs_dev_repo(master, 'puppetserver', package_build_version,
+                                  nil, install_opts)
     else
       abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
     end
@@ -19,8 +18,8 @@ if puppet_build_version
   confine_block :except, :platform => ['windows'] do
     step "Setup Puppet Labs Dev Repositories." do
       hosts.each do |host|
-        install_puppetlabs_dev_repo host, 'puppet-agent', puppet_build_version,
-                                    repo_config_dir, install_opts
+        install_puppetlabs_dev_repo(host, 'puppet-agent', puppet_build_version,
+                                    nil, install_opts)
       end
     end
   end

--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -13,14 +13,11 @@ when :package
   end
 end
 
-puppet_build_version = test_config[:puppet_build_version]
-if puppet_build_version
-  confine_block :except, :platform => ['windows'] do
-    step "Setup Puppet Labs Dev Repositories." do
-      hosts.each do |host|
-        install_puppetlabs_dev_repo(host, 'puppet-agent', puppet_build_version,
+confine_block :except, :platform => ['windows'] do
+  step "Setup Puppet Labs Dev Repositories." do
+    hosts.each do |host|
+      install_puppetlabs_dev_repo(host, 'puppet-agent', test_config[:puppet_build_version],
                                     nil, install_opts)
-      end
     end
   end
 end

--- a/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
@@ -12,11 +12,8 @@ when :package
     end
   end
 
-  puppet_build_version = test_config[:puppet_build_version]
-  if puppet_build_version
-    step "Setup Puppet dev repository on the master." do
-      install_puppetlabs_dev_repo(master, 'puppet-agent', puppet_build_version,
-                                  repo_config_dir, install_opts)
-    end
+  step "Setup Puppet dev repository on the master." do
+    install_puppetlabs_dev_repo(master, 'puppet-agent', test_config[:puppet_build_version],
+                                repo_config_dir, install_opts)
   end
 end

--- a/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
@@ -1,13 +1,12 @@
 install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
-repo_config_dir = 'tmp/repo_configs'
 
 case test_config[:puppetserver_install_type]
 when :package
   step "Setup Puppet Server dev repository on the master." do
     package_build_version = ENV['PACKAGE_BUILD_VERSION']
     if package_build_version
-      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version,
-                                  repo_config_dir, install_opts
+      install_puppetlabs_dev_repo(master, 'puppetserver', package_build_version,
+                                  nil, install_opts)
     else
       abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
     end
@@ -17,8 +16,8 @@ when :package
   if puppet_build_version
     confine_block :except, :platform => ['windows'] do
       step "Setup Puppet dev repository on the master." do
-        install_puppetlabs_dev_repo master, 'puppet-agent', puppet_build_version,
-                                    repo_config_dir, install_opts
+        install_puppetlabs_dev_repo(master, 'puppet-agent', puppet_build_version,
+                                    repo_config_dir, install_opts)
       end
     end
   end

--- a/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
@@ -14,12 +14,9 @@ when :package
 
   puppet_build_version = test_config[:puppet_build_version]
   if puppet_build_version
-    confine_block :except, :platform => ['windows'] do
-      step "Setup Puppet dev repository on the master." do
-        install_puppetlabs_dev_repo(master, 'puppet-agent', puppet_build_version,
-                                    repo_config_dir, install_opts)
-      end
+    step "Setup Puppet dev repository on the master." do
+      install_puppetlabs_dev_repo(master, 'puppet-agent', puppet_build_version,
+                                  repo_config_dir, install_opts)
     end
   end
 end
-

--- a/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
@@ -1,19 +1,16 @@
-install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
 
-case test_config[:puppetserver_install_type]
-when :package
+if test_config[:puppetserver_install_type] == :package
+  package_build_version = ENV['PACKAGE_BUILD_VERSION']
+  if package_build_version.nil?
+    abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
+  end
+
   step "Setup Puppet Server dev repository on the master." do
-    package_build_version = ENV['PACKAGE_BUILD_VERSION']
-    if package_build_version
-      install_puppetlabs_dev_repo(master, 'puppetserver', package_build_version,
-                                  nil, install_opts)
-    else
-      abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
-    end
+    install_opts = options.merge({ :dev_builds_repos => ["PC1"]})
+    install_puppetlabs_dev_repo(master, 'puppetserver', package_build_version, nil, install_opts)
   end
 
   step "Setup Puppet dev repository on the master." do
-    install_puppetlabs_dev_repo(master, 'puppet-agent', test_config[:puppet_build_version],
-                                repo_config_dir, install_opts)
+    install_puppet_agent_dev_repo_on(master, {:puppet_agent_version => test_config[:puppet_build_version]})
   end
 end


### PR DESCRIPTION
The puppetserver and puppet agent setup for acceptance was starting to pick up a lot of organic growth; this adds some cleanup to those files.