### PR TITLE
(SERVER-1893) Cherry-pick JRE switching in upgrade tests from master

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -208,6 +208,7 @@ module PuppetServerExtensions
       create_remote_file(master, "/etc/apt/sources.list.d/jessie-backports.list", "deb http://ftp.debian.org/debian jessie-backports main")
       on master, 'apt-get update'
       master.install_package("openjdk-8-jre-headless", "-t jessie-backports")
+      on master, 'update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java'
     end
   end
 


### PR DESCRIPTION
This cherry-pick's b4b9938 from master into 5.0.x.