### PR TITLE
(PUP-7794) Update gettext-setup gem dependency

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -3,5 +3,5 @@ hocon 1.1.3
 text 1.3.1
 locale 2.1.2
 gettext 3.2.2
-gettext-setup 0.8
+gettext-setup 0.26
 fast_gettext 1.1.0


### PR DESCRIPTION
Code to load translations in modules requires gettext-setup > 0.17. This
commit updates the gettext-setup dependency to the most recent version,
0.26.