### PR TITLE
(SERVER-1807) Update Hocon to 1.2.5

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -1,5 +1,5 @@
 semantic_puppet 0.1.3
-hocon 1.2.4
+hocon 1.2.5
 text 1.3.1
 locale 2.1.2
 gettext 3.2.2


### PR DESCRIPTION
 - 1.2.5 addresses loading files with UTF-8 characters in their path