### PR TITLE
(MAINT) Set GEM_HOME and GEM_PATH for gem install bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -76,6 +76,7 @@ namespace :spec do
       ## Line 1 launches the JRuby that we depend on via leiningen
       ## Line 2 programmatically runs 'gem install bundler' via the gem command that comes with JRuby
       gem_install_bundler = <<-CMD
+      GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
       lein run -m org.jruby.Main \
       -e 'load "META-INF/jruby.home/bin/gem"' install -i '#{TEST_GEMS_DIR}' --no-rdoc --no-ri bundler
       CMD


### PR DESCRIPTION
This commit sets the GEM_HOME and GEM_PATH for the 'gem install bundler'
command that the Rakefile uses for spec tests.  Not having these set may
cause paths from the default system ruby, which is usually a different
version than the language version JRuby is being run under, to be used.
Using system ruby paths with JRuby commands may otherwise lead to
compatibility problems at some point.