### PR TITLE
(SERVER-715) environment registry isExpired returns nil

### DIFF
--- a/src/clj/puppetlabs/services/jruby/puppet_environments.clj
+++ b/src/clj/puppetlabs/services/jruby/puppet_environments.clj
@@ -26,7 +26,7 @@
       (isExpired [this env-name]
         (when-not env-name
           (throw (IllegalArgumentException. (i18n/trs "Missing environment name!"))))
-        (get-in @state [(keyword env-name) :expired]))
+        (get-in @state [(keyword env-name) :expired] true))
       (removeEnvironment [this env-name]
         (when-not env-name
           (throw (IllegalArgumentException. (i18n/trs "Missing environment name!"))))

--- a/test/unit/puppetlabs/services/jruby/puppet_environments_test.clj
+++ b/test/unit/puppetlabs/services/jruby/puppet_environments_test.clj
@@ -61,6 +61,14 @@
       (is (false? (contains-environment? reg :foo)))
       (.registerEnvironment reg "foo")
       (is (false? (.isExpired reg "foo")))
-      (is (false? (expired? reg :foo))))))
+      (is (false? (expired? reg :foo)))))
+  (testing "unregistered environments are expired by default"
+    (let [reg (puppet-env/environment-registry)]
+      (is (false? (contains-environment? reg :foo)))
+      (is (true? (.isExpired reg "foo")))
+      ; expired? returns nil because it bypasses the
+      ; EnvironmentRegistry.isExpired fn and accesses the underlying data
+      ; directly, which of course not contain :foo
+      (is (nil? (expired? reg :foo))))))
 
 


### PR DESCRIPTION
The `EnvironmentRegistry.isExpired` method reified in the `environment-registry` fn will
try to return `nil` if an environment is unregistered. The java interface requires it
returns a boolean, and so an exception is thrown.

This commit changes the implementation of `isExpired` to return `true` if the environment
is unregistered, since returning `false` might indicate the cache entry is still valid,
when the registry doesn't actually know anything about the entry