### PR TITLE
(SERVER-1826) Send mime type with static file serving response

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -472,6 +472,7 @@
 
         :else
         {:status 200
+         :headers {"Content-Type" "application/octet-stream"}
          :body (get-code-content environment code-id file-path)}))))
 
 (def MetricIdsForStatus (schema/atom [[schema/Str]]))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -457,17 +457,22 @@
       (cond
         (some empty? [environment code-id file-path])
         {:status 400
+         :headers {"Content-Type" "text/plain"}
          :body (i18n/tru "Error: A /static_file_content request requires an environment, a code-id, and a file-path")}
+
         (not (nil? (schema/check ps-common/Environment environment)))
         {:status 400
+         :headers {"Content-Type" "text/plain"}
          :body (ps-common/environment-validation-error-msg environment)}
 
         (not (nil? (schema/check ps-common/CodeId code-id)))
         {:status 400
+         :headers {"Content-Type" "text/plain"}
          :body (ps-common/code-id-validation-error-msg code-id)}
 
         (not (valid-static-file-path? file-path))
         {:status 403
+         :headers {"Content-Type" "text/plain"}
          :body (i18n/tru "Request Denied: A /static_file_content request must be a file within the files directory of a module.")}
 
         :else

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -194,11 +194,13 @@
       (testing "the /static_file_content endpoint successfully streams file content"
         (let [response (testutils/get-static-file-content "modules/foo/files/bar.txt?code_id=foobar&environment=test")]
           (is (= 200 (:status response)))
+          (is (= "application/octet-stream" (get-in response [:headers "content-type"])))
           (is (= "test foobar modules/foo/files/bar.txt\n" (:body response)))))
       (testing (str "the /static_file_content endpoint successfully streams file content "
                     "from directories other than /modules")
         (let [response (testutils/get-static-file-content "site/foo/files/bar.txt?code_id=foobar&environment=test")]
           (is (= 200 (:status response)))
+          (is (= "application/octet-stream" (get-in response [:headers "content-type"])))
           (is (= "test foobar site/foo/files/bar.txt\n" (:body response))))
         (let [response (testutils/get-static-file-content "dist/foo/files/bar.txt?code_id=foobar&environment=test")]
           (is (= 200 (:status response)))


### PR DESCRIPTION
I'm curious what folks think of this. Since it was just for one response of one endpoint I thought that simply updating the map returned would be the simplest solution, and since we're already directly returning a map with `:body` and `:status` it seemed weird to use the ring helpers to set the header.