### PR TITLE
(TK-443) Disable http url based metrics

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.1.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.2.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/ruby/puppetserver-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/http_client.rb
@@ -181,6 +181,7 @@ class Puppet::Server::HttpClient
     self.configure_timeouts(client_options)
     self.configure_ssl(client_options)
     self.configure_metrics(client_options)
+    client_options.set_enable_url_metrics(false)
     client_options
   end
 

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -419,20 +419,14 @@
                (testing "GET request"
                  (.runScriptlet container "$c.get('/hello', {})")
                  (let [metrics-data (metrics/get-client-metrics-data metric-registry)]
-                   (is (= #{(add-metric-ns "with-url.http://localhost:8080/hello")}
-                          (set (map :metric-name (:url metrics-data)))))
-                   (is (= #{(add-metric-ns "with-url-and-method.http://localhost:8080/hello.GET")}
-                          (set (map :metric-name (:url-and-method metrics-data)))))))
+                   (is (= [] (:url metrics-data)))
+                   (is (= [] (:url-and-method metrics-data)))))
                (testing "POST request"
                  (.runScriptlet container "$c.post('/hello', 'body', {})")
                  (let [metrics-data (metrics/get-client-metrics-data metric-registry)
                        url-metrics-data (:url metrics-data)]
-                   (is (= #{(add-metric-ns "with-url.http://localhost:8080/hello")}
-                          (set (map :metric-name url-metrics-data))))
-                   (is (= 2 (:count (first url-metrics-data))))
-                   (is (= #{(add-metric-ns "with-url-and-method.http://localhost:8080/hello.GET")
-                            (add-metric-ns "with-url-and-method.http://localhost:8080/hello.POST")}
-                          (set (map :metric-name (:url-and-method metrics-data)))))))
+                   (is (= [] (:url metrics-data)))
+                   (is (= [] (:url-and-method metrics-data)))))
                (testing "no metric-id metrics are registered"
                  (is (= [] (:metric-id (metrics/get-client-metrics-data metric-registry))))))
              (testing (str "metric registry has metric-id metrics after http requests have been made"

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -414,8 +414,7 @@
              (testing "metric registry has no metrics when no http requests have been made"
                (is (= {:url [] :url-and-method [] :metric-id []}
                       (metrics/get-client-metrics-data metric-registry))))
-             (testing (str "metric registry has url and url-and-method metrics after http requests"
-                           " have been made without metric-id specified")
+             (testing "metric registry does not have any metrics by default"
                (testing "GET request"
                  (.runScriptlet container "$c.get('/hello', {})")
                  (let [metrics-data (metrics/get-client-metrics-data metric-registry)]


### PR DESCRIPTION
Previously http-client would create url and url+method metrics for every
call which could become expensive in terms of memory on a production
system.

With the 0.9.0 release (brought in by clj-parent 1.2.1) we can disable this
behavior, which we do with this patch.