### PR TITLE
(MAINT) Don't flush non-initialized pool-context at shutdown

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -41,7 +41,12 @@
   (stop
    [this context]
    (let [{:keys [pool-context]} (tk-services/service-context this)]
-     (jruby-core/flush-pool-for-shutdown! pool-context))
+     ;; Only flush the pool if there is a pool-context available.  No pool-context
+     ;; would be available if an exception were to be thrown during service
+     ;; initialization before the pool-context were created - e.g., during the
+     ;; the initialization of an upstream service.
+     (when pool-context
+       (jruby-core/flush-pool-for-shutdown! pool-context)))
    context)
 
   (free-instance-count


### PR DESCRIPTION
Previously, if an exception were thrown before the jruby-puppet-service
had been completely initialized, a stop call to the service on shutdown
would lead to a separate exception being thrown and logged due to trying
to operate on a nil pool-context.

This commit changes the jruby-puppet-service stop logic to avoid trying
to flush the pool-context if it has not yet been created.  This avoids
having the exception be thrown and logged for the nil pool-context.