### PR TITLE
(SERVER-1850) Server 5.0 release notes

### DIFF
--- a/documentation/config_file_logbackxml.markdown
+++ b/documentation/config_file_logbackxml.markdown
@@ -22,7 +22,7 @@ Puppet Server also relies on Logback to manage, rotate, and archive Server log f
 
 #### `level`
 
-To modify Puppet Server's logging level, change the `level` attribute of the `root` tag. By default, the logging level is set to `info`:
+To modify Puppet Server's logging level, change the `level` attribute of the `root` element. By default, the logging level is set to `info`:
 
     <root level="info">
 
@@ -31,6 +31,10 @@ Supported logging levels, in order from most to least information logged, are `t
     <root level="debug">
 
 Puppet Server profiling data is included at the `debug` logging level.
+
+You can also change the logging level for JRuby logging from its defaults of `error` and `info` by setting the `level` attribute of the `jruby` element. For example, to enable debug logging for JRuby, set the attribute to `debug`:
+
+    <jruby level="debug">
 
 #### Logging location
 

--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -20,7 +20,9 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
 > **Note:** Under most conditions, you won't change the default settings for `master-conf-dir` or `master-code-dir`. However, if you do, also change the equivalent Puppet settings (`confdir` or `codedir`) to ensure that commands like `puppet cert` and `puppet module` use the same directories as Puppet Server. You must also specify the non-default `confdir` when running commands, since that setting must be set before Puppet tries to find its config file.
 
-* The `jruby-puppet` settings configure the interpreter:
+* The `jruby-puppet` settings configure the interpreter.
+
+    > **Deprecation Note:** Puppet Server 5.0 removed the `compat-version` setting, which is incompatible with JRuby 1.7.27, and the service won't start if `compat-version` is set. To use Ruby 2.x with Puppet Server, enable Puppet Server 5.x's JRuby 9k support by assigning the `JRUBY_JAR` environment variable. See [Puppet Server Configuration](./configuration.markdown) for details.
 
     * `ruby-load-path`: The location where Puppet Server expects to find Puppet, Facter, and other components.
 
@@ -54,7 +56,7 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
     * `borrow-timeout`: Optional. The timeout in milliseconds, when attempting to borrow an instance from the JRuby pool. The default is 1200000.
 
-    * `use-legacy-auth-conf`: Optional. The method to be used for authorizing access to the HTTP endpoints served by the master service. The applicable endpoints are listed in [Puppet v3 HTTP API](https://docs.puppet.com/puppet/latest/reference/http_api/http_api_index.html#puppet-v3-http-api).
+    * `use-legacy-auth-conf`: Optional. The method to be used for authorizing access to the HTTP endpoints served by the master service. The applicable endpoints are listed in [Puppet v3 HTTP API](https://docs.puppet.com/puppet/latest/reference/http_api/http_api_index.html#puppet-v3-http-api). As of Puppet Server 5.0, this setting's default value is false.
 
         If this setting is set to `true`, Puppet uses the [deprecated][] Ruby `puppet-agent` authorization method and [Puppet `auth.conf`][`auth.conf` documentation] format, which will be removed in a future version of Puppet Server.
 

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -102,15 +102,17 @@ puppetlabs.services.ca.certificate-authority-service/certificate-authority-servi
 #puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
 ~~~
 
-## Configuring JRuby Version
+## Configuring the JRuby Version
 
-By default, Puppet Server utilizes a version of the JRuby 1.7.x series, running in a mode which conforms to MRI/Ruby language version 1.9. Starting with the Puppet Server 5.0 release, however, it is now possible to configure Puppet Server to instead use a version of the JRuby 9k series (9.x.y.z). The specific Ruby language version that each JRuby 9k release conforms to is expected to evolve over time, tracking newer Ruby 2.x language versions.  For example, the JRuby 9.1.8.0 release conforms to Ruby language version 2.3.1 whereas 9.1.9.0 conforms to Ruby language version 2.3.3.
+By default, Puppet Server uses a version of the JRuby 1.7.x series, running in a mode which conforms to MRI/Ruby language version 1.9. Starting with the Puppet Server 5.0 release, however, you can configure Puppet Server to instead use the JRuby 9k series (9.x.y.z). The Ruby language version supported by each JRuby 9k release is expected to evolve over time, tracking newer Ruby 2.x language versions. For example, the JRuby 9.1.8.0 release conforms to Ruby language version 2.3.1, whereas 9.1.9.0 conforms to Ruby language version 2.3.3.
 
-Note that the use of JRuby 9k with Puppet Server is still considered somewhat experimental.  We have not encountered any significant functional issues with it in internal testing so far and the JRuby community is solidly behind it as their base going forward. We have, however, observed some [targeted performance regressions](https://github.com/jruby/jruby/issues/4112#issuecomment-242504130) and increased memory usage as compared to the JRuby 1.7 series. We hope to see these issues improved upon over time, though, and at some point be able to switch to 9k as the default JRuby for Puppet Server. In the meantime, we are very interested in hearing about external users' experiences with JRuby 9k and hope to work with the JRuby community to make incremental improvements.
+Using JRuby 9k with Puppet Server is still considered somewhat experimental. We have not encountered any significant functional issues with it in internal testing so far, and the JRuby community is solidly behind it as their base going forward. We have, however, observed some [targeted performance regressions](https://github.com/jruby/jruby/issues/4112#issuecomment-242504130) and increased memory usage compared to the JRuby 1.7 series.
 
-Note also that with the ability to configure Puppet Server to use JRuby 9k for Ruby language 2.x support, we have also now removed support for the `jruby-puppet.compat-version` setting.  The JRuby community no longer supports the use of the `compat-version` setting for configuring Ruby language 2.0, which is [effectively broken](https://github.com/jruby/jruby/issues/4613) in the latest version in the JRuby 1.7 series, 1.7.27.  If the `compat-version` setting is present in your Puppet Server configuration, the puppetserver service will fail to startup with an error message which describes steps you can follow in order to configure the use of JRuby 9k instead.
+We hope to see these issues resolved over time, and at some point be able to switch to 9k as the default JRuby. In the meantime, we are very interested in hearing about external users' experiences with JRuby 9k and hope to work with the JRuby community to make incremental improvements.
 
-To provide configurable support for JRuby 1.7 vs. 9k, Puppet Server 5.0 and later packages include both versions of JRuby and their upstream dependencies.  Because of this, the size of the rpm and deb packages for Puppet Server 5.0 is significantly larger than for the Puppet Server 2.x series - around 30 MB.
+With the ability to configure Puppet Server to use JRuby 9k for Ruby language 2.x support, we have also removed support for the `jruby-puppet.compat-version` setting from `puppetserver.conf`. The JRuby community no longer supports the `compat-version` setting for configuring Ruby language 2.0, which is [effectively broken](https://github.com/jruby/jruby/issues/4613) as of JRuby 1.7.27. If the `compat-version` setting is present in your Puppet Server configuration, the `puppetserver` service exits with an error message that describes steps you can follow in order to configure the use of JRuby 9k instead.
+
+To provide configurable support for JRuby 1.7 vs. 9k, Puppet Server 5.0 and later packages include both versions of JRuby and their upstream dependencies. Because of this, the packages are about 30 MB larger than in the Puppet Server 2.x series.
 
 To change the JRuby version Puppet Server uses, you can edit the init config file.
 
@@ -121,55 +123,67 @@ To change the JRuby version Puppet Server uses, you can edit the init config fil
 
 ### Enabling JRuby 9k
 
-1. Open the init config file and add the following line:
+1.  Open the init config file and add the following line:
 
-        JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
+    ```
+    JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
+    ```
 
-This line causes a jar containing JRuby 9k and its upstream dependencies to be added to the java classpath in place of the default JRuby jar file which is used on the java classpath, `/opt/puppetlabs/server/apps/puppetserver/jruby-1_7.jar`.
+    This line causes a jar containing JRuby 9k and its upstream dependencies to be added to the java classpath in place of the default JRuby jar file which is used on the java classpath, `/opt/puppetlabs/server/apps/puppetserver/jruby-1_7.jar`.
 
-If the path to the jar file for the `JRUBY_JAR` setting does not exist, the puppetserver service will fail to start, with an error message like the following being written to the system journal or `/var/log/puppetlabs/puppetserver-daemon.log` file, depending upon the OS:
+    If the path to the jar file for the `JRUBY_JAR` setting does not exist, the puppetserver service will fail to start, with an error message like the following being written to the system journal or `/var/log/puppetlabs/puppetserver-daemon.log` file, depending upon the OS:
 
-~~~
-Jun 01 19:58:16 myhost puppetserver[24001]: Unable to find specified JRUBY_JAR: /opt/puppetlabs/server/apps/puppetserver/jruby-wrong.jar
-~~~
+    ```
+    Jun 01 19:58:16 myhost puppetserver[24001]: Unable to find specified JRUBY_JAR:/opt/puppetlabs/server/apps/puppetserver/jruby-wrong.jar
+    ```
 
-2. Restart the `puppetserver` service.
+2.  Restart the `puppetserver` service.
 
-Note that a full service restart is needed for the new JRuby version to be used. A service reload or `kill -HUP` is not sufficient.
+    You must fully restart the service to use the new JRuby version. A service reload or `kill -HUP` reload is not sufficient.
 
-Note that the `JRUBY_JAR` setting affects the version of JRuby that the puppetserver service and all subcommands (including foreground, gem, irb, and ruby) use.
+    The `JRUBY_JAR` setting changes the version of JRuby that the `puppetserver` service and all subcommands (including `foreground`, `gem`, `irb`, and `ruby`) use.
 
-To confirm that JRuby 9k is being used by puppetserver, you could run the following command:
+    To confirm that `puppetserver` is using JRuby 9k, run:
 
-~~~sh
-$ puppetserver ruby --version
-jruby 9.1.9.0 (2.3.3) 2017-05-15 28aa830 OpenJDK 64-Bit Server VM 25.131-b12 on 1.8.0_131-b12 +jit [linux-x86_64]
-~~~
+    ```sh
+    puppetserver ruby --version
+    ```
 
-In the puppetserver log file, `/var/log/puppetlabs/puppetserver/puppetserver.log`, you should also see an INFO log entry which outputs the same JRuby version info:
+    This returns the JRuby version in use. For JRuby 9k, the version starts with `9.`:
 
-~~~
-2017-06-01 18:41:49,563 INFO  [async-dispatch-2] [p.s.j.jruby-puppet-service] JRuby version info: jruby 9.1.9.0 (2.3.3) 2017-05-15 28aa830 OpenJDK 64-Bit Server VM 25.131-b12 on 1.8.0_131-b12 +jit [linux-x86_64]
-~~~
+    ```
+    jruby 9.1.9.0 (2.3.3) 2017-05-15 28aa830 OpenJDK 64-Bit Server VM 25.131-b12 on 1.8.0_131-b12 +jit [linux-x86_64]
+    ```
+
+    In `/var/log/puppetlabs/puppetserver/puppetserver.log`, you should also see an INFO log entry that outputs the same JRuby version info:
+
+    ```
+    2017-06-01 18:41:49,563 INFO  [async-dispatch-2] [p.s.j.jruby-puppet-service] JRuby version info: jruby 9.1.9.0 (2.3.3) 2017-05-15 28aa830 OpenJDK 64-Bit Server VM 25.131-b12 on 1.8.0_131-b12 +jit [linux-x86_64]
+    ```
 
 ### Reverting to the default JRuby, 1.7.x
 
-1. To return to using JRuby 1.7.x, open the init config file and remove the `JRUBY_JAR` line that had been previously been added to enable the use of JRuby 9k.
+1.  To return to using JRuby 1.7.x, open the init config file and remove the `JRUBY_JAR` line that had been previously been added to enable the use of JRuby 9k.
 
-2. Restart the `puppetserver` service.
+2.  Restart the `puppetserver` service.
 
-After doing this, the puppetserver service and all subcommands should again be using the default JRuby version.  To confirm this for the subcommands, you could run the following:
+    After doing this, the `puppetserver` service and all subcommands should again use the default JRuby version. To confirm this for the subcommands, run:
 
-~~~sh
-$ puppetserver ruby --version
-jruby 1.7.27 (1.9.3p551) 2017-05-11 8cdb01a on OpenJDK 64-Bit Server VM 1.8.0_131-b12 +jit [linux-amd64]
-~~~
+    ``` sh
+    puppetserver ruby --version
+    ```
 
-A jruby 1.7.x version line should also appear in the puppetserver.log file after the service restart as well:
+    This returns the JRuby version in use:
 
-~~~
-2017-06-01 18:49:52,198 INFO  [async-dispatch-2] [p.s.j.jruby-puppet-service] JRuby version info: jruby 1.7.27 (1.9.3p551) 2017-05-11 8cdb01a on OpenJDK 64-Bit Server VM 1.8.0_131-b12 +jit [linux-amd64]
-~~~
+    ```
+    jruby 1.7.27 (1.9.3p551) 2017-05-11 8cdb01a on OpenJDK 64-Bit Server VM 1.8.0_131-b12 +jit [linux-amd64]
+    ```
+
+    In `/var/log/puppetlabs/puppetserver/puppetserver.log`, you should also see an INFO log entry that outputs the same JRuby version info:
+
+    ```
+    2017-06-01 18:49:52,198 INFO  [async-dispatch-2] [p.s.j.jruby-puppet-service] JRuby version info: jruby 1.7.27 (1.9.3p551) 2017-05-11 8cdb01a on OpenJDK 64-Bit Server VM 1.8.0_131-b12 +jit [linux-amd64]
+    ```
 
 ## Enabling the Insecure SSLv3 Protocol
 

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -114,16 +114,18 @@ With the ability to configure Puppet Server to use JRuby 9k for Ruby language 2.
 
 To provide configurable support for JRuby 1.7 vs. 9k, Puppet Server 5.0 and later packages include both versions of JRuby and their upstream dependencies. Because of this, the packages are about 30 MB larger than in the Puppet Server 2.x series.
 
-To change the JRuby version Puppet Server uses, you can edit the init config file.
+To change the JRuby version Puppet Server uses, you can add an environment variable to the init configuration file.
 
 ### Location
+
+The init configuration file location depends on your operating system.
 
 * For RHEL/CentOS, open `/etc/sysconfig/puppetserver`.
 * For Debian/Ubuntu, open `/etc/default/puppetserver`.
 
 ### Enabling JRuby 9k
 
-1.  Open the init config file and add the following line:
+1.  Open the init configuration file and add the following line:
 
     ```
     JRUBY_JAR="/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"

--- a/documentation/deprecated_features.markdown
+++ b/documentation/deprecated_features.markdown
@@ -389,3 +389,25 @@ To retain the Puppet 4.x behavior, add the [`puppet.conf`](./configuration.markd
 #### Context
 
 This cache was used in workflows where external tooling needs a list of nodes. PuppetDB is the preferred source of node information.
+
+### JRuby's "compat-version" setting
+
+#### Now
+
+Puppet Server 5.0 removes the `jruby-puppet.compat-version` setting in [`puppetserver.conf`](./config_file_puppetserver.markdown), and exits the `puppetserver` service with an error if you start the service with that setting.
+
+#### Previously
+
+Puppet Server 2.7.x allowed you to set `compat-version` to `1.9` or `2.0` to choose a preferred Ruby interpreter version.
+
+#### Detecting and Updating
+
+Launching the `puppetserver` service with this setting enabled will cause it to exit with an error message. The error includes information on [switching from JRuby 1.7.x to JRuby 9k](./configuration.markdown).
+
+For Ruby language 2.x support in Puppet Server, configure Puppet Server to use JRuby 9k instead of JRuby 1.7.27. See the "Configuring the JRuby Version" section of [Puppet Server Configuration](./configuration.markdown) for details.
+
+#### Context
+
+Puppet Server 5.0 updated JRuby v1.7 to v1.7.27, which in turn updated the `jruby-openssl` gem to v0.9.19 and `bouncycastle` libraries to v1.55. JRuby 1.7.27 breaks setting `jruby-puppet.compat-version` to `2.0`.
+
+Server 5.0 also added optional, experimental support for JRuby 9k, which includes Ruby 2.x language support.

--- a/documentation/deprecated_features.markdown
+++ b/documentation/deprecated_features.markdown
@@ -27,15 +27,15 @@ used when authorizing client requests.
 
 For a value of `false` (also the default if not specified), Puppet Server uses the `authorization` settings in
 its own "auth.conf" file, evaluated by the `trapperkeeper-authorization`
-service.  This "auth.conf" file is installed at
-`/etc/puppetlabs/puppetserver/conf.d/auth.conf`.  See the
+service. This "auth.conf" file is installed at
+`/etc/puppetlabs/puppetserver/conf.d/auth.conf`. See the
 [puppetserver "auth.conf"](./config_file_auth.markdown) page for more
 information.
 
 #### In a Future Major Release
 
 The `jruby-puppet.use-legacy-auth-conf` setting will be removed from
-Puppet Server configuration and Puppet Server will instead always use
+Puppet Server configuration, and Puppet Server will instead always use
 the new `trapperkeeper-authorization` "auth.conf" when authorizing client
 requests.
 
@@ -61,12 +61,12 @@ setting to `false` and restart the puppetserver service.
 #### Context
 
 In previous Puppet Server releases, there was no unified mechanism for
-controlling access to the various endpoints that Puppet Server hosts.  Puppet
+controlling access to the various endpoints that Puppet Server hosts. Puppet
 Server used core Puppet "auth.conf" to authorize requests handled by the master
 service and custom client whitelists for the CA and Admin endpoints.
 
 `trapperkeeper-authorization` unifies authorization configuration across all
-of these endpoints into a single file.  The newer "auth.conf" file also uses
+of these endpoints into a single file. The newer "auth.conf" file also uses
 the more flexible HOCON file format for compatibility with how Puppet Server
 configuration files are handled by the Trapperkeeper framework.
 
@@ -352,13 +352,13 @@ of these endpoints into a single file and provides more granular control.
 
 #### Now
 
+The `resource_type` and `resource_types` HTTP APIs were removed in Puppet Server 5.0.
+
+#### Previously
+
 The [`resource_type` and `resource_types` Puppet HTTP API endpoints](https://docs.puppet.com/puppet/4.6/reference/http_api/http_resource_type.html) return information about classes, defined types, and node definitions.
 
 The [`environment_classes` HTTP API in Puppet Server](./puppet-api/v3/environment_classes.markdown) serves as a replacement for the Puppet resource type API for classes.
-
-#### In a Future Major Release
-
-The `resource_type` and `resource_types` HTTP APIs will be removed.
 
 #### Detecting and Updating
 
@@ -371,3 +371,21 @@ The `environment_classes` endpoint ignores Puppet's Ruby-based authorization met
 Users often rely on the `resource_types` endpoint for lists of classes and associated parameters in an environment. For such requests, the `resource_types` endpoint is inefficient and can trigger problematic events, such as [manifests being parsed during a catalog request](https://tickets.puppetlabs.com/browse/SERVER-1200).
 
 To fulfill these requests more efficiently and safely, Puppet Server 2.3.0 introduced the narrowly defined `environment_classes` endpoint.
+
+### Puppet's node cache terminus
+
+#### Now
+
+Puppet 5.0 (and by extension, Puppet Server 5.0) no longer writes node YAML files to its cache by default.
+
+#### Previously
+
+Puppet wrote YAML to its node cache.
+
+#### Detecting and Updating
+
+To retain the Puppet 4.x behavior, add the [`puppet.conf`](./configuration.markdown) setting `node_cache_terminus = write_only_yaml`. The `write_only_yaml` option is deprecated.
+
+#### Context
+
+This cache was used in workflows where external tooling needs a list of nodes. PuppetDB is the preferred source of node information.

--- a/documentation/puppet-api/v3/static_file_content.markdown
+++ b/documentation/puppet-api/v3/static_file_content.markdown
@@ -44,8 +44,10 @@ You must also pass two parameters in the GET request:
 
 ### Response
 
-A successful request to this endpoint returns an `HTTP 200` response code, and the
-contents of the specified file's requested version in the response body. An unsuccessful request returns one of the following error response codes:
+A successful request to this endpoint returns an `HTTP 200` response code and
+`application/octet-stream` Content-Type header, and the contents of the specified file's
+requested version in the response body. An unsuccessful request returns an error response
+code with a `text/plain` Content-Type header:
 
 -   400: returned when any of the parameters are not provided.
 -   403: returned when requesting a file that is not within a module's `files`
@@ -91,7 +93,7 @@ is not configured on Puppet Server.
 
 > **Note:** The `code-content-command` and `code-id-command` scripts are not provided in a
 > default installation or upgrade. For more information about these scripts, see the
-> [static catalog documentation](/puppet/latest/reference/static_catalogs.html).
+> [static catalog documentation](//docs.puppet.com/puppet/latest/reference/static_catalogs.html).
 
 #### Authorization
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -16,7 +16,46 @@ For release notes on versions of Puppet Server prior to Puppet Server 5, see [do
 
 Released June 27, 2017.
 
-This is a major release of Puppet Server.
+This is a major release of Puppet Server, and corresponds with the major release of Puppet 5.0, which also includes many changes and new features relevant to Puppet Server users. 
+
+### Platform changes
+
+Puppet Server 5.0 packages are available for RHEL 6 and 7, Debian 8 (Jessie), Ubuntu 16.04 (Xenial), and SLES 12 SP1.
+
+Puppet Server 5.0 is built with JDK 8, and therefore cannot run on a Java 7 runtime. Server 5.0 packages now depend exclusively upon the `openjdk-8-jre-headless` package. Since Ubuntu Precise and Trusty, and versions of Debian prior to 8 (Jessie), do not distribute that package, we do not provide Puppet Server packages for those operating systems.
+
+For SLES 12 SP1, install the `jessie-backports` repository to add access to Java 8. For details, see [Installing From Packages](./install_from_packages.markdown).
+
+-   [SERVER-1738](https://tickets.puppetlabs.com/browse/SERVER-1738)
+-   [SERVER-1741](https://tickets.puppetlabs.com/browse/SERVER-1741)
+-   [SERVER-1800](https://tickets.puppetlabs.com/browse/SERVER-1800)
+
+### Upgrading from previous versions
+
+Consult the [Puppet 5.0 release notes](https://docs.puppet.com/puppet/5.0/release_notes.html) for more information about important new features and breaking changes. Some especially relevant Puppet 5.0 changes are also noted below.
+
+#### Deprecation: Puppet 5 no longer writes YAML node caches
+
+As of Puppet 5.0, Puppet no longer writes node YAML files to its cache by default. This cache has been used in workflows where external tooling needs a list of nodes, but PuppetDB is now the preferred source of node information.
+
+To retain the Puppet 4.x behavior, add the [`puppet.conf`](./configuration.markdown) setting `node_cache_terminus = write_only_yaml`. Note that `write_only_yaml` is deprecated, and users are encouraged to migrate to PuppetDB in order to retrieve node information.
+
+-   [SERVER-1819](https://tickets.puppetlabs.com/browse/SERVER-1819)
+-   [PUP-6060](https://tickets.puppetlabs.com/browse/PUP-6060)
+
+#### Deprecation/New Feature: Puppet 5 uses JSON serialization by default
+
+Previous versions of Puppet exclusively used PSON, our vendored version of `pure_json`, for serializing communication between agents and masters. Testing showed that PSON serialization's performance was significantly worse than using JSON, and JSON adds opportunities for easier and better interoperability with other tools and programming languages.
+
+As part of this, Puppet Server 5.0 requests JSON over PSON from Puppet 5.0 agents by default, and consumes JSON facts and reports provided by Puppet 5.0 agents.
+
+Puppet 3 and 4 agents continue to use PSON, and Server 5.0 remains compatible with these agents.
+
+For details, consult the [Puppet 5.0 documentation](https://docs.puppet.com/puppet/5.0/release_notes.html).
+
+-   [PUP-3852](https://tickets.puppetlabs.com/browse/PUP-3852)
+
+----
 
 ### Security Fix: Default `auth.conf` rules clarify what's allowed for `file_` endpoints
 
@@ -28,17 +67,11 @@ For clarity, the `file_` endpoint rules are now separated into definitions per e
 
 ### Deprecation: Puppet Server 5 no longer runs on JDK 7
 
-Puppet Server 5.0 is built with JDK 8, and therefore cannot run on a Java 7 runtime. Server 5.0 packages now depend exclusively upon the `openjdk-8-jre-headless` package.
-
--   [SERVER-1738](https://tickets.puppetlabs.com/browse/SERVER-1738)
--   [SERVER-1741](https://tickets.puppetlabs.com/browse/SERVER-1741)
--   [SERVER-1800](https://tickets.puppetlabs.com/browse/SERVER-1800)
-
 ### Deprecation: Legacy `auth.conf` settings are no longer enabled by default
 
 By default, Puppet Server uses the HOCON-based [`auth.conf`][auth.conf] file introduced in Puppet Server 2.4. This uses the `trapperkeeper-authorization` methods of evaluating access to HTTP endpoints, instead of the legacy Puppet `auth.conf` file.
 
-Puppet Server 5.0 completes this switch by changing the default value of the `use-legacy-auth-conf` setting in [`puppetserver.comf`](./config_file_puppetserver.markdown) from true to false.
+Puppet Server 5.0 completes this switch by changing the default value of the `use-legacy-auth-conf` setting in [`puppetserver.conf`](./config_file_puppetserver.markdown) from true to false.
 
 -   [SERVER-1732](https://tickets.puppetlabs.com/browse/SERVER-1732)
 
@@ -49,35 +82,28 @@ Puppet Server 5.0 removes the deprecated HTTP `resource_type` and `resource_type
 -   [SERVER-1251](https://tickets.puppetlabs.com/browse/SERVER-1251)
 -   [SERVER-1120](https://tickets.puppetlabs.com/browse/SERVER-1120)
 
-### Deprecation: Puppet 5 no longer writes YAML node caches
-
-As of Puppet 5.0, Puppet no longer writes node YAML files to its cache by default. This cache has been used in workflows where external tooling needs a list of nodes, but PuppetDB is now the preferred source of node information.
-
-To retain the Puppet 4.x behavior, add the [`puppet.conf`](./configuration.markdown) setting `node_cache_terminus = write_only_yaml`. Note that `write_only_yaml` is deprecated, and users are encouraged to migrate to PuppetDB in order to retrieve node information.
-
--   [SERVER-1819](https://tickets.puppetlabs.com/browse/SERVER-1819)
--   [PUP-6060](https://tickets.puppetlabs.com/browse/PUP-6060)
-
 ### New Feature: Performance metrics
 
-Puppet Server 5.0 includes metrics support previously released in Puppet Enterprise, including [Grafana and Graphite support](./puppet_server_metrics.markdown), both [PE-style](./metrics-api/v1/metrics_api.markdown) and [Jokola-powered](./metrics-api/v2/metrics_api.markdown) metrics API endpoints, and the developer dashboard.
+Puppet Server 5.0 includes metrics support previously released in Puppet Enterprise, including [Grafana and Graphite support](./puppet_server_metrics.markdown), both [PE-style](./metrics-api/v1/metrics_api.markdown) and [Jolokia-powered](./metrics-api/v2/metrics_api.markdown) metrics API endpoints, and the developer dashboard.
 
 -   [SERVER-1797](https://tickets.puppetlabs.com/browse/SERVER-1797)
 -   [SERVER-1752](https://tickets.puppetlabs.com/browse/SERVER-1752)
 -   [SERVER-1739](https://tickets.puppetlabs.com/browse/SERVER-1739)
 -   [SERVER-1737](https://tickets.puppetlabs.com/browse/SERVER-1737)
 -   [SERVER-1721](https://tickets.puppetlabs.com/browse/SERVER-1721)
-- [SERVER-1266](https://tickets.puppetlabs.com/browse/SERVER-1266)
-- [SERVER-1262](https://tickets.puppetlabs.com/browse/SERVER-1262)
-- [SERVER-1261](https://tickets.puppetlabs.com/browse/SERVER-1261)
-- [SERVER-1260](https://tickets.puppetlabs.com/browse/SERVER-1260)
-- [SERVER-1259](https://tickets.puppetlabs.com/browse/SERVER-1259)
+-   [SERVER-1266](https://tickets.puppetlabs.com/browse/SERVER-1266)
+-   [SERVER-1262](https://tickets.puppetlabs.com/browse/SERVER-1262)
+-   [SERVER-1261](https://tickets.puppetlabs.com/browse/SERVER-1261)
+-   [SERVER-1260](https://tickets.puppetlabs.com/browse/SERVER-1260)
+-   [SERVER-1259](https://tickets.puppetlabs.com/browse/SERVER-1259)
 
 ### New Feature: Optional support for JRuby 9k
 
 Puppet Server 5.0 packages include the dependencies for both JRuby 1.7 (running Ruby language version 1.9.3) and JRuby 9k (running Ruby language version 2.3 or later). Puppet Server 5.0 uses JRuby 1.7 by default.
 
 To instead run Puppet Server using JRuby 9k, see the "Configuring the JRuby Version" section of [Puppet Server Configuration](./configuration.markdown).
+
+To facilitate this, the Puppet Server packages include both JRuby 1.7.27 and JRuby 9k, increasing package sizes by about 30 MB.
 
 -   [SERVER-1630](https://tickets.puppetlabs.com/browse/SERVER-1630)
 
@@ -162,6 +188,5 @@ Puppet Server 5.0 resolves this by instead using `/dev/urandom` for CLI subcomma
 ### Other changes
 
 -   [SERVER-1807](https://tickets.puppetlabs.com/browse/SERVER-1807): Puppet Server 5.0 embeds `hocon` gem version 1.2.5 in the default Puppet Server gem path, an upgrade from v1.1.3 used in Server v2.7.2.
--   [SERVER-1772](https://tickets.puppetlabs.com/browse/SERVER-1772): Added ezbake option to specify additional uberjars to be built and installed with the main project, and allows `puppetserver` to include 2 jars for JRuby 1.7 and JRuby 9k dependencies.
 -   [SERVER-1671](https://tickets.puppetlabs.com/browse/SERVER-1671): Log only error output (stderr) to `puppetserver.log` for `generate()` function calls.
 - [SERVER-715](https://tickets.puppetlabs.com/browse/SERVER-715): Resolve intermittent 500 error status results and `isExpired(puppet_environments.clj:27)` logged errors on some HTTP API requests.

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -10,329 +10,158 @@ canonical: "/puppetserver/latest/release_notes.html"
 [puppetserver.conf]: ./config_file_puppetserver.markdown
 [product.conf]: ./config_file_product.markdown
 
-For release notes on versions of Puppet Server prior to Puppet Server 2.5, see [docs.puppet.com](https://docs.puppet.com/puppetserver/2.4/release_notes.html).
+For release notes on versions of Puppet Server prior to Puppet Server 5, see [docs.puppet.com](https://docs.puppet.com/puppetserver/2.7/release_notes.html).
 
-## Puppet Server 2.7.2
+## Puppet Server 5.0
 
-Released December 6, 2016.
+Released June 27, 2017.
 
-This is a bug-fix and feature release of Puppet Server.
+This is a major release of Puppet Server.
 
-> **Warning:** If you're upgrading from Puppet Server 2.4 or earlier and have modified `bootstrap.cfg`, `/etc/sysconfig/puppetserver`, or `/etc/default/puppetserver`, see the [Puppet Server 2.5 release notes first](#potential-breaking-issues-when-upgrading-with-a-modified-bootstrapcfg) **before upgrading** for instructions on avoiding potential failures.
+### Security Fix: Default `auth.conf` rules clarify what's allowed for `file_` endpoints
 
-### Bug Fix: `puppetserver` package no longer depends on `/usr/bin/ruby`
+Puppet Server 5.0 updates the default authorization rules in the [`auth.conf`][auth.conf] file to reflect that access to the "delete" HTTP method for all `/puppet/v3/file_` endpoints cannot be granted, even if a rule in `auth.conf` would permit it. This access is always forbidden due to a hard-coded restriction in the Ruby Puppet endpoint code.
 
-As of Puppet Server 2.7.0, a packaging issue caused the `puppetserver` package to unnecessarily depend on Ruby being installed at `/usr/bin/ruby`. This could potentially block upgrades from older versions of Puppet if Ruby isn't (or couldn't be) installed.
+For clarity, the `file_` endpoint rules are now separated into definitions per endpoint in order to reflect the valid methods that each endpoint supports, including `file_bucket_file`, `file_content`, and `file_metadata`.
 
-Puppet Server 2.7.2 resolves this issue by removing the unnecessary dependency.
+-   [SERVER-1808](https://tickets.puppetlabs.com/browse/SERVER-1808)
 
--   [SERVER-1670](https://tickets.puppetlabs.com/browse/SERVER-1670)
+### Deprecation: Puppet Server 5 no longer runs on JDK 7
 
-### New Feature: Native systemd and SysV service files in Debian packages
+Puppet Server 5.0 is built with JDK 8, and therefore cannot run on a Java 7 runtime. Server 5.0 packages now depend exclusively upon the `openjdk-8-jre-headless` package.
 
-Puppet Server 2.7.2 includes native systemd and SysV service files in Debian packages, allowing for more consistent service management behavior on operating systems that use systemd. This also makes it easier to change service providers after installation.
+-   [SERVER-1738](https://tickets.puppetlabs.com/browse/SERVER-1738)
+-   [SERVER-1741](https://tickets.puppetlabs.com/browse/SERVER-1741)
+-   [SERVER-1800](https://tickets.puppetlabs.com/browse/SERVER-1800)
 
--   [EZ-102](https://tickets.puppetlabs.com/browse/EZ-102)
+### Deprecation: Legacy `auth.conf` settings are no longer enabled by default
 
-## Puppet Server 2.7.1
+By default, Puppet Server uses the HOCON-based [`auth.conf`][auth.conf] file introduced in Puppet Server 2.4. This uses the `trapperkeeper-authorization` methods of evaluating access to HTTP endpoints, instead of the legacy Puppet `auth.conf` file.
 
-Released November 21, 2016.
+Puppet Server 5.0 completes this switch by changing the default value of the `use-legacy-auth-conf` setting in [`puppetserver.comf`](./config_file_puppetserver.markdown) from true to false.
 
-This is a bug-fix release of Puppet Server.
+-   [SERVER-1732](https://tickets.puppetlabs.com/browse/SERVER-1732)
 
-> **Warning:** If you're upgrading from Puppet Server 2.4 or earlier and have modified `bootstrap.cfg`, `/etc/sysconfig/puppetserver`, or `/etc/default/puppetserver`, see the [Puppet Server 2.5 release notes first](#potential-breaking-issues-when-upgrading-with-a-modified-bootstrapcfg) **before upgrading** for instructions on avoiding potential failures.
+### Deprecation: Removed `resource_types` API endpoints and `resource_type` CLI face
 
-### Bug Fix: Set `puppetserver gem` Java arguments separately from the Server service
+Puppet Server 5.0 removes the deprecated HTTP `resource_type` and `resource_types` API endpoints, and the `resource_type` Puppet CLI face. The [`/puppet/v3/environment_classes`](./puppet-api/v3/environment_classes.markdown) HTTP endpoint in Puppet Server replaces a subset of the `resource_type` functionality, including name and parameter metadata for classes.
 
-In Puppet Server 2.7.0, the `JAVA_ARGS` from Puppet Server's sysconfig/default file (typically located at `/etc/sysconfig/puppetserver` or `/etc/defaults/puppetserver`) were passed along to the Java process started when running the [`puppetserver gem`](./gems.markdown) command. This could lead to arguments that are intended only for use when running the full puppetserver service --- for example, debug arguments or large memory heap settings --- being used when running `gem` commands, which could cause the `gem` commands to fail.
+-   [SERVER-1251](https://tickets.puppetlabs.com/browse/SERVER-1251)
+-   [SERVER-1120](https://tickets.puppetlabs.com/browse/SERVER-1120)
 
-In Puppet Server 2.7.1, you can set custom arguments to be passed into the Java process for the `gem` command via the new `JAVA_ARGS_CLI` environment variable, either temporarily on the command line or persistently by adding it to the sysconfig/default file. The `JAVA_ARGS_CLI` environment variable also controls the arguments used when running the `puppetserver ruby` and `puppetserver irb` [subcommands](./subcommands.markdown).
+### Deprecation: Puppet 5 no longer writes YAML node caches
 
--   [SERVER-1644](https://tickets.puppetlabs.com/browse/SERVER-1644)
+As of Puppet 5.0, Puppet no longer writes node YAML files to its cache by default. This cache has been used in workflows where external tooling needs a list of nodes, but PuppetDB is now the preferred source of node information.
 
-## Puppet Server 2.7.0
+To retain the Puppet 4.x behavior, add the [`puppet.conf`](./configuration.markdown) setting `node_cache_terminus = write_only_yaml`. Note that `write_only_yaml` is deprecated, and users are encouraged to migrate to PuppetDB in order to retrieve node information.
 
-Released November 8, 2016.
+-   [SERVER-1819](https://tickets.puppetlabs.com/browse/SERVER-1819)
+-   [PUP-6060](https://tickets.puppetlabs.com/browse/PUP-6060)
 
-This is a feature and bug-fix release of Puppet Server.
+### New Feature: Performance metrics
 
-> **Warning:** If you're upgrading from Puppet Server 2.4 or earlier and have modified `bootstrap.cfg`, `/etc/sysconfig/puppetserver`, or `/etc/default/puppetserver`, see the [Puppet Server 2.5 release notes first](#potential-breaking-issues-when-upgrading-with-a-modified-bootstrapcfg) **before upgrading** for instructions on avoiding potential failures.
+Puppet Server 5.0 includes metrics support previously released in Puppet Enterprise, including [Grafana and Graphite support](./puppet_server_metrics.markdown), both [PE-style](./metrics-api/v1/metrics_api.markdown) and [Jokola-powered](./metrics-api/v2/metrics_api.markdown) metrics API endpoints, and the developer dashboard.
 
-### New Feature: Disable update checking and telemetry data collection
+-   [SERVER-1797](https://tickets.puppetlabs.com/browse/SERVER-1797)
+-   [SERVER-1752](https://tickets.puppetlabs.com/browse/SERVER-1752)
+-   [SERVER-1739](https://tickets.puppetlabs.com/browse/SERVER-1739)
+-   [SERVER-1737](https://tickets.puppetlabs.com/browse/SERVER-1737)
+-   [SERVER-1721](https://tickets.puppetlabs.com/browse/SERVER-1721)
+- [SERVER-1266](https://tickets.puppetlabs.com/browse/SERVER-1266)
+- [SERVER-1262](https://tickets.puppetlabs.com/browse/SERVER-1262)
+- [SERVER-1261](https://tickets.puppetlabs.com/browse/SERVER-1261)
+- [SERVER-1260](https://tickets.puppetlabs.com/browse/SERVER-1260)
+- [SERVER-1259](https://tickets.puppetlabs.com/browse/SERVER-1259)
 
-Puppet Server automatically communicates with Puppet's servers to check for updates. Puppet Server 2.7 adds the option to stop checking for updates by creating a new configuration file, [`product.conf`][product.conf], setting `check-for-updates` to false, then [restarting Puppet Server](./restarting.markdown).
+### New Feature: Optional support for JRuby 9k
 
-For more information, see the [`product.conf`][product.conf] documentation.
+Puppet Server 5.0 packages include the dependencies for both JRuby 1.7 (running Ruby language version 1.9.3) and JRuby 9k (running Ruby language version 2.3 or later). Puppet Server 5.0 uses JRuby 1.7 by default.
 
--   [SERVER-1599](https://tickets.puppetlabs.com/browse/SERVER-1599)
+To instead run Puppet Server using JRuby 9k, see the "Configuring the JRuby Version" section of [Puppet Server Configuration](./configuration.markdown).
 
-### New Feature: New `reload` service action for faster, safer service restarts
+-   [SERVER-1630](https://tickets.puppetlabs.com/browse/SERVER-1630)
 
-Since Puppet Server 2.3, administrators could send a HUP signal to the `puppetserver` process to [quickly reload the service](./restarting.markdown). This provides a faster way to apply changes to settings that require a Puppet Server restart, but sending the signal directly to the process could lead to potential conflicts with actions attempted while the service was reloading.
+### Deprecation: `jruby-puppet.compat-version` setting removed
 
-Puppet Server 2.7 adds a `reload` action can be performed via the operating system's service framework (for example, running `service puppetserver reload`) to perform a HUP reload without requiring a Java process restart. The result is similar to sending a SIGHUP directly to the process, but with the additional benefits of waiting until the server has been reloaded before performing additional scripted commands, tracking the process's ID for you, and providing a more informative exit code should the service fail to reload.
+Puppet Server 5.0 also updates JRuby v1.7 to v1.7.27, which in turn updates the `jruby-openssl` gem to v0.9.19 and `bouncycastle` libraries to v1.55. JRuby 1.7.27 breaks setting `jruby-puppet.compat-version` to `2.0` in [`puppetserver.conf`](./config_file_puppetserver.markdown), so Server 5.0 removes the `jruby-puppet.compat-version` setting and exits the `puppetserver` service with an error if you start the service with that setting.
 
-For details, see [Restarting Puppet Server](./restarting.markdown).
+For Ruby language 2.x support in Puppet Server, configure Puppet Server to use JRuby 9k instead of JRuby 1.7.27 as noted above.
 
--   [SERVER-1490](https://tickets.puppetlabs.com/browse/SERVER-1490)
+-   [SERVER-1630](https://tickets.puppetlabs.com/browse/SERVER-1630)
 
-### Bug Fix: Fix attribute order in CA certificates
+### New Feature: Logback logging for JRuby
 
-In Puppet Server 2.6 and earlier, when the server's certificate authority (CA) service issued a client certificate from a CA with multiple attributes in its certificate Subject's distinguished name (DN), the attributes in the client certificate's Issuer DN were in reverse order from the corresponding attributes in the CA certificate's Subject DN.
+Previous versions of Puppet Server logged JRuby errors to stderr, which Puppet Server wrote to either `/var/log/puppetlabs/puppetserver/puppetserver-daemon.log`, `syslog`, or `journalctl` (depending upon the OS). By default, JRuby also does not log debug messages.
 
-For example, if the Subject DN in the CA certificate were `/C=US/CN=myca.org`, the Issuer DN in the client certificate would be `/CN=myca.org/C=US`. The improper attribute order causes SSL connections made with the client certificate to fail validation.
+To take advantage of the [Logback](./configuration.markdown#Logback) logging infrastructure already in Puppet Server, JRuby now uses a custom `slf4j` logger that bridges logging from JRuby to Logback. As a result, Puppet Server now logs "info" and "error" messages from JRuby into `/var/log/puppetlabs/puppetserver/puppetserver.log` by default. To log debug-level JRuby messages, set the "level" attribute for the "jruby" element in [`/etc/puppetlabs/puppetserver/logback.xml`](./config_file_logback.xml) file to "debug".
 
-In Puppet Server 2.7, the Issuer DN attributes for newly generated client certificates are formatted in the same order as in the corresponding CA Subject DN. SSL connections made with these new certificates are now validated, allowing for successful secure connections.
+-   [SERVER-1475](https://tickets.puppetlabs.com/browse/SERVER-1475)
 
--   [SERVER-1545](https://tickets.puppetlabs.com/browse/SERVER-1545)
+### New Feature: Profiling enabled by default
 
-### Experimental Feature: Run Puppet Server in an MRI 2.0 compatibility mode
+Puppet Server 5.0 enables [profiling](.config_file_puppetserver.markdown) by default, matching the default behavior of Puppet Server in Puppet Enterprise.
 
-Puppet Server uses JRuby 1.7 configured in a "1.9" MRI compatibility mode. In Puppet Server 2.6 and earlier, this configuration could not be changed.
+-   [SERVER-1761](https://tickets.puppetlabs.com/browse/SERVER-1761)
 
-In Puppet Server 2.7, you can choose to run JRuby in modes compatible with 1.9 or 2.0 by changing the `compat-version` setting in [`puppetserver.conf`][puppetserver.conf]. If set to "2.0", users can install and use gems that require Ruby 2.0 with Puppet Server.
+### New Feature: `environment_modules` endpoint can return all modules in all environments
 
-> **Warning:** This is an experimental feature and might not be suitable for production.
+Puppet Server 5.0 makes the environment query parameter of the [`puppet/v3/environment_modules`](./puppet-api/v3/environment_modules.markdown) endpoint optional. Also, to retrieve information about all modules in all environments at once, make a GET request of the `puppet/v3/environment_modules` endpoint without passing any parameters.
 
--   [SERVER-1585](https://tickets.puppetlabs.com/browse/SERVER-1585)
+-   [SERVER-1758](https://tickets.puppetlabs.com/browse/SERVER-1758)
 
-### Bug Fix: Honor all `pp_` custom certificate extension short names
+### New Feature: Respect HTTP(S) proxy variables for `puppetserver gem` subcommand
 
-In Puppet Server 2.6, the Puppet Server certificate authority (CA) did not honor short names for these `pp_*` custom certificate extensions in Puppet:
+In Puppet Server 5.0, the `puppetserver gem` command respects `HTTP_PROXY`, `http_proxy`, `HTTPS_PROXY`, `https_proxy`, `NO_PROXY`, and `no_proxy` environment variables, allowing `puppetserver` to install gems when behind a proxy defined by these environment variables.
 
--   pp_region
--   pp_datacenter
--   pp_zone
--   pp_network
--   pp_securitypolicy
--   pp_cloudplatform
--   pp_apptier
--   pp_hostname
+-   [SERVER-377](https://tickets.puppetlabs.com/browse/SERVER-377)
 
-Puppet Server 2.7 honors these short names as expected.
+### Bug Fix: Add timeout to JRuby lock requests to avoid hanging the `puppetserver` service
 
--   [SERVER-1583](https://tickets.puppetlabs.com/browse/SERVER-1583)
+In previous versions of Puppet Server, a request to lock all JRuby instances would stall indefinitely was made while a single instance in the JRuby pool stalled, effectively deadlocking the `puppetserver` service and requiring manual intervention to release the lock.
 
-### Bug Fix: Make `generate()` function behavior consistent with MRI/Rack Puppet masters
+Puppet Server 5.0 resolves this by adding a timeout to the pool lock request. If that timeout expires, Puppet Server throws an exception instead of locking up indefinitely.
 
-When a command executed by Puppet's [`generate()` function](https://docs.puppet.com/puppet/latest/reference/function.html#generate) returns a non-zero exit code, the MRI/Rack Puppet master throws an exception while retrieving the catalog similar to:
+-    [SERVER-1704](https://tickets.puppetlabs.com/browse/SERVER-1704)
 
-```
-Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to execute generator /bin/false: Execution of '/bin/false' returned 1:  at /etc/puppet/environments/production/manifests/test.pp:2 on node MYNODE.mygtld
-```
+### Bug Fix: Include Content-Type headers in static file content API responses
 
-However, Puppet Server 2.6 and earlier do not throw an exception as expected, and instead appears to apply the catalog without error, making Puppet Server's behavior inconsistent with the MRI/Rack master.
+In previous versions of Puppet Server, responses to requests of the `puppet/v3/static_file_content` endpoint did not include a Content-Type header. As of Puppet Server 5.0, responses to successful requests include a `application/octet-stream` Content-Type header. Error responses from this endpoint include a `text/plain` Content-Type.
 
-Puppet Server 2.7 resolves this issue by throwing the expected exception.
+-   [SERVER-1826](https://tickets.puppetlabs.com/browse/SERVER-1826)
 
-Also, in Puppet Server 2.6 and earlier, `generate()` doesn't merge the executed command's output from `STDERR` to `STDOUT` as expected. Puppet Server 2.7 resolves this issue by including the `STDERR` output.
+### Bug Fix: Require `which` command for RPM package installation
 
--   [SERVER-1570](https://tickets.puppetlabs.com/browse/SERVER-1570): puppet4 function generate() should throw exception when command fails
--   [SERVER-1571](https://tickets.puppetlabs.com/browse/SERVER-1571): The function generate() should merge stdout and stderr
+Installing previous versions of Puppet Server via RPM packages could fail with a `which: command not found` error if `which` was not installed on the system.
 
-### Bug Fix: Avoid "partial state" error if an agent attempts a Puppet run on the master before first puppetserver service start
+Puppet Server 5.0 packages require `/usr/bin/which`, ensuring that it will be installed.
 
-In Puppet Server 2.6 and earlier, if the agent on a Puppet Server master starts a Puppet run (such as `puppet agent -t`) before the Puppet Server service has first started, private and public keys would be created for the agent but the Puppet Server service would subsequently fail to start with an error message similar to:
+-   [SERVER-1746](https://tickets.puppetlabs.com/browse/SERVER-1746)
 
-```
-java.lang.IllegalStateException: Cannot initialize master with partial state; need all files or none.
-Found:
-/var/lib/puppet/ssl/private_keys/master.pem
-Missing:
-/var/lib/puppet/ssl/certs/master.pem
-```
+### Bug Fix: Wait for `puppetserver` to stop before attempting to restart it via sysvinit
 
-In this situation, Puppet Server 2.7 now uses pre-generated public and private keys to generate a certificate for the master and will finish starting without error.
+In previous versions of Puppet Server, attempting to restart the `puppetserver` service using its sysvinit script would always try to immediately restart the service, even if stopping the service failed. Also, in some cases the service might not terminate immediately when sent a kill signal (SIGKILL), which exacerbated the issue.
 
--   [SERVER-528](https://tickets.puppetlabs.com/browse/SERVER-528)
+Puppet Server 5.0 resolves this by waiting for a grace period after sending a SIGKILL to the `puppetserver` service to ensure that it successfully exits, and attempts to restart the service only after the service is successfully stopped.
 
-### New Feature: Required gems are packaged with Puppet Server, with a new `GEM_PATH` and setting
+### Bug Fix: Improved handling of CLI subcommands
 
-Some gems are required by both the Puppet agent and Puppet Server. To ship these gems as part of our packaging, Puppet Server 2.7 changes how Puppet Server looks for gems.
+In previous versions of Puppet Server, `puppetserver` CLI subcommands discarded exit codes, which could prevent errors from commands like `puppetserver gem` from being detected. In Puppet Server 5.0, these CLI commands now exit with the same return code as the Ruby command would have provided.
 
-In Puppet Server 2.6 and earlier, Puppet Server's `GEM_PATH` was comprised of only a single directory by default: `/opt/puppetlabs/server/data/puppetserver/jruby-gems`. Puppet Server also used this directory as the value for `GEM_HOME`, meaning that the `puppetserver gem install` command installed gems to this directory.
+-   [SERVER-1759](https://tickets.puppetlabs.com/browse/SERVER-1759)
 
-In Puppet Server 2.7, we've added a second path to `GEM_PATH`: `/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems`. Gems that are known to be needed by Puppet Server will be installed in this directory as part of the Puppet Server packaging.
+Also, subcommands previously did not account for errors raised when loading and validating the `puppetserver` configuration. An invalid configuration could crash the subcommand with an unhelpful error message unrelated to the actual configuration validation failure. Puppet Server 5.0 resolves this by propagating errors with an unexpected format to output without modification.
 
-`GEM_HOME` still points to the same `jruby-gems` directory as it did in previous releases, and `puppetserver gem install` continues to install gems to, and use gems from, that directory.
+-   [SERVER-1690](https://tickets.puppetlabs.com/browse/SERVER-1690)
 
-To configure the `GEM_PATH`, set the new `gem-path` setting in [`puppetserver.conf`][puppetserver.conf].
+In previous versions of Puppet Server, `puppetserver` CLI subcommands used `/dev/random` for entropy. On systems with limited sources of entropy, such as virtual machines, these subcommands could rapidly drain the entropy pool, leading to slow performance as the pool gradually refilled. For instance, this could cause gem installation using the `puppetserver gem` subcommand to take much longer than expected.
 
--   [SERVER-1412](https://tickets.puppetlabs.com/browse/SERVER-1412)
+Puppet Server 5.0 resolves this by instead using `/dev/urandom` for CLI subcommands.
 
-### Bug Fix: `puppetserver gem` command makes installed gems readable
-
-In Puppet Server 2.6 and earlier, if the system's default umask did not permit world-readability for gems installed with the 'puppetserver gem' subcommand, the `puppetserver` process might not be able to use the resulting gemspec files, leading to errors such as:
-
-```
-Exception in thread "main" org.jruby.exceptions.RaiseException: (LoadError) no such file to load -- trollop
-Exception in thread "main" org.jruby.exceptions.RaiseException: (Errno::EACCES) /opt/puppetlabs/server/data/puppetserver/jruby-gems/specifications/trollop-2.1.2.gemspec
-```
-
-Puppet Server 2.7 resolves this issue by explicitly setting a umask of 0022 when running any `puppetserver gem` subcommand. This ensures that `puppetserver` can use any gems installed by the `gem` subcommand at run-time.
-
--   [SERVER-1601](https://tickets.puppetlabs.com/browse/SERVER-1601)
-
-### Known issue: Package mistakenly requires `/usr/bin/ruby`
-
-As of Puppet Server 2.7.0, a packaging issue caused the `puppetserver` package to unnecessarily depend on Ruby being installed at `/usr/bin/ruby`. This can potentially block upgrades from older versions of Puppet if Ruby isn't (or couldn't be) installed.
-
-This issue is resolved in Puppet Server 2.7.2.
-
--   [EZ-102](https://tickets.puppetlabs.com/browse/SERVER-1670)
-
-### Other new features
-
--   [SERVER-1589](https://tickets.puppetlabs.com/browse/SERVER-1589): Use `.gz` extensions for Puppet Server log file archives, and rotate them when they reach 200MB in size instead of 10MB.
-
-## Puppet Server 2.6
-
-Released September 8, 2016.
-
-This is a feature and bug-fix release of Puppet Server. This release also adds an official Puppet Server package for SUSE Enterprise Linux (SLES) 12.
-
-> **Warning:** If you're upgrading from Puppet Server 2.4 or earlier and have modified `bootstrap.cfg`, `/etc/sysconfig/puppetserver`, or `/etc/default/puppetserver`, see the [Puppet Server 2.5 release notes first](#potential-breaking-issues-when-upgrading-with-a-modified-bootstrapcfg) **before upgrading** for instructions on avoiding potential failures.
-
-### New feature: JVM metrics endpoint `/status/v1/services`
-
-Puppet Server provides a new endpoint, `/status/v1/services`, which can provide basic Java Virtual Machine-level metrics related to the current Puppet Server process's memory usage.
-
-To request this data, make an HTTP GET request to Puppet Server with a query string of `level=debug`. For details on the endpoint and its response, see the [Services endpoint documentation](./status-api/v1/services.markdown).
-
-> **Experimental feature note:** These metrics are experimental. The names and values of the metrics may change in future releases.
-
--   [SERVER-1502](https://tickets.puppetlabs.com/browse/SERVER-1502)
-
-### New feature: Logback replaces logrotate for Server log rotation
-
-Previous versions of Puppet Server would rotate and compress logs daily using logrotate. Puppet Server 2.6 uses Logback, the logging library used by Puppet Server's Java Virtual Machine (JVM).
-
-Under logrotate, certain pathological error states --- such as running out of file handles --- could cause previous versions of Puppet Server to fill up disk partitions with logs of stack traces.
-
-In Puppet Server 2.6, Logback compresses Server-related logs into archives when their size exceeds 10MB. Also, when the total size of all Puppet Server logs exceeds 1GB, Logback deletes the oldest logs. These improvements should limit the space that Puppet Server's logs consume and prevent them from filling partitions.
-
-> **Debian upgrade note:** On Debian-based Linux distributions, logrotate will continue to attempt to manage your Puppet Server log files until `/etc/logrotate.d/puppetserver` is removed. These logrotate attempts are harmless, but will generate a duplicate archive of logs. As a best practice, delete `puppetserver` from `logrotate.d` after upgrading to Puppet Server 2.6.
->
-> This doesn't affect clean installations of Puppet Server on Debian, or any upgrade or clean installation on other Linux distributions.
-
--   [SERVER-366](https://tickets.puppetlabs.com/browse/SERVER-366)
-
-### Bug fixes: Update JRuby to resolve several issues
-
-This release resolves two issues by updating the version of JRuby used by Puppet Server to 1.7.26.
-
-In previous versions of Puppet Server 2.x, when a variable lookup is performed from Ruby code or an ERB template and the variable is not defined, catalog compilation could periodically fail with an error message similar to:
-
-```
-Puppet Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, integer 2181729414 too big to convert to `int` at <PUPPET FILE>
-```
-
-The error message is inaccurate; the lookup should return nil. The error is a [bug in JRuby](https://github.com/jruby/jruby/issues/3980), which Puppet Server uses to run Ruby code. Puppet Server 2.6 resolves this by updating JRuby.
-
--   [SERVER-1408](https://tickets.puppetlabs.com/browse/SERVER-1408)
-
-Also, when Puppet Server uses a large JVM memory heap and large number of JRuby instances, Puppet Server could fail to start and produce error messages in the `puppetserver.log` file similar to:
-
-```
-java.lang.IllegalStateException: There was a problem adding a JRubyPuppet instance to the pool.
-Caused by: org.jruby.embed.EvalFailedException: (LoadError) load error: jopenssl/load -- java.lang.NoClassDefFoundError: org/jruby/ext/openssl/NetscapeSPKI
-```
-
-We [fixed the underlying issue in JRuby](https://github.com/jruby/jruby/pull/4063), and this fix is included in Puppet Server 2.6.
-
-- [SERVER-858](https://tickets.puppetlabs.com/browse/SERVER-1408)
-
-### New feature: Whitelist Ruby environment variables
-
-Puppet Server 2.6 adds the ability to specify a whitelist of environment variables made available to Ruby code. To whitelist variables, add them to the `environment-vars` section under the `jruby-puppet` configuration section in [`puppetserver.conf`][puppetserver.conf].
-
-- [SERVER-584](https://tickets.puppetlabs.com/browse/SERVER-584)
-
-### Known issue: Changes to logback.xml are applied more slowly than expected
-
-In previous versions of Puppet Server, changes to [`logback.xml`](./config_file_logbackxml.markdown) were applied automatically within a minute or so. Since Puppet Server 2.6, those changes can take longer than expected or not be applied at all until the service is [restarted](./restarting.markdown).
-
-As a workaround, restart the `puppetserver` service after making changes to the `logback.xml` file.
-
-- [TK-424](https://tickets.puppetlabs.com/browse/TK-424)
-- [TK-426](https://tickets.puppetlabs.com/browse/TK-426)
-
-## Puppet Server 2.5
-
-Released August 11, 2016.
-
-This is a feature and bug-fix release of Puppet Server.
-
-> ### Potential breaking issues when upgrading with a modified `bootstrap.cfg`
->
-> If you disabled the certificate authority (CA) on Puppet Server by editing the [`bootstrap.cfg`][service bootstrapping] file on older versions of Puppet Server --- for instance, because you have a multi-master configuration with the default CA disabled on some masters, or use an external CA --- be aware that Puppet Server as of version 2.5.0 no longer uses the `bootstrap.cfg` file.
->
-> Puppet Server 2.5.0 and newer instead create a new configuration file, `/etc/puppetlabs/puppetserver/services.d/ca.cfg`, if it doesn't already exist, and this new file enables CA services by default.
->
-> To ensure that CA services remain disabled after upgrading, create the `/etc/puppetlabs/puppetserver/services.d/ca.cfg` file with contents that disable the CA services _before_ you upgrade to Server 2.5.0 or newer. The `puppetserver` service restarts after the upgrade if the service is running before the upgrade, and the service restart also reloads the new `ca.cfg` file.
->
-> Also, back up your masters' [`ssldir`](https://docs.puppet.com/puppet/latest/reference/dirs_ssldir.html) (or at least your `crl.pem` file) _before_ you upgrade to ensure that you can restore your previous certificates and certificate revocation list, so you can restore them in case any mistakes or failures to disable the CA services in `ca.cfg` lead to a master unexpectedly enabling CA services and overwriting them.
->
-> For more details, including a sample `ca.cfg` file that disables CA services, see the [bootstrap upgrade notes](./bootstrap_upgrade_notes.markdown).
-
-> ### Potential service failures when upgrading with a modified init configuration
->
-> If you modified the init configuration file --- for instance, to [configure Puppet Server's JVM memory allocation](./install_from_packages.html#memory-allocation) or [maximum heap size](./tuning_guide.html) --- and upgrade Puppet Server 2.5.0 or newer with a package manager, you might see a warning during the upgrade that the updated package will overwrite the file (`/etc/sysconfig/puppetserver` in Red Hat and derivatives, or `/etc/default/puppetserver` in Debian-based systems).
->
-> The changes to the file support the new service bootstrapping behaviors. If you don't accept changes to the file during the upgrade, the puppetserver service fails and you might see a `Service ':PoolManagerService' not found` or similar warning. To resolve the issue, set the `BOOTSTRAP_CONFIG` setting in the init configuration file to:
->
->     BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetserver/services.d/,/opt/puppetlabs/server/apps/puppetserver/config/services.d/"
->
-> If you modified other settings in the file before upgrading, and then overwrite the file during the upgrade, you might need to reapply those modifications after the upgrade.
-
-### New feature: Flexible service bootstrapping/CA configuration file
-
-To disable the Puppet CA service in previous versions of Puppet Server 2.x, users edited the [`bootstrap.cfg`][service bootstrapping] file, usually located at `/etc/puppetlabs/puppetserver/bootstrap.cfg`.
-
-This workflow could cause problems for users performing package upgrades of Puppet Server where `bootstrap.cfg` was modified, because the package might overwrite the modified `bootstrap.cfg` and undo their changes.
-
-To improve the upgrade experience for these users, Puppet Server 2.5.0 can load the service bootstrapping settings from multiple files. This in turn allows us to provide user-modifiable settings in a separate file and avoid overwriting any changes during an upgrade.
-
--   [SERVER-1470](https://tickets.puppetlabs.com/browse/SERVER-1470)
--   [SERVER-1247](https://tickets.puppetlabs.com/browse/SERVER-1247)
--   [SERVER-1213](https://tickets.puppetlabs.com/browse/SERVER-1213)
-
-### New feature: Signing CSRs with OIDs from a new arc
-
-Puppet Server 2.5.0 can sign certificate signing requests (CSRs) from Puppet 4.6 agents that contain a new custom object identifier (OID) arc to represent secured extensions for use with [`trapperkeeper-authorization`][Trapperkeeper].
-
-> **Aside:** Trapperkeeper powers the [HOCON `auth.conf` and authorization methods][auth.conf] introduced in Puppet Server 2.2.0. This new CSR-signing functionality in Server 2.5.0 builds on features added to Puppet 4.6 and the addition of X.509 extension-based authorization rules added to Trapperkeeper alongside Puppet Server 2.4.
-
-To sign CSRs wth the new OID arc via the Puppet 4.6 command-line tools, use the `puppet cert sign --allow-authorization-extensions` command. See the [`puppet cert` man page](https://docs.puppet.com/puppet/4.6/reference/man/cert.html) for details. This workflow is similar to signing DNS alt names.
-
-The new OID arc is "puppetlabs.1.3", with a long name of "Puppet Authorization Certificate Extension" and short name of `ppAuthCertExt` (where "puppetlabs" is our registered OID arc 1.3.6.1.4.1.34380). Set the extension "puppetlabs.1.3.1" (`pp_authorization`) on CSRs that need to be authenticated via the new workflow. We've also included an default alias of `pp_auth_role` at extension "puppetlabs.1.3.13" for common workflows. See [the Puppet CSR attributes and certificate extensions documentation](https://docs.puppet.com/puppet/4.6/reference/ssl_attributes_extensions.html) for more information.
-
-We've also improved the CLI output of `puppet cert list` and `puppet cert sign` to work better with the `--human-readable` and `--machine-readable` flags, and we allow administrators to force a prompt when signing certificates with the `--interactive` flag.
-
-This allows for easier automated failover to authorized nodes within a Puppet infrastructure and provides tools for creating new, securely automated workflows, such as automated component promotions within Puppet-managed infrastructure.
-
--   [SERVER-1305](https://tickets.puppetlabs.com/browse/SERVER-1305)
-
-### Bug fix: Unrecognized parse-opts
-
-Puppet Server 2.4.x used a deprecated API for a Clojure CLI option-parsing library. As a result, calls to `puppetserver gem` (either directly, or indirectly by using a `puppetserver_gem` package resource) generated unexpected warning messages:
-
-    Warning: Could not match Warning: The following options to parse-opts are unrecognized: :flag
-
-Puppet Server 2.5.0 updates this library, which prevents this error message from appearing.
-
--   [SERVER-1378](https://tickets.puppetlabs.com/browse/SERVER-1378)
-
-### Bug fix: Puppet Server no longer ships with an empty PID file
-
-When installed on CentOS 6, Puppet Server 2.4.x included an empty PID file. When running `service puppetserver status`, Puppet Server returned an unexpected error message: `puppetserver dead but pid file exists`.
-
-When performing a clean installation of Puppet Server 2.5.0, no PID file is created, and `service puppetserver status` should return the expected `not running` message.
-
--   [SERVER-1455](https://tickets.puppetlabs.com/browse/SERVER-1455)
--   [EZ-84](https://tickets.puppetlabs.com/browse/EZ-84)
+-   [SERVER-1723](https://tickets.puppetlabs.com/browse/SERVER-1723)
 
 ### Other changes
 
--   [SERVER-1310](https://tickets.puppetlabs.com/browse/SERVER-1310): Error messages in Puppet Server 2.5.0 use the same standard types as other Puppet projects.
--   [SERVER-1121](https://tickets.puppetlabs.com/browse/SERVER-1121): JRuby pool management code for the [Trapperkeeper Webserver Service][Trapperkeeper] is now its own open-source project, [puppetlabs/jrubyutils](https://github.com/puppetlabs/jruby-utils).
+-   [SERVER-1807](https://tickets.puppetlabs.com/browse/SERVER-1807): Puppet Server 5.0 embeds `hocon` gem version 1.2.5 in the default Puppet Server gem path, an upgrade from v1.1.3 used in Server v2.7.2.
+-   [SERVER-1772](https://tickets.puppetlabs.com/browse/SERVER-1772): Added ezbake option to specify additional uberjars to be built and installed with the main project, and allows `puppetserver` to include 2 jars for JRuby 1.7 and JRuby 9k dependencies.
+-   [SERVER-1671](https://tickets.puppetlabs.com/browse/SERVER-1671): Log only error output (stderr) to `puppetserver.log` for `generate()` function calls.
+- [SERVER-715](https://tickets.puppetlabs.com/browse/SERVER-715): Resolve intermittent 500 error status results and `isExpired(puppet_environments.clj:27)` logged errors on some HTTP API requests.

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -47,9 +47,9 @@ To retain the Puppet 4.x behavior, add the [`puppet.conf`](./configuration.markd
 
 Previous versions of Puppet exclusively used PSON, our vendored version of `pure_json`, for serializing communication between agents and masters. Testing showed that PSON serialization's performance was significantly worse than using JSON, and JSON adds opportunities for easier and better interoperability with other tools and programming languages.
 
-As part of this, Puppet Server 5.0 requests JSON over PSON from Puppet 5.0 agents by default, and consumes JSON facts and reports provided by Puppet 5.0 agents.
+Puppet Server 5.0 now produces `application/json` responses when a Puppet 5.x agent requests them, and consumes `application/json` request bodies sent from Puppet 5.x agents.
 
-Puppet 3 and 4 agents continue to use PSON, and Server 5.0 remains compatible with these agents.
+Server 5.0 remains compatible with Puppet 3.x and 4.x agents that use PSON, and Puppet 5.x agents attempt to request and send `text/pson` only when communicating with masters that don't support JSON communications, such as Puppet Server 2.7.x or earlier.
 
 For details, consult the [Puppet 5.0 documentation](https://docs.puppet.com/puppet/5.0/release_notes.html).
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -20,11 +20,11 @@ This is a major release of Puppet Server, and corresponds with the major release
 
 ### Platform changes
 
-Puppet Server 5.0 packages are available for RHEL 6 and 7, Debian 8 (Jessie), Ubuntu 16.04 (Xenial), and SLES 12 SP1.
+Puppet Server 5.0 packages are available for RHEL 6 and 7, Debian 8 (Jessie), Ubuntu 16.04 (Xenial), and SLES 12 (SP1 or later only).
 
-Puppet Server 5.0 is built with JDK 8, and therefore cannot run on a Java 7 runtime. Server 5.0 packages now depend exclusively upon the `openjdk-8-jre-headless` package. Since Ubuntu Precise and Trusty, and versions of Debian prior to 8 (Jessie), do not distribute that package, we do not provide Puppet Server packages for those operating systems.
+Puppet Server 5.0 is built with JDK 8, and therefore cannot run on a Java 7 runtime. Server 5.0 packages now depend exclusively upon the `openjdk-8-jre-headless` package. Because Ubuntu 12.04 (Precise) and 14.04 (Trusty), and versions of Debian prior to 8 (Jessie), do not distribute that package, we no longer provide Puppet Server packages for those operating systems.
 
-For SLES 12 SP1, install the `jessie-backports` repository to add access to Java 8. For details, see [Installing From Packages](./install_from_packages.markdown).
+For Debian 8, install the `jessie-backports` repository to add access to Java 8. For details, see [Installing From Packages](./install_from_packages.markdown).
 
 -   [SERVER-1738](https://tickets.puppetlabs.com/browse/SERVER-1738)
 -   [SERVER-1741](https://tickets.puppetlabs.com/browse/SERVER-1741)


### PR DESCRIPTION
-   Removes Server 2.x release notes and points to the docs site as an archive.
-   Adds Server 5.0 release notes.
-   Updates related docs with relevant information.