### PR TITLE
(MAINT) Bump tk-webserver-jetty9 to 2.0.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def ps-version "5.0.0-master-SNAPSHOT")
-(def tk-ws-jetty9-version "2.0.0")
+(def tk-ws-jetty9-version "2.0.1")
 (def jruby-1_7-version "1.7.26-1")
 (def jruby-9k-version "9.1.8.0-1")
 


### PR DESCRIPTION
This commit bumps the tk-webserver-jetty9 version from 2.0.0 to 2.0.1.