### PR TITLE
(SERVER-1842) HTTP client metrics docs.

### DIFF
--- a/documentation/http_client_metrics.markdown
+++ b/documentation/http_client_metrics.markdown
@@ -4,6 +4,8 @@ title: "Puppet Server: HTTP Client Metrics"
 canonical: "/puppetserver/latest/http_client_metrics.html"
 ---
 
+[status API]: ./status-api/v1/services.markdown
+
 HTTP client metrics available in Puppet Server 5 allows users to measure how long it takes for Puppet Server to make requests to and receive responses from other services, such as PuppetDB.
 
 ## Determining metrics IDs
@@ -12,32 +14,32 @@ All of these metrics are of the form `puppetlabs.<SERVER ID>.http-client.experim
 
 > **Note:** The `<METRIC ID>` describes what the metric measures. A metric ID is represented in the [status endpoint](./status-api/v1/services.markdown) as an array of strings, and in the metric itself the strings are joined together with periods. For instance, the metric ID of `[puppetdb resource search]` is `puppetdb.resource.search`, so the full metric name would be `puppetlabs.<server-id>.http-client.experimental.with-metric-id.puppetdb.resource.search.full-response`.
 
-During the course of handling a Puppet agent run, Puppet Server makes several calls to other services to get or store information.
+You can configure PuppetDB to be a backend for [configuration files](https://docs.puppet.com/puppetdb/latest/connect_puppet_master.html#step-2-edit-configuration-files) (through the `storeconfigs` setting), and you can configure Puppet Server to send reports to an external report processing service. If you configure either of these, then during the course of handling a Puppet agent run, Puppet Server makes several calls to external services to retrieve or store information.
 
--   During handling of a /puppet/v3/node request, Puppet Server issues:
+-   During handling of a `/puppet/v3/node` request, Puppet Server issues:
     -   a `facts find` request to PuppetDB for facts about the node, if they aren't yet cached (typically the first time it requests facts for the node). **Metric ID:** `[puppetdb facts find]`.
--   During handling of a /puppet/v3/catalog request, Puppet Server issues several requests:
+-   During handling of a `/puppet/v3/catalog` request, Puppet Server issues several requests:
     -   a PuppetDB `replace facts` request, to replace the facts for the agent in PuppetDB with the facts it received from the agent. **Metric ID:** `[puppetdb, command, replace_facts]`.
     -   a PuppetDB `resource search` request, to search for resources if exported resources are used. **Metric ID:** `[puppetdb, resource, search]`.
     -   a PuppetDB `query` request, if the `puppetdb_query` function is used in Puppet code. **Metric ID:** `[puppetdb, query]`.
     -   a PuppetDB `replace catalog` request, to replace the catalog for the agent in PuppetDB with the newly compiled catalog. **Metric ID:** `[puppetdb, command, replace_catalog]`.
--   During handling of a /puppet/v3/reports request, Puppet Server issues:
-    -   a PuppetDB `store report` request, to store the submitted report. **Metric ID:** `[puppetb command store_report]`.
+-   During handling of a `/puppet/v3/report` request, Puppet Server issues:
+    -   a PuppetDB `store report` request, to store the submitted report. **Metric ID:** `[puppetdb command store_report]`.
     -   a request to the configured `reports_url` to store the report, if the HTTP report processor is enabled. **Metric ID:** `[puppetdb report http]`.
 
 ## Configuring
 
 HTTP client metrics are enabled by default, but can be disabled by setting `metrics-enabled` to `false` in the `http-client` section of [`puppetserver.conf`](./config_file_puppetserver.markdown).
 
-These metrics also depend on the `server-id` setting in the `metrics` section of `puppetserver.conf`. This defaults to `localhost` but must be changed in production.
+These metrics also depend on the `server-id` setting in the `metrics` section of `puppetserver.conf`. This defaults to `localhost`, and while `localhost` can collect metrics, change this setting to something unique to avoid metric naming collisions when exporting metrics to an external tool, such as Graphite.
 
-This data is all available via the status endpoint, at `https://<MASTER HOSTNAME>:8140/status/v1/services/master?level=debug`. Puppet Server 5 adds a `http-client-metrics` keyword in the map. If metrics are not enabled, or if Puppet Server has not issued any requests yet, then this array will be empty, like so: `"http-client-metrics": []`.
+This data is all available via the [status API][] endpoint, at `https://<MASTER HOSTNAME>:8140/status/v1/services/master?level=debug`. Puppet Server 5.0 adds a `http-client-metrics` keyword in the map. If metrics are not enabled, or if Puppet Server has not issued any requests yet, then this array will be empty, like so: `"http-client-metrics": []`.
 
 In the [sample Grafana dashboard](./sample-puppetserver-metrics-dashboard.json), the `External HTTP Communications` graph visualizes all of these metrics, and the tooltip describes each of them.
 
 ## Example metrics output
 
-```
+```json
 "http-client-metrics": [
   {
     "aggregate": 407,

--- a/documentation/http_client_metrics.markdown
+++ b/documentation/http_client_metrics.markdown
@@ -1,0 +1,120 @@
+---
+layout: default
+title: "Puppet Server: HTTP Client Metrics"
+canonical: "/puppetserver/latest/http_client_metrics.html"
+---
+
+HTTP client metrics available in Puppet Server 5 allows users to measure how long it takes for Puppet Server to make requests to and receive responses from other services, such as PuppetDB.
+
+## Determining metrics IDs
+
+All of these metrics are of the form `puppetlabs.<SERVER ID>.http-client.experimental.with-metric-id.<METRIC ID>.full-response`.
+
+> **Note:** The `<METRIC ID>` describes what the metric measures. A metric ID is represented in the [status endpoint](./status-api/v1/services.markdown) as an array of strings, and in the metric itself the strings are joined together with periods. For instance, the metric ID of `[puppetdb resource search]` is `puppetdb.resource.search`, so the full metric name would be `puppetlabs.<server-id>.http-client.experimental.with-metric-id.puppetdb.resource.search.full-response`.
+
+During the course of handling a Puppet agent run, Puppet Server makes several calls to other services to get or store information.
+
+-   During handling of a /puppet/v3/node request, Puppet Server issues:
+    -   a `facts find` request to PuppetDB for facts about the node, if they aren't yet cached (typically the first time it requests facts for the node). **Metric ID:** `[puppetdb facts find]`.
+-   During handling of a /puppet/v3/catalog request, Puppet Server issues several requests:
+    -   a PuppetDB `replace facts` request, to replace the facts for the agent in PuppetDB with the facts it received from the agent. **Metric ID:** `[puppetdb, command, replace_facts]`.
+    -   a PuppetDB `resource search` request, to search for resources if exported resources are used. **Metric ID:** `[puppetdb, resource, search]`.
+    -   a PuppetDB `query` request, if the `puppetdb_query` function is used in Puppet code. **Metric ID:** `[puppetdb, query]`.
+    -   a PuppetDB `replace catalog` request, to replace the catalog for the agent in PuppetDB with the newly compiled catalog. **Metric ID:** `[puppetdb, command, replace_catalog]`.
+-   During handling of a /puppet/v3/reports request, Puppet Server issues:
+    -   a PuppetDB `store report` request, to store the submitted report. **Metric ID:** `[puppetb command store_report]`.
+    -   a request to the configured `reports_url` to store the report, if the HTTP report processor is enabled. **Metric ID:** `[puppetdb report http]`.
+
+## Configuring
+
+HTTP client metrics are enabled by default, but can be disabled by setting `metrics-enabled` to `false` in the `http-client` section of [`puppetserver.conf`](./config_file_puppetserver.markdown).
+
+These metrics also depend on the `server-id` setting in the `metrics` section of `puppetserver.conf`. This defaults to `localhost` but must be changed in production.
+
+This data is all available via the status endpoint, at `https://<MASTER HOSTNAME>:8140/status/v1/services/master?level=debug`. Puppet Server 5 adds a `http-client-metrics` keyword in the map. If metrics are not enabled, or if Puppet Server has not issued any requests yet, then this array will be empty, like so: `"http-client-metrics": []`.
+
+In the [sample Grafana dashboard](./sample-puppetserver-metrics-dashboard.json), the `External HTTP Communications` graph visualizes all of these metrics, and the tooltip describes each of them.
+
+## Example metrics output
+
+```
+"http-client-metrics": [
+  {
+    "aggregate": 407,
+    "count": 1,
+    "mean": 407,
+    "metric-id": [
+      "puppetdb",
+      "facts",
+      "find"
+    ],
+    "metric-name": "puppetlabs.localhost.http-client.experimental.with-metric-id.puppetdb.facts.find.full-response"
+  },
+  {
+    "aggregate": 66,
+    "count": 1,
+    "mean": 66,
+    "metric-id": [
+      "puppetdb",
+      "command",
+      "replace_facts"
+    ],
+    "metric-name": "puppetlabs.localhost.http-client.experimental.with-metric-id.puppetdb.command.replace_facts.full-response"
+  },
+  {
+    "aggregate": 60,
+    "count": 2,
+    "mean": 30,
+    "metric-id": [
+      "puppetdb",
+      "resource",
+      "search"
+    ],
+    "metric-name": "puppetlabs.localhost.http-client.experimental.with-metric-id.puppetdb.resource.search.full-response"
+  },
+  {
+    "aggregate": 53,
+    "count": 1,
+    "mean": 53,
+    "metric-id": [
+      "puppetdb",
+      "query"
+    ],
+    "metric-name": "puppetlabs.localhost.http-client.experimental.with-metric-id.puppetdb.query.full-response"
+  },
+  {
+    "aggregate": 22,
+    "count": 1,
+    "mean": 22,
+    "metric-id": [
+      "puppetdb",
+      "command",
+      "store_report"
+    ],
+    "metric-name": "puppetlabs.localhost.http-client.experimental.with-metric-id.puppetdb.command.store_report.full-response"
+  },
+  {
+    "aggregate": 16,
+    "count": 1,
+    "mean": 16,
+    "metric-id": [
+      "puppetdb",
+      "command",
+      "replace_catalog"
+    ],
+    "metric-name": "puppetlabs.localhost.http-client.experimental.with-metric-id.puppetdb.command.replace_catalog.full-response"
+  },
+  {
+    "aggregate": 2,
+    "count": 1,
+    "mean": 2,
+    "metric-id": [
+      "puppet",
+      "report",
+      "http"
+    ],
+    "metric-name": "puppetlabs.localhost.http-client.experimental.with-metric-id.puppet.report.http.full-response"
+  }
+],
+```
+

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -33,6 +33,7 @@ Puppet Server is the next-generation application for managing Puppet agents.
     * [Using an external certificate authority](./external_ca_configuration.markdown)
     * [External SSL termination](./external_ssl_termination.markdown)
     * [Monitoring Puppet Server metrics](./puppet_server_metrics.markdown)
+        * [HTTP client metrics](./http_client_metrics.markdown)
     * [Tuning guide](./tuning_guide.markdown)
     * [Restarting Puppet Server](./restarting.markdown)
 * **Known issues and workarounds**

--- a/documentation/puppet_server_metrics.markdown
+++ b/documentation/puppet_server_metrics.markdown
@@ -10,16 +10,18 @@ canonical: "/puppetserver/latest/puppet_server_metrics.html"
 [Grafana]: http://grafana.org
 [sample Grafana dashboard]: ./sample-puppetserver-metrics-dashboard.json
 [static catalogs]: https://docs.puppet.com/puppet/latest/reference/static_catalogs.html
-[`grafanadash`](https://forge.puppet.com/cprice404/grafanadash)
-[`metrics.conf`](./config_file_metrics.markdown)
+[`grafanadash`]: (https://forge.puppet.com/cprice404/grafanadash)
+[`metrics.conf`]: (./config_file_metrics.markdown)
+[HTTP client metrics]: (./http_client_metrics.markdown)
 
-Puppet Server tracks several advanced performance and health metrics. You can track these metrics using:
+Puppet Server tracks several advanced performance and health metrics, all of which take advantage of the [metrics API][]. You can track these metrics using:
 
 -   Customizable, networked [Graphite and Grafana instances](#getting-started-with-graphite)
 -   A built-in experimental [developer dashboard][]
+-   [HTTP client metrics][]
 -   [Metrics API][metrics API] endpoints
 
-> **Note:** The `grafanadash` and `puppet-graphite` modules referenced in this document are _not_ Puppet-supported modules. They are provided as testing and demonstration purposes _only_. Both of those methods take advantage of the metrics API.
+> **Note:** The `grafanadash` and `puppet-graphite` modules referenced in this document are _not_ Puppet-supported modules. They are provided as testing and demonstration purposes _only_.
 
 ## Getting started with Graphite
 
@@ -393,6 +395,8 @@ These metrics measure raw resource availability and capacity.
     -   `puppetlabs.<MASTER-HOSTNAME>.memory.non-heap.used`
 
     -   `puppetlabs.<MASTER-HOSTNAME>.memory.non-heap.max`
+
+For details about HTTP client metrics, which measure performance of Puppet Server's requests to other services, see [their documentation][HTTP client metrics].
 
 ### Modifying Puppet Server's exported metrics
 

--- a/documentation/status-api/v1/services.markdown
+++ b/documentation/status-api/v1/services.markdown
@@ -16,6 +16,9 @@ for help interpreting the memory information.
 > **Note:** This is an experimental feature provided for troubleshooting
 purposes. In future releases, the `services` endpoint's response payload might
 change without warning.
+>
+> For information about HTTP client metrics, which are served from the status endpoint,
+> see [their documentation](../../http_client_metrics.markdown).
 
 ## `GET /status/v1/services`
 


### PR DESCRIPTION
Adds HTTP client metrics docs, and links to them from the nav and existing metrics docs.