### PR TITLE
(SERVER-1798) Support testing against puppetdb and puppet-agent nightly

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -303,6 +303,11 @@ module PuppetServerExtensions
     param_from_build(url, "PUPPETDB_PACKAGE_BUILD_VERSION")
   end
 
+  def latest_agent_build
+    url = "https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-agent%20suite%20pipelines/job/platform_puppet-agent_intn-van-promote_suite-daily-promotion-master/lastSuccessfulBuild/api/json"
+    param_from_build(url, "SUITE_COMMIT")
+  end
+
   def param_from_build(url, param)
     response = https_request(url, :git)
     json = JSON.parse(response.body)

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -298,6 +298,20 @@ module PuppetServerExtensions
     OpenSSL::PKey::RSA.new(rawkey)
   end
 
+  def latest_pdb_build
+    url = "https://cinext-jenkinsmaster-enterprise-prod-1.delivery.puppetlabs.net/view/puppetdb/view/master/job/enterprise_puppetdb_integration-system-puppetdb_full-master/lastSuccessfulBuild/api/json"
+    param_from_build(url, "PUPPETDB_PACKAGE_BUILD_VERSION")
+  end
+
+  def param_from_build(url, param)
+    response = https_request(url, :git)
+    json = JSON.parse(response.body)
+    actions = json["actions"].find { |hash| hash["_class"] == "hudson.model.ParametersAction" }
+    parameters = actions["parameters"]
+    pkg_build_param = parameters.find { |hash| hash["name"] == param }
+    pkg_build_param["value"]
+  end
+
   # Issue an HTTP request and return the Net::HTTPResponse object. Lifted from
   # https://github.com/puppetlabs/pe_acceptance_tests/blob/2015.3.x/lib/http_calls.rb
   # and slightly modified.

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -52,9 +52,10 @@ module PuppetServerExtensions
       :puppet_build_version => puppet_build_version,
       :puppetdb_build_version => puppetdb_build_version,
     }
+  end
 
+  def self.print_config
     pp_config = PP.pp(@config, "")
-
     Beaker::Log.notify "Puppet Server Acceptance Configuration:\n\n#{pp_config}\n\n"
   end
 

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -308,6 +308,11 @@ module PuppetServerExtensions
     param_from_build(url, "SUITE_COMMIT")
   end
 
+  def latest_puppet_version
+    url = "https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-agent%20suite%20pipelines/job/platform_puppet-agent_intn-van-promote_suite-daily-promotion-master/lastSuccessfulBuild/api/json"
+    param_from_build(url, "SUITE_VERSION")
+  end
+
   def param_from_build(url, param)
     response = https_request(url, :git)
     json = JSON.parse(response.body)

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -26,8 +26,7 @@ module PuppetServerExtensions
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
                          "4.99.0.345.ge20bbc5",
-                         :string) ||
-                         get_puppet_version
+                         :string)
 
     # puppet-agent version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppet-agent/
@@ -102,18 +101,6 @@ module PuppetServerExtensions
     end
 
     value
-  end
-
-  def self.get_puppet_version
-    puppet_submodule = "ruby/puppet"
-    puppet_version = `git --work-tree=#{puppet_submodule} --git-dir=#{puppet_submodule}/.git describe | cut -d- -f1`
-    case puppet_version
-    when /(\d\.\d\.\d)\n/
-      return $1
-    else
-      logger.warn("Failed to discern Puppet version using `git describe` on #{puppet_submodule}")
-      return nil
-    end
   end
 
   def puppetserver_initialize_ssl

--- a/acceptance/suites/pre_suite/foss/00_setup_environment.rb
+++ b/acceptance/suites/pre_suite/foss/00_setup_environment.rb
@@ -1,2 +1,13 @@
-step "Initialize Test Config"
+step "Initialize Test Config" do
   PuppetServerExtensions.initialize_config options
+
+  if PuppetServerExtensions.config[:puppet_build_version] == 'LATEST'
+    PuppetServerExtensions.config[:puppet_build_version] = latest_agent_build
+    logger.info "Using latest Puppet agent build version (#{PuppetServerExtensions.config[:puppet_build_version]})"
+  end
+
+  if PuppetServerExtensions.config[:puppetdb_build_version] == 'LATEST'
+    PuppetServerExtensions.config[:puppetdb_build_version] = latest_pdb_build
+    logger.info "Using latest PuppetDB build version (#{PuppetServerExtensions.config[:puppetdb_build_version]})"
+  end
+end

--- a/acceptance/suites/pre_suite/foss/00_setup_environment.rb
+++ b/acceptance/suites/pre_suite/foss/00_setup_environment.rb
@@ -1,13 +1,16 @@
 step "Initialize Test Config" do
   PuppetServerExtensions.initialize_config options
 
-  if PuppetServerExtensions.config[:puppet_build_version] == 'LATEST'
-    PuppetServerExtensions.config[:puppet_build_version] = latest_agent_build
-    logger.info "Using latest Puppet agent build version (#{PuppetServerExtensions.config[:puppet_build_version]})"
-  end
+  latest_options = [
+    [:puppet_build_version, lambda { latest_agent_build }],
+    [:puppet_version, lambda { latest_puppet_version }],
+    [:puppetdb_build_version, lambda { latest_pdb_build }]
+  ]
 
-  if PuppetServerExtensions.config[:puppetdb_build_version] == 'LATEST'
-    PuppetServerExtensions.config[:puppetdb_build_version] = latest_pdb_build
-    logger.info "Using latest PuppetDB build version (#{PuppetServerExtensions.config[:puppetdb_build_version]})"
+  latest_options.each do |(option, fn)|
+    if PuppetServerExtensions.config[option] == 'LATEST'
+      PuppetServerExtensions.config[option] = fn.call
+      logger.info "Setting option #{option} to latest version #{PuppetServerExtensions.config[option]}"
+    end
   end
 end

--- a/acceptance/suites/pre_suite/foss/00_setup_environment.rb
+++ b/acceptance/suites/pre_suite/foss/00_setup_environment.rb
@@ -8,7 +8,7 @@ step "Initialize Test Config" do
   ]
 
   latest_options.each do |(option, fn)|
-    if PuppetServerExtensions.config[option] == 'LATEST'
+    if PuppetServerExtensions.config[option].upcase == 'LATEST'
       PuppetServerExtensions.config[option] = fn.call
       logger.info "Setting option #{option} to latest version #{PuppetServerExtensions.config[option]}"
     end

--- a/acceptance/suites/pre_suite/foss/00_setup_environment.rb
+++ b/acceptance/suites/pre_suite/foss/00_setup_environment.rb
@@ -13,4 +13,5 @@ step "Initialize Test Config" do
       logger.info "Setting option #{option} to latest version #{PuppetServerExtensions.config[option]}"
     end
   end
+  PuppetServerExtensions.print_config
 end

--- a/acceptance/suites/pre_suite/foss/35_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/35_install_pdb.rb
@@ -5,14 +5,8 @@ install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
 repo_config_dir = 'tmp/repo_configs'
 
 step "Install PuppetDB repository" do
-  pdb_build_version = test_config[:puppetdb_build_version]
-  if pdb_build_version == 'LATEST'
-    pdb_build_version = latest_pdb_build
-    puts "Using latest PuppetDB build version (#{pdb_build_version})"
-  end
-
   install_puppetlabs_dev_repo(
-    master, 'puppetdb', pdb_build_version,
+    master, 'puppetdb', test_config[:pdb_build_version],
     repo_config_dir, install_opts)
 
   # Internal packages on ubuntu/debian aren't authenticated and thus apt

--- a/acceptance/suites/pre_suite/foss/35_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/35_install_pdb.rb
@@ -5,8 +5,14 @@ install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
 repo_config_dir = 'tmp/repo_configs'
 
 step "Install PuppetDB repository" do
+  pdb_build_version = test_config[:puppetdb_build_version]
+  if pdb_build_version == 'LATEST'
+    pdb_build_version = latest_pdb_build
+    puts "Using latest PuppetDB build version (#{pdb_build_version})"
+  end
+
   install_puppetlabs_dev_repo(
-    master, 'puppetdb', test_config[:puppetdb_build_version],
+    master, 'puppetdb', pdb_build_version,
     repo_config_dir, install_opts)
 
   # Internal packages on ubuntu/debian aren't authenticated and thus apt

--- a/acceptance/suites/pre_suite/foss/35_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/35_install_pdb.rb
@@ -6,7 +6,7 @@ repo_config_dir = 'tmp/repo_configs'
 
 step "Install PuppetDB repository" do
   install_puppetlabs_dev_repo(
-    master, 'puppetdb', test_config[:pdb_build_version],
+    master, 'puppetdb', test_config[:puppetdb_build_version],
     repo_config_dir, install_opts)
 
   # Internal packages on ubuntu/debian aren't authenticated and thus apt


### PR DESCRIPTION
This commit allows the PUPPET_BUILD_VERSION and PUPPETDB_BUILD_VERSION variables to be set to 'LATEST'. When those environment variables are set to 'LATEST' the version will be set based on the last successful build of puppetdb or puppet-agent.