### PR TITLE
(SERVER-1866) Copy the cacrl to the hostcrl file on change at runtime

### DIFF
--- a/acceptance/suites/tests/service_framework/reload_updated_crl.rb
+++ b/acceptance/suites/tests/service_framework/reload_updated_crl.rb
@@ -1,4 +1,4 @@
-test_name '(SERVER-1380) Server loads updated CRL after being reloaded'
+test_name 'Server reloads updated CRL without a restart'
 
 puppetservice=options['puppetservice']
 cert_to_revoke="reload_updated_crl"
@@ -78,24 +78,9 @@ step 'Revoke cert' do
   on(master, puppet('cert', 'revoke', cert_to_revoke))
 end
 
-if options[:type] == 'pe'
-  step 'Copy cacrl to hostcrl in order to work around SERVER-911' do
-    on(master, 'cp "$(puppet config print cacrl)" "$(puppet config print hostcrl)"')
-  end
-end
-
-step 'Validate that noop agent run successful after cert revoked but before reload' do
-  on(master, puppet('agent', '--test',
-                    '--server', server,
-                    '--certname', cert_to_revoke,
-                    '--noop'))
-end
-
-step 'Reload the server' do
-  reload_server
-end
-
-step 'Validate that noop run for revoked agent fails with SSL error after server reload' do
+step 'Validate that noop run for revoked agent fails with SSL error after CRL reload' do
+  # Sleep for a few seconds to give the server a chance to reload the updated CRL
+  sleep 5
   on(master, puppet('agent', '--test',
                     '--server', server,
                     '--certname', cert_to_revoke,

--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -12,6 +12,7 @@ puppetlabs.trapperkeeper.services.authorization.authorization-service/authorizat
 puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
+puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service
 
 # To enable the CA service, leave the following line uncommented
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service

--- a/ezbake/system-config/services.d/bootstrap.cfg
+++ b/ezbake/system-config/services.d/bootstrap.cfg
@@ -12,3 +12,4 @@ puppetlabs.trapperkeeper.services.authorization.authorization-service/authorizat
 puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
+puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def ps-version "2.7.3-SNAPSHOT")
-(def tk-jetty9-version "1.7.1-SNAPSHOT")
+(def tk-jetty9-version "1.8.0")
 
 (defn deploy-info
   [url]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
 (def ps-version "2.7.3-SNAPSHOT")
+(def tk-jetty9-version "1.7.1-SNAPSHOT")
 
 (defn deploy-info
   [url]
@@ -63,6 +64,7 @@
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-scheduler]
                  [puppetlabs/trapperkeeper-status]
+                 [puppetlabs/trapperkeeper-filesystem-watcher "1.0.1"]
                  [puppetlabs/kitchensink]
                  [puppetlabs/ssl-utils]
                  [puppetlabs/ring-middleware]
@@ -109,8 +111,8 @@
 
   :profiles {:dev {:source-paths  ["dev"]
                    :dependencies  [[org.clojure/tools.namespace]
-                                   [puppetlabs/trapperkeeper-webserver-jetty9]
-                                   [puppetlabs/trapperkeeper-webserver-jetty9 nil :classifier "test"]
+                                   [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
+                                   [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version :classifier "test"]
                                    [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
                                    [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
                                    [ring-basic-authentication]
@@ -141,12 +143,12 @@
                                                ;; lein depend on clojure 1.6.
                                                [org.clojure/clojure nil]
                                                [puppetlabs/puppetserver ~ps-version]
-                                               [puppetlabs/trapperkeeper-webserver-jetty9 nil]
+                                               [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
                                                [org.clojure/tools.nrepl nil]]
                       :plugins [[puppetlabs/lein-ezbake "1.1.7"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
-                       :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]]}
+                       :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}
              :voom {:plugins [[lein-voom "0.1.0-20150115_230705-gd96d771" :exclusions [org.clojure/clojure]]]}}
 

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -783,8 +783,14 @@
                                          localcacrl
                                          cacrl-as-string)]
                (if (zero? attempts-left)
-                 (log/error (i18n/trs "Unable to synchronize crl file {0} to {1}: {2}"
-                                      cacrl localcacrl (.getMessage write-exception)))
+                 (log/error (format "%s\n%s\n%s"
+                                    (i18n/trs
+                                     "Unable to synchronize crl file {0} to {1}: {2}."
+                                     cacrl localcacrl (.getMessage write-exception))
+                                    (i18n/trs
+                                     "Recent changes to the CRL may not have taken effect.")
+                                    (i18n/trs
+                                     "To load the updated CRL reload or restart the Puppet Server service.")))
                  (do
                    (Thread/sleep 100)
                    (recur (dec attempts-left))))))))))))

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -1,7 +1,9 @@
 (ns puppetlabs.services.ca.certificate-authority-service
   (:require [clojure.tools.logging :as log]
+            [me.raynes.fs :as fs]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.services :as tk-services]
+            [puppetlabs.trapperkeeper.services.protocols.filesystem-watch-service :as watch-protocol]
             [puppetlabs.puppetserver.certificate-authority :as ca]
             [puppetlabs.services.ca.certificate-authority-core :as core]
             [puppetlabs.services.protocols.ca :refer [CaService]]
@@ -12,7 +14,8 @@
   CaService
   [[:PuppetServerConfigService get-config get-in-config]
    [:WebroutingService add-ring-handler get-route]
-   [:AuthorizationService wrap-with-authorization-check]]
+   [:AuthorizationService wrap-with-authorization-check]
+   [:FilesystemWatchService create-watcher]]
   (init
    [this context]
    (let [path (get-route this)
@@ -20,7 +23,14 @@
          puppet-version (get-in-config [:puppetserver :puppet-version])
          custom-oid-file (get-in-config [:puppetserver :trusted-oid-mapping-file])
          oid-mappings (ca/get-oid-mappings custom-oid-file)
-         auth-handler (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))]
+         auth-handler (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))
+         ca-crl-file (.getCanonicalPath (fs/file
+                                         (get-in-config
+                                          [:puppetserver :cacrl])))
+         host-crl-file (.getCanonicalPath (fs/file
+                                           (get-in-config
+                                            [:puppetserver :hostcrl])))
+         watcher (create-watcher)]
      (ca/validate-settings! settings)
      (ca/initialize! settings)
      (log/info (i18n/trs "CA Service adding a ring handler"))
@@ -35,7 +45,20 @@
          auth-handler
          puppet-version)
        {:normalize-request-uri true})
-     (assoc context :auth-handler auth-handler)))
+     (when (not= ca-crl-file host-crl-file)
+       (watch-protocol/add-watch-dir! watcher
+                                      (fs/parent ca-crl-file)
+                                      {:recursive true})
+       (watch-protocol/add-callback!
+        watcher
+        (fn [events]
+          (when (some #(and (:changed-path %)
+                            (= (.getCanonicalPath (:changed-path %))
+                               ca-crl-file))
+                      events)
+            (ca/retrieve-ca-crl! ca-crl-file host-crl-file)))))
+     (assoc context :auth-handler auth-handler
+                    :watcher watcher)))
 
   (initialize-master-ssl!
    [this master-settings certname]

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -328,11 +328,11 @@
                                            (client-request)
                                            false
                                            (catch ConnectionClosedException e
-                                             (is true)))]
-         (loop [times 30]
-           (cond
-             (ssl-exception-for-request?) (is true)
-             (zero? times) (is false "No exception thrown after revocation")
-             :else (do
-                     (Thread/sleep 500)
-                     (recur (dec times))))))))))
+                                             true))]
+         (is (loop [times 30]
+               (cond
+                 (ssl-exception-for-request?) true
+                 (zero? times) false
+                 :else (do
+                         (Thread/sleep 500)
+                         (recur (dec times)))))))))))

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -12,7 +12,8 @@
     [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.ssl-utils.core :as ssl-utils]
     [puppetlabs.puppetserver.certificate-authority :as ca]
-    [me.raynes.fs :as fs]))
+    [me.raynes.fs :as fs])
+   (:import (org.apache.http ConnectionClosedException)))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/certificate_authority/certificate_authority_int_test")
@@ -265,3 +266,73 @@
            (is (= 404 (:status response))
                (ks/pprint-to-string response))
            (is (= "Not Found" (:body response)))))))))
+
+(deftest ^:integration crl-reloaded-without-server-restart
+  (bootstrap/with-puppetserver-running
+   app
+   {:webserver
+    {:ssl-cert (str bootstrap/master-conf-dir "/ssl/certs/localhost.pem")
+     :ssl-key (str bootstrap/master-conf-dir "/ssl/private_keys/localhost.pem")
+     :ssl-ca-cert (str bootstrap/master-conf-dir "/ssl/ca/ca_crt.pem")
+     :ssl-crl-path (str bootstrap/master-conf-dir "/ssl/crl.pem")}}
+   (let [key-pair (ssl-utils/generate-key-pair)
+         subject "crl_reload"
+         subject-dn (ssl-utils/cn subject)
+         public-key (ssl-utils/get-public-key key-pair)
+         private-key (ssl-utils/get-private-key key-pair)
+         private-key-file (ks/temp-file)
+         csr (ssl-utils/generate-certificate-request key-pair
+                                                     subject-dn)
+         options {:ssl-cert (str bootstrap/master-conf-dir
+                                 "/ssl/ca/ca_crt.pem")
+                  :ssl-key (str bootstrap/master-conf-dir
+                                "/ssl/ca/ca_key.pem")
+                  :ssl-ca-cert (str bootstrap/master-conf-dir
+                                    "/ssl/ca/ca_crt.pem")
+                  :as :text}
+         _ (ssl-utils/key->pem! private-key private-key-file)
+         _ (ssl-utils/obj->pem! csr (str bootstrap/master-conf-dir
+                                       "/ssl/ca/requests/"
+                                       subject
+                                       ".pem"))
+         cert-status-request (fn [action]
+                               (http-client/put
+                                (str "https://localhost:8140/"
+                                     "puppet-ca/v1/certificate_status/"
+                                     subject)
+                                (merge options
+                                       {:body (str "{\"desired_state\": \""
+                                                   action
+                                                   "\"}")
+                                        :headers {"content-type"
+                                                  "application/json"}})))
+         client-request #(http-client/get
+                          "https://localhost:8140/status/v1/services"
+                          (merge options
+                                 {:ssl-key (str private-key-file)
+                                  :ssl-cert (str bootstrap/master-conf-dir
+                                                 "/ssl/ca/signed/"
+                                                 subject
+                                                 ".pem")}))]
+     (testing "node certificate request can be signed successfully"
+       (let [sign-response (cert-status-request "signed")]
+         (is (= 204 (:status sign-response)))))
+     (testing "node request before revocation is successful"
+       (let [node-response-before-revoke (client-request)]
+         (is (= 200 (:status node-response-before-revoke)))))
+     (testing "node certificate can be revoked successfully"
+       (let [revoke-response (cert-status-request "revoked")]
+         (is (= 204 (:status revoke-response)))))
+     (testing "node request after revocation fails"
+       (let [ssl-exception-for-request? #(try
+                                           (client-request)
+                                           false
+                                           (catch ConnectionClosedException e
+                                             (is true)))]
+         (loop [times 30]
+           (cond
+             (ssl-exception-for-request?) (is true)
+             (zero? times) (is false "No exception thrown after revocation")
+             :else (do
+                     (Thread/sleep 500)
+                     (recur (dec times))))))))))

--- a/test/unit/puppetlabs/services/master/master_service_test.clj
+++ b/test/unit/puppetlabs/services/master/master_service_test.clj
@@ -21,7 +21,8 @@
     [puppetlabs.dujour.version-check :as version-check]
     [me.raynes.fs :as fs]
     [puppetlabs.kitchensink.core :as ks]
-    [puppetlabs.services.protocols.jruby-puppet :as jruby-puppet]))
+    [puppetlabs.services.protocols.jruby-puppet :as jruby-puppet]
+    [puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service :as filesystem-watch-service]))
 
 (deftest ca-files-test
   (testing "CA settings from puppet are honored and the CA
@@ -43,7 +44,8 @@
              certificate-authority-service
              authorization-service
              versioned-code-service
-             scheduler-service]
+             scheduler-service
+             filesystem-watch-service/filesystem-watch-service]
 
             (-> (jruby-testutils/jruby-puppet-tk-config
                   (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -29,7 +29,8 @@
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
-            [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core]))
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core]
+            [puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service :as filesystem-watch-service]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Test Data
@@ -315,7 +316,8 @@
                       authorization-service/authorization-service
                       routing-service/webrouting-service
                       custom-vcs
-                      tk-scheduler/scheduler-service]]
+                      tk-scheduler/scheduler-service
+                      filesystem-watch-service/filesystem-watch-service]]
         (jruby-bootstrap/with-puppetserver-running-with-services
          app services {:jruby-puppet {:max-active-instances 1}}
          (jruby-testutils/wait-for-jrubies app)


### PR DESCRIPTION
This commit uses the tk-filesystem-watcher service to listen for changes
to the cacrl file.  When a change is detected, the cacrl file is copied
over to the hostcrl file.  This allows a watcher that the newer
tk-jetty9 service has established on changes to the hostcrl file to
trigger a reload of the CRL being used by the webserver, with no restart
to the webserver service being required.

The tk-jetty9 bump in this PR for the crl watcher changes also includes
a fix for previously failing gzip encoding for server responses.
To account for this fix, a couple of updates to the
environment-classes-int-test tests were added to account for the --gzip
text appended to some response etags.