### PR TITLE
(MAINT) Add http-client metrics-enabled setting to puppetserver.conf doc

### DIFF
--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -140,6 +140,9 @@ http-client: {
     # the timeout is infinite and if negative, the value is undefined in the
     # application and governed by the system default behavior.
     #connect-timeout-milliseconds: 120000
+
+    # Whether to enable http-client metrics; defaults to 'true'.
+    #metrics-enabled: true
 }
 
 # Settings related to profiling the puppet Ruby code.


### PR DESCRIPTION
This commit adds info for the new metrics-enabled setting in the
http-client section of the puppetserver.conf file to the
config_file_puppetserver.markdown doc.