### PR TITLE
[dnm] (TK-442) Bring in clj-parent with new version of tk-metrics

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.1.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.2.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
I think we'll probably want to wait on this and instead pull in a new version after we've bumped tk-metrics within clj-parent to take in this PR https://github.com/puppetlabs/trapperkeeper-metrics/pull/52 as well.