### PR TITLE
(MAINT) Fix dev repo install for puppet3-compat suite

### DIFF
--- a/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
@@ -11,6 +11,6 @@ if test_config[:puppetserver_install_type] == :package
   end
 
   step "Setup Puppet dev repository on the master." do
-    install_puppetlabs_dev_repo(host, 'puppet-agent', test_config[:puppet_build_version], nil, install_opts)
+    install_puppetlabs_dev_repo(master, 'puppet-agent', test_config[:puppet_build_version], nil, install_opts)
   end
 end


### PR DESCRIPTION
Previously, the test step in the puppet3_compat pre_suite which
installed the puppetlabs dev repo referenced a non-existent variable,
host, causing the step to fail.  This commit fixes that line to
reference the intended variable, master.