### PR TITLE
(MAINT) Bump puppet-agent to 33cc892e8f

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -25,7 +25,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "4.99.0.345.ge20bbc5",
+                         "4.99.0.403.g33cc892",
                          :string)
 
     # puppet-agent version corresponds to packaged development version located at:
@@ -33,7 +33,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "e20bbc51b0534cab213ed4b82cf4a711f34bf931",
+                         "33cc892e8f5705408e18d3b109334bcd9e27b446",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:


### PR DESCRIPTION
This commit bumps the puppet submodule and puppet-agent versions for
testing to f24e03659 and 4.99.0.403.g33cc892, respectively.