### PR TITLE
(MAINT) Bump minimum puppet-agent for packaging to 4.99.0

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -7,7 +7,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["puppet-agent >= 1.6.0"],
+      redhat: { dependencies: ["puppet-agent >= 4.99.0"],
                 build-dependencies: ["%{open_jdk}"],
                 # Install some gems
                 install: [
@@ -35,7 +35,7 @@ ezbake: {
                ]
              }
 
-      debian: { dependencies: ["puppet-agent (>= 1.6.0)"],
+      debian: { dependencies: ["puppet-agent (>= 4.99.0)"],
                 build-dependencies: ["openjdk-8-jre-headless"],
                 # Install some gems
                 install: [


### PR DESCRIPTION
This commit bumps the minimum puppet-agent package version from 1.6.0 to
4.99.0 in preparation for the Puppet 5 release.