### PR TITLE
(MAINT) Add JRuby version log message

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -5,7 +5,8 @@
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby]
-            [puppetlabs.i18n.core :as i18n]))
+            [puppetlabs.i18n.core :as i18n])
+  (:import (org.jruby.runtime Constants)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -34,6 +35,9 @@
                         metrics-service)
           _ (core/add-facter-jar-to-system-classloader! (:ruby-load-path jruby-config))
           pool-context (create-pool jruby-config)]
+      (log/info (i18n/trs "Using JRuby version {0}, Ruby language version {1}"
+                          Constants/VERSION
+                          (:compat-version jruby-config)))
       (-> context
           (assoc :pool-context pool-context)
           (assoc :environment-class-info-tags (atom {})))))


### PR DESCRIPTION
This commit adds an info-level log message during startup which outputs
the version of JRuby which is being used and the Ruby language version
that JRuby is currently emulating.