### PR TITLE
(SERVER-1786) Remove site.pp file between Puppet compat tests

### DIFF
--- a/acceptance/lib/puppetserver/acceptance/compat_utils.rb
+++ b/acceptance/lib/puppetserver/acceptance/compat_utils.rb
@@ -16,7 +16,7 @@ SITEPP
   end
 end
 
-def rm_vardirs()
+def rm_compat_test_files()
   # In order to prevent file caching and ensure agent-master HTTP communication
   # during agent runs we blow away the vardirs, which contains the cached files
   hosts.each do |host|

--- a/acceptance/lib/puppetserver/acceptance/compat_utils.rb
+++ b/acceptance/lib/puppetserver/acceptance/compat_utils.rb
@@ -1,9 +1,12 @@
+def sitepp
+  '/etc/puppetlabs/code/environments/production/manifests/site.pp'
+end
+
 def nonmaster_agents()
   agents.reject { |agent| agent == master }
 end
 
 def apply_simmons_class(agent, studio, classname)
-  sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
   create_remote_file(master, sitepp, <<SITEPP)
 class { 'simmons':
   studio    => "#{studio}",
@@ -23,4 +26,7 @@ def rm_compat_test_files()
     vardir = on(host, puppet("config print vardir")).stdout.chomp
     on(host, "rm -rf #{vardir}")
   end
+  # Remove any custom site.pp file which may have been laid down so that it
+  # doesn't pollute the outcome from any additional tests which are run.
+  on(master, "rm -f #{sitepp}")
 end

--- a/acceptance/suites/compat_tests/020_backwards_compat/binary_file_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/binary_file_test.rb
@@ -3,7 +3,7 @@ require 'puppetserver/acceptance/compat_utils'
 test_name 'binary file resource'
 
 teardown do
-  rm_vardirs()
+  rm_compat_test_files()
 end
 
 agents.each do |agent|

--- a/acceptance/suites/compat_tests/020_backwards_compat/content_file_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/content_file_test.rb
@@ -3,7 +3,7 @@ require 'puppetserver/acceptance/compat_utils'
 test_name 'content file resource'
 
 teardown do
-  rm_vardirs()
+  rm_compat_test_files()
 end
 
 agents.each do |agent|

--- a/acceptance/suites/compat_tests/020_backwards_compat/custom_fact_output_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/custom_fact_output_test.rb
@@ -3,7 +3,7 @@ require 'puppetserver/acceptance/compat_utils'
 test_name 'custom fact'
 
 teardown do
-  rm_vardirs()
+  rm_compat_test_files()
 end
 
 agents.each do |agent|

--- a/acceptance/suites/compat_tests/020_backwards_compat/external_fact_output_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/external_fact_output_test.rb
@@ -3,7 +3,7 @@ require 'puppetserver/acceptance/compat_utils'
 test_name 'executable external fact'
 
 teardown do
-  rm_vardirs()
+  rm_compat_test_files()
 end
 
 agents.each do |agent|

--- a/acceptance/suites/compat_tests/020_backwards_compat/mount_point_binary_file_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/mount_point_binary_file_test.rb
@@ -3,7 +3,7 @@ require 'puppetserver/acceptance/compat_utils'
 test_name 'binary file resource from custom mount point'
 
 teardown do
-  rm_vardirs()
+  rm_compat_test_files()
 end
 
 agents.each do |agent|

--- a/acceptance/suites/compat_tests/020_backwards_compat/mount_point_source_file_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/mount_point_source_file_test.rb
@@ -3,7 +3,7 @@ require 'puppetserver/acceptance/compat_utils'
 test_name 'source file resource from custom mount point'
 
 teardown do
-  rm_vardirs()
+  rm_compat_test_files()
 end
 
 agents.each do |agent|

--- a/acceptance/suites/compat_tests/020_backwards_compat/recursive_directory_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/recursive_directory_test.rb
@@ -3,7 +3,7 @@ require 'puppetserver/acceptance/compat_utils'
 test_name 'recursive directory file resource'
 
 teardown do
-  rm_vardirs()
+  rm_compat_test_files()
 end
 
 agents.each do |agent|

--- a/acceptance/suites/compat_tests/020_backwards_compat/source_file_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/source_file_test.rb
@@ -3,7 +3,7 @@ require 'puppetserver/acceptance/compat_utils'
 test_name 'source file resource'
 
 teardown do
-  rm_vardirs()
+  rm_compat_test_files()
 end
 
 agents.each do |agent|


### PR DESCRIPTION
Previously, each of the Puppet compat tests uploaded a site.pp file but
did not remove the file as each test completed.  This would lead to any
subsequent tests which did not replace the site.pp file having problems
when an agent run reused the file from the prior test - in particular
the puppetX_version_test.rb.  In this commit, the site.pp file is
cleaned up as part of each test's teardown.