### PR TITLE
(SERVER-1819) don't set node_cache_terminus

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -27,5 +27,17 @@ describe 'Puppet::Server::PuppetConfig' do
         expect(subject).to eq(false)
       end
     end
+
+    describe '(PUP-6060) Puppet::Node indirection caching' do
+      subject { Puppet[:node_cache_terminus] }
+      it 'is nil to avoid superfluous caching' do
+        expect(subject).to be_nil
+      end
+
+      subject { Puppet::Node.indirection.cache_class }
+      it 'is nil to avoid superfluous caching'do
+        expect(subject).to be_nil
+      end
+    end
   end
 end

--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -35,7 +35,6 @@ class Puppet::Server::PuppetConfig
     master_run_mode = Puppet::Util::RunMode[:master]
     app_defaults = Puppet::Settings.app_defaults_for_run_mode(master_run_mode).
         merge({:name => "master",
-               :node_cache_terminus => :write_only_yaml,
                :facts_terminus => 'yaml'})
     Puppet.settings.initialize_app_defaults(app_defaults)
 
@@ -48,8 +47,6 @@ class Puppet::Server::PuppetConfig
     Puppet::FileServing::Content.indirection.terminus_class = :file_server
     Puppet::FileServing::Metadata.indirection.terminus_class = :file_server
     Puppet::FileBucket::File.indirection.terminus_class = :file
-
-    Puppet::Node.indirection.cache_class = Puppet[:node_cache_terminus]
 
     Puppet::ApplicationSupport.configure_indirector_routes("master")
 


### PR DESCRIPTION
This commit stops overriding the default `node_cache_terminus` for puppet
server's master application as `write_only_yaml` and removes the setting of
Puppet::Node's indirection cache_class. With this, Puppet::Node's indirection
never gets its cache class set and won't cache by default. Per PUP-6060, with
the advent of PuppetDB, workflows using lists of nodes are better off querying
it than these yaml files on the master, and since this was a `write_only` cache
we were always querying the node terminus for nodes anyway.

Signed-off-by: Moses Mendoza <moses@puppet.com>