### PR TITLE
(maint) delete puppet version spec test

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -18,16 +18,6 @@ describe 'Puppet::Server::Master' do
     end
   end
 
-  context "puppet version" do
-    subject do
-      master.puppetVersion
-    end
-
-    it "returns the correct puppet version number" do
-      expect(subject).to eq('5.0.0')
-    end
-  end
-
   class MasterTestProfiler
     def start(description, metric_id)
       metric_id


### PR DESCRIPTION
Previously we checked the version of Puppet from PuppetServer's Ruby
interface. This test was checking that we could reach values that Puppet
sets in Ruby via JRuby running through Puppet Server's JVM layer.

Testing the version makes any kind of automated version bumping
problematic. There is a similar test that checks run_mode so the risk
in a bug not being caught by this test is small, and the return on
investment in automating some of our workflow is large.

This patch deletes the spec test.