### PR TITLE
(SERVER-1787) Puppet 3 agents must use foss install type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.11.0')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.17.0')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
   gem 'uuidtools'

--- a/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
@@ -10,4 +10,6 @@ if not puppet_version
   puppet_version = default_puppet_version
 end
 
+# Always force 3.x agents to use FOSS puppet install type
+nonmaster_agents.each { |agent| agent[:type] = 'foss' }
 install_puppet_on(nonmaster_agents, {:version => puppet_version})


### PR DESCRIPTION
If we're running Puppet 3 compatibility tests the agent install type
doesn't matter, as we _must_ use the 'foss' install type. This commit
manually reconfigures the Puppet agent hosts to use the 'foss' install
type and ignore the '--aio' command line flag and config option as that
option can only meaningfully apply to the master node, and never the
agents under test.