### PR TITLE
(SERVER-1819) honor node_cache_terminus setting

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -40,4 +40,13 @@ describe 'Puppet::Server::PuppetConfig' do
       end
     end
   end
+
+  # Even though we don't set the node_cache_terminus setting value, so it
+  # defaults to nil, we want to honor it if users have specified it directly.
+  # PUP-6060 / SERVER-1819
+  subject { Puppet::Node.indirection.cache_class }
+  it 'honors the Puppet[:node_cache_terminus] setting' do
+    Puppet::Server::PuppetConfig.initialize_puppet({ :node_cache_terminus => "plain" })
+    expect(subject).to eq(:plain)
+  end
 end

--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -48,6 +48,8 @@ class Puppet::Server::PuppetConfig
     Puppet::FileServing::Metadata.indirection.terminus_class = :file_server
     Puppet::FileBucket::File.indirection.terminus_class = :file
 
+    Puppet::Node.indirection.cache_class = Puppet[:node_cache_terminus]
+
     Puppet::ApplicationSupport.configure_indirector_routes("master")
 
     oid_defns = Puppet::SSL::Oids.parse_custom_oid_file(Puppet[:trusted_oid_mapping_file])


### PR DESCRIPTION
38e0a0c stopped setting the node_cache_terminus setting value, and stopped
setting the cache_class to its result. This commit undoes the latter half of
that change - we return to setting the cache_class. This will still default to
nil since we aren't specifying the setting value, which will disable caching,
but it will enable users to easily revert to the 4.x behavior of caching by
specifying :node_cache_terminus => :write_only_yaml. Without this commit users
would have to augment their routes.yaml file with a `:node` key specifying the
cache_class.

Signed-off-by: Moses Mendoza <moses@puppet.com>