### PR TITLE
(SERVER-1840) Bump to JRuby 9.1.11.0-1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def ps-version "5.0.0-master-SNAPSHOT")
 (def jruby-1_7-version "1.7.27-1")
-(def jruby-9k-version "9.1.9.0-2")
+(def jruby-9k-version "9.1.11.0-1")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the jruby-deps dependencies for JRuby 9k to
9.1.11.0-1.