### PR TITLE
(SERVER-911) Remove sync step for PE in reload crl test

### DIFF
--- a/acceptance/suites/tests/service_framework/reload_updated_crl.rb
+++ b/acceptance/suites/tests/service_framework/reload_updated_crl.rb
@@ -78,12 +78,6 @@ step 'Revoke cert' do
   on(master, puppet('cert', 'revoke', cert_to_revoke))
 end
 
-if options[:type] == 'pe'
-  step 'Copy cacrl to hostcrl in order to work around SERVER-911' do
-    on(master, 'cp "$(puppet config print cacrl)" "$(puppet config print hostcrl)"')
-  end
-end
-
 step 'Validate that noop agent run successful after cert revoked but before reload' do
   on(master, puppet('agent', '--test',
                     '--server', server,


### PR DESCRIPTION
Previously, the `reload_updated_crl` acceptance test included a step for
PE which copied the file at the cacrl location over to the file at the
hostcrl location after a certificate was revoked.  The work done for
PE-19484 allowed for the hostcrl file to be updated automatically after
service restart for PE, as had already previously been the case for OSS
Puppet Server.  This commit removes the synchronization step from the
test since it is no longer necessary for PE.