### PR TITLE
(SERVER-1825) Add '--retry=3' arg to bundle install for jruby spec tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,7 @@ namespace :spec do
       BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
       lein run -m org.jruby.Main \
-        -S bundle install --without extra development --path='#{TEST_BUNDLE_DIR}'
+        -S bundle install --without extra development --path='#{TEST_BUNDLE_DIR}' --retry=3
       CMD
       sh bundle_install
     end


### PR DESCRIPTION
This commit adds a '--retry=3' argument to the bundle install command
used in the jruby spec tests.  This is being done to decrease the number
of failures due to connection problems.