### PR TITLE
(SERVER-1786) Install Puppet GPG key for SLES 12 Puppet 4 compat agent

### DIFF
--- a/acceptance/suites/pre_suite/puppet4_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet4_compat/70_install_puppet.rb
@@ -1,5 +1,18 @@
 require 'puppetserver/acceptance/compat_utils'
 
+# zypper installs of puppet-agent for SLES will fail if the package can't be
+# validated with the Puppet GPG key.  Beaker doesn't implicitly install the
+# Puppet GPG key so need to install it before trying to install the
+# puppet-agent.
+step "Install Updated Puppet GPG key for Any SLES Agents."
+
+nonmaster_agents.each { |agent|
+  variant = master['platform'].variant
+  if variant == 'sles'
+    on(agent, 'rpmkeys --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppet')
+  end
+}
+
 step "Install Legacy Puppet Agents."
 
 default_puppet_version = '1.10.1'


### PR DESCRIPTION
Previously, when the Puppet 4 compatibility suite tried to install the
SLES 12 agent from the PC1 repo, it failed due to the GPG public key
associated with the package not being present on the host.  This commit
adds a step which installs the public key prior to the package install.
This is done for SLES 12 only because it isn't necessary for other
package managers.  yum and apt installs pull down the public key
automatically as part of the package install.