### PR TITLE
(SERVER-1870) create Rake tasks to update puppet submodule and acceptance pins

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -23,6 +23,8 @@ module PuppetServerExtensions
                          nil, "Puppet Server Version",
                          "PUPPETSERVER_VERSION", nil, :string)
 
+    # This value now comes from the beaker options file, or PUPPET_VERSION env var
+    #   the beaker options file can have this value updated via the rake task
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
                          "5.0.0.72.gf7c6ceb",
@@ -31,6 +33,8 @@ module PuppetServerExtensions
 
     # puppet-agent version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppet-agent/
+    # This value now come from the beaker options file, or PUPPET_BUILD_VERSION env var
+    #   the beaker options file can have this value updated via the rake task
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",


### PR DESCRIPTION
* find latest passing puppet-agent
* update puppet submodule to the puppet SHA contained in the
puppet-agent build
* update beaker options file with puppet and puppet-agent versions