### PR TITLE
(DO NOT MERGE) (RE-8458) Update tests to use the puppet repos

### DIFF
--- a/acceptance/suites/pre_suite/compat_common/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/compat_common/30_install_dev_repos.rb
@@ -1,4 +1,4 @@
-install_opts = options.merge({ :dev_builds_repos => ["PC1"]})
+install_opts = options.merge({ :dev_builds_repos => ["puppet"]})
 
 if test_config[:puppetserver_install_type] == :package
   package_build_version = ENV['PACKAGE_BUILD_VERSION']

--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -1,4 +1,4 @@
-install_opts = options.merge({ :dev_builds_repos => ["PC1"]})
+install_opts = options.merge({ :dev_builds_repos => ["puppet"]})
 
 if test_config[:puppetserver_install_type] == :package
   package_build_version = ENV['PACKAGE_BUILD_VERSION']

--- a/acceptance/suites/pre_suite/foss/35_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/35_install_pdb.rb
@@ -1,7 +1,7 @@
 matching_puppetdb_platform = puppetdb_supported_platforms.select { |r| r =~ master.platform }
 skip_test unless matching_puppetdb_platform.length > 0
 
-install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
+install_opts = options.merge( { :dev_builds_repos => ["puppet"] })
 repo_config_dir = 'tmp/repo_configs'
 
 step "Install PuppetDB repository" do

--- a/acceptance/suites/pre_suite/upgrade/10_install_puppet.rb
+++ b/acceptance/suites/pre_suite/upgrade/10_install_puppet.rb
@@ -1,5 +1,5 @@
-step "Install PC1 repository" do
-  install_puppetlabs_release_repo(hosts, 'pc1')
+step "Install puppet repository" do
+  install_puppetlabs_release_repo(hosts, 'puppet')
 end
 
 hosts.each { |agent|

--- a/acceptance/suites/upgrade_tests/10_upgrade.rb
+++ b/acceptance/suites/upgrade_tests/10_upgrade.rb
@@ -1,6 +1,6 @@
 test_name "Upgrade Puppetserver"
 
-install_opts = options.merge({ :dev_builds_repos => ["PC1"]})
+install_opts = options.merge({ :dev_builds_repos => ["puppet"]})
 
 package_build_version = ENV['PACKAGE_BUILD_VERSION']
 if package_build_version.nil?


### PR DESCRIPTION
In order to test against the right set of packages, we need to update
these tests to hit the new repos. Rather than pin to puppet 5, we're
just going to pin to the rolling puppet repos. This will change
automatically to puppet6 once we change these repos to point to puppet6.