### PR TITLE
(MAINT) Remove "-stable" from the project.clj version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "2.7.3-stable-SNAPSHOT")
+(def ps-version "2.7.3-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit removes the "-stable" modifier from the `ps-version` in the
project.clj file.  This is no longer needed for builds being produced
from the new '2.x' branch.