### PR TITLE
(SERVER-1894) install `apt-transport-https` on Debian for PDB

### DIFF
--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -25,6 +25,10 @@ if !master.is_pe?
     on(master, puppet('module install puppetlabs-puppetdb'))
   end
 
+  if master.platform.variant == 'debian'
+    master.install_package('apt-transport-https')
+  end
+
   step 'Configure PuppetDB via site.pp' do
     sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
     create_remote_file(master, sitepp, <<SITEPP)


### PR DESCRIPTION
We install PDB and smoke test it in
`acceptance/suites/tests/00_smoke/puppetdb_integration.rb`. As of
2017-07-17 the puppetlabs-puppetdb module will attempt to install
postgresql using a repo with in the https url. apt-get cannot use
https by default, the `apt-transport-https` package installs the addon
needed to use apt-get with https.

This patch installs `apt-transport-https` on debian variants.