### PR TITLE
(SERVER-1821) Bump JRuby 9k dep to 9.1.9.0-2 for ffi memory leak fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def ps-version "5.0.0-master-SNAPSHOT")
 (def jruby-1_7-version "1.7.27-1")
-(def jruby-9k-version "9.1.9.0-1")
+(def jruby-9k-version "9.1.9.0-2")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the jruby-deps for 9k from 9.1.9.0-1 to 9.1.9.0-2.
This transitively pins to newer versions of jffi and jnr-ffi, 1.2.16 and
2.1.6, which have a fix for leaks around native memory allocations.  See
https://github.com/jnr/jnr-ffi/issues/117.