### PR TITLE
(SERVER-1786) Set default versions of puppet when testing legacy compat

### DIFF
--- a/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
@@ -2,9 +2,12 @@ require 'puppetserver/acceptance/compat_utils'
 
 step "Install Legacy Puppet Agents."
 
+default_puppet_version = '3.8.7'
 puppet_version = ENV['PUPPET_LEGACY_VERSION']
 if not puppet_version
-  fail "PUPPET_LEGACY_VERSION is not set, e.g. '3.7.5'"
+  logger.info "PUPPET_LEGACY_VERSION is not set!"
+  logger.info "  using default value of #{default_puppet_version}"
+  puppet_version = default_puppet_version
 end
 
 install_puppet_on(nonmaster_agents, {:version => puppet_version})


### PR DESCRIPTION
This adds a default value to puppet versions that we will use when
testing legacy compatability.

Previously we failed when no value was given, with this change we will
now log an info message.

Amended to apply to Puppetserver 2.7.x.