### PR TITLE
(maint) Switch java version on Debian 8 upgrade tests

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -192,6 +192,7 @@ module PuppetServerExtensions
       create_remote_file(master, "/etc/apt/sources.list.d/jessie-backports.list", "deb http://ftp.debian.org/debian jessie-backports main")
       on master, 'apt-get update'
       master.install_package("openjdk-8-jre-headless", "-t jessie-backports")
+      on master, 'update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java'
     end
   end
 


### PR DESCRIPTION
When testing the upgrade path on Debian 8, Puppetserver 2.7.x pulls
in openjdk-7-jre-headless as a dependency. Upgrading Puppetserver to 5.x
pulls in openjdk-8-jre-headless but this Java version isn't necessarily
used. This commit adds a call to update-alternatives on Debian 8 to
ensure that we have the right jvm installed and active for testing.