### PR TITLE
(MAINT) Remove "master" from project version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "5.0.1-master-SNAPSHOT")
+(def ps-version "5.0.1-SNAPSHOT")
 (def jruby-1_7-version "1.7.27-1")
 (def jruby-9k-version "9.1.11.0-1")
 


### PR DESCRIPTION
This commit removes the "master" tag from the puppetserver artifact
version in the project.clj file.  This is being removed because the
corresponding branch is now "5.0.x" and not "master".