### PR TITLE
(SERVER-1661) Bump JRuby dep to 1.7.27 and remove compat-version setting

### DIFF
--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -70,8 +70,6 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
         For more information, see the [`environment_classes` API documentation][].
 
-    * `compat-version`: Optional, experimental.  Used to control the MRI compatibility version under which JRuby runs.  The allowed values are "1.9" and "2.0".  The default value is "1.9".
-
     * `compile-mode`: Optional, experimental. Used to control JRuby's "CompileMode", which may improve performance. The default value is `off`, which is the most conservative value. A value of `jit` enables JRuby's "just-in-time" compilation of Ruby code. A value of `force` causes JRuby to attempt to pre-compile all Ruby code.
 
 * The `profiler` settings configure profiling:

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def ps-version "5.0.0-master-SNAPSHOT")
-(def jruby-1_7-version "1.7.26-2")
+(def jruby-1_7-version "1.7.27-1")
 (def jruby-9k-version "9.1.9.0-1")
 
 (defn deploy-info
@@ -64,7 +64,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "0.9.1"]
+                 [puppetlabs/jruby-utils "0.10.0"]
                  [puppetlabs/jruby-deps ~jruby-1_7-version]
 
                  ;; JRuby 1.7.x and trapperkeeper (via core.async) both bring in

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -270,9 +270,9 @@
     metrics-service]
    (when (get-in raw-config [:jruby-puppet :compat-version])
      (log/errorf "%s %s %s"
-                 "The jruby-puppet.compat-version setting is no longer supported."
-                 "To use Ruby language version 1.9.3, remove the jruby-puppet.compat-version setting."
-                 "To use a Ruby language version later than 2.0, remove the jruby-puppet.compat-version setting and add the line 'JRUBY_JAR=/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar' to the /etc/sysconfig/(pe-)puppet(-)server or /etc/default/(pe-)puppet(-)server file.")
+                 (i18n/trs "The jruby-puppet.compat-version setting is no longer supported.")
+                 (i18n/trs "To use Ruby language version 1.9.3, remove the jruby-puppet.compat-version setting.")
+                 (i18n/trs "To use a Ruby language version later than 2.0, remove the jruby-puppet.compat-version setting and add the line 'JRUBY_JAR=/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar' to the /etc/sysconfig/(pe-)puppet(-)server or /etc/default/(pe-)puppet(-)server file."))
      (throw (IllegalArgumentException.
              (i18n/trs "jruby-puppet.compat-version setting no longer supported"))))
    (let [jruby-puppet-config (initialize-puppet-config

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -268,6 +268,13 @@
     agent-shutdown-fn :- IFn
     warn-legacy-auth-conf? :- schema/Bool
     metrics-service]
+   (when (get-in raw-config [:jruby-puppet :compat-version])
+     (log/errorf "%s %s %s"
+                 "The jruby-puppet.compat-version setting is no longer supported."
+                 "To use Ruby language version 1.9.3, remove the jruby-puppet.compat-version setting."
+                 "To use a Ruby language version later than 2.0, remove the jruby-puppet.compat-version setting and add the line 'JRUBY_JAR=/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar' to the /etc/sysconfig/(pe-)puppet(-)server or /etc/default/(pe-)puppet(-)server file.")
+     (throw (IllegalArgumentException.
+             (i18n/trs "jruby-puppet.compat-version setting no longer supported"))))
    (let [jruby-puppet-config (initialize-puppet-config
                               (extract-http-config (:http-client raw-config))
                               (extract-puppet-config (:jruby-puppet raw-config)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -35,9 +35,8 @@
                         metrics-service)
           _ (core/add-facter-jar-to-system-classloader! (:ruby-load-path jruby-config))
           pool-context (create-pool jruby-config)]
-      (log/info (i18n/trs "Using JRuby version {0}, Ruby language version {1}"
-                          Constants/VERSION
-                          (:compat-version jruby-config)))
+      (log/info (i18n/trs "JRuby version info: {0}"
+                          jruby-core/jruby-version-info))
       (-> context
           (assoc :pool-context pool-context)
           (assoc :environment-class-info-tags (atom {})))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -132,7 +132,6 @@
     (let [jruby-puppet-config (jruby-puppet-core/initialize-puppet-config {} {})
           unitialized-jruby-config {:gem-home "/foo"
                                     :gem-path ["/foo" "/bar"]
-                                    :compat-version 2.0
                                     :compile-mode :jit
                                     :borrow-timeout 1234
                                     :max-active-instances 4321
@@ -151,8 +150,6 @@
       (testing "jruby-config values are not overridden if provided"
         (is (= "/foo" (:gem-home initialized-jruby-config)))
         (is (= "/foo:/bar" (:gem-path initialized-jruby-config)))
-        (is (= (if jruby-schemas/using-jruby-9k? Constants/RUBY_VERSION "2.0")
-               (:compat-version initialized-jruby-config)))
         (is (= :jit (:compile-mode initialized-jruby-config)))
         (is (= 1234 (:borrow-timeout initialized-jruby-config)))
         (is (= 4321 (:max-active-instances initialized-jruby-config)))
@@ -170,8 +167,6 @@
                                     nil)]
 
       (testing "jruby-config default values are used if not provided"
-        (is (= (if jruby-schemas/using-jruby-9k? Constants/RUBY_VERSION "1.9")
-               (:compat-version initialized-jruby-config)))
         (is (= :off (:compile-mode initialized-jruby-config)))
         (is (= jruby-core/default-borrow-timeout (:borrow-timeout initialized-jruby-config)))
         (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:max-active-instances initialized-jruby-config)))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -55,16 +55,11 @@
   This represents what would be in a real TK configuration's jruby-puppet section,
   so we remove some things from the JRubyConfig:
   - remove :max-borrows-per-instance (keep :max-requests-per-instance)
-  - remove :lifecycle
-  - make :compat-version optional"
-  (let [initial-schema (-> jruby-puppet-schemas/JRubyPuppetConfig
-                           (merge jruby-schemas/JRubyConfig)
-                           (dissoc :max-borrows-per-instance
-                                   :lifecycle))]
-    (-> initial-schema
-        (assoc (schema/optional-key :compat-version)
-               (:compat-version initial-schema))
-        (dissoc :compat-version))))
+  - remove :lifecycle"
+  (-> jruby-puppet-schemas/JRubyPuppetConfig
+      (merge jruby-schemas/JRubyConfig)
+      (dissoc :max-borrows-per-instance
+              :lifecycle)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; JRubyPuppet Test util functions
@@ -166,7 +161,7 @@ create-mock-pool-instance :- JRubyInstance
          updated-config (-> combined-configs
                             (assoc :max-requests-per-instance max-requests-per-instance)
                             (dissoc :max-borrows-per-instance))]
-     (dissoc updated-config :lifecycle :compat-version)))
+     (dissoc updated-config :lifecycle)))
   ([options]
    (merge (jruby-puppet-config) options)))
 


### PR DESCRIPTION
This commit bumps the jruby-deps dependency for 1.7 from 1.7.26-2 to
1.7.27-1 and jruby-utils dep from 0.9.0 to 0.10.0.

This commit removes support for the jruby-puppet.compat-version setting.
The compat-version setting was introduced in Puppet Server 2.7.0 to
allow for JRuby to run under Ruby language version 2.0 instead of the
default version, 1.9.  Setting compat-version to "2.0" for JRuby 1.7.27,
however, was broken due to a regression - see:
https://github.com/jruby/jruby/issues/4613 - and is unlikely to be fixed
in the future.  For Puppet Server 5+, users will be able to, via the
JRUBY_JAR environment variable in packaging, configure JRuby 9k to be
used instead of JRuby 1.7 for Ruby language version 2+ support.

In conjunction with a corresponding jruby-utils bump, this commit causes
the presence of the jruby-puppet.compat-version setting to throw an
error at startup, with a message indicating how users can configure the
use of JRuby 9k for Ruby language version 2+ support.