### PR TITLE
(SERVER-1808) Adjust file endpoint auth.conf rules for valid methods

### DIFF
--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -56,18 +56,43 @@ authorization: {
             name: "puppetlabs environments"
         },
         {
-            # Allow nodes to access all file services; this is necessary for
-            # pluginsync, file serving from modules, and file serving from
-            # custom mount points (see fileserver.conf). Note that the `/file`
-            # prefix matches requests to file_metadata, file_content, and
-            # file_bucket_file paths.
+            # Allow nodes to access all file_bucket_files.  Note that access for
+            # the 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
             match-request: {
-                path: "/puppet/v3/file"
+                path: "/puppet/v3/file_bucket_file"
                 type: path
+                method: [get, head, post, put]
             }
             allow: "*"
             sort-order: 500
-            name: "puppetlabs file"
+            name: "puppetlabs file bucket file"
+        },
+        {
+            # Allow nodes to access all file_content.  Note that access for the
+            # 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_content"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file content"
+        },
+        {
+            # Allow nodes to access all file_metadata.  Note that access for the
+            # 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_metadata"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file metadata"
         },
         {
             # Allow nodes to retrieve only their own node definition
@@ -123,15 +148,15 @@ authorization: {
             name: "puppetlabs experimental"
         },
         {
-          # Deny everything else. This ACL is not strictly
-          # necessary, but illustrates the default policy
-          match-request: {
-            path: "/"
-            type: path
-          }
-          deny: "*"
-          sort-order: 999
-          name: "puppetlabs deny all"
+            # Deny everything else. This ACL is not strictly
+            # necessary, but illustrates the default policy
+            match-request: {
+                path: "/"
+                type: path
+            }
+            deny: "*"
+            sort-order: 999
+            name: "puppetlabs deny all"
         }
     ]
 }


### PR DESCRIPTION
This commit splits the /puppet/v3/file auth.conf rule into separate
rules for file_bucket_file, file_content, and file_metadata.  The
discrete rules reflect the minimal set of request methods which are
valid for each endpoint.