### PR TITLE
(MAINT) Bump puppet-agent to 98208e4

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -25,7 +25,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "4.99.0.202.ge36cade",
+                         "4.99.0.269.g98208e4",
                          :string) ||
                          get_puppet_version
 
@@ -34,7 +34,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "e36cade45d32f0cca85dd3e51b1fcc17e7cd8bcc",
+                         "98208e4335746b14197800a75948e6c022debfb3",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:

--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -61,7 +61,7 @@
   JRubyPuppet.  Returns `nil` if Puppet does not have a setting for the given
   key.  The keyword will be converted into the appropriate format before it is
   passed to Puppet - for example, if you want the value of Puppet's
-  'archive_files' setting, pass in `:archive-files`."
+  'autoflush' setting, pass in `:autoflush`."
   [jruby-puppet k]
   {:pre [(keyword? k)]}
   (->> (keyword->setting k)

--- a/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -34,7 +34,7 @@
            (is (= "0.0.0.0" (get-puppet-config-value jruby-puppet :bindaddress)))
            (is (= 8140 (get-puppet-config-value jruby-puppet :masterport)))
            (is (= false (get-puppet-config-value jruby-puppet :onetime)))
-           (is (= false (get-puppet-config-value jruby-puppet :archive-files)))
+           (is (= true (get-puppet-config-value jruby-puppet :autoflush)))
            (is (= nil (get-puppet-config-value jruby-puppet :not-a-valid-setting))))
          (testing "get-puppet-config* values match mock config values"
            (let [mock-config-with-keywordized-keys


### PR DESCRIPTION
This PR bumps the puppet submodule and puppet-agent versions for
testing to 27fdad2 and 4.99.0.269.g98208e4, respectively.

Previously, the Clojure unit tests contained a test for the value of the
Puppet archive_files setting.  Per changes in PUP-7260 which just landed
in Ruby Puppet, this setting no longer exists.  This commit changes the
test to instead validate the value of the autoflush setting.  The
specific setting being tested isn't important.  The test just proves
that a known expected default value for a setting can be retrieved from
Ruby Puppet.