### PR TITLE
(MAINT) Fix agent reference in 70_install_puppet acceptance test

### DIFF
--- a/acceptance/suites/pre_suite/puppet4_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet4_compat/70_install_puppet.rb
@@ -7,7 +7,7 @@ require 'puppetserver/acceptance/compat_utils'
 step "Install Updated Puppet GPG key for Any SLES Agents."
 
 nonmaster_agents.each { |agent|
-  variant = master['platform'].variant
+  variant = agent['platform'].variant
   if variant == 'sles'
     on(agent, 'rpmkeys --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppet')
   end


### PR DESCRIPTION
This commit replaces a bad reference to 'master' with 'agent' in the
70_install_puppet.rb acceptance test from the puppet4_compat suite.