### PR TITLE
(SERVER-1755) Do not deserialize msgpack payloads to UTF-8 string

### DIFF
--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -65,7 +65,7 @@
         content-type (if-let [raw-type (:content-type request)]
                        (string/lower-case raw-type))]
     (case content-type
-      (nil "" "application/octet-stream") body
+      (nil "" "application/octet-stream" "application/x-msgpack") body
       ; Treatment of the *default* encoding arguably should be much more
       ; intelligent than just choosing UTF-8.  Basing the default on the
       ; Content-Type would be an improvement although even this could lead to

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -121,7 +121,8 @@
   (testing "request with binary content type does not consume body"
     (let [body-string "some random text"]
       (doseq [content-type [nil "" "application/octet-stream"
-                            "APPLICATION/octet-Stream"]]
+                            "APPLICATION/octet-Stream"
+                            "application/x-msgpack"]]
         (let [body-reader (StringReader. body-string)
               wrapped-request (core/wrap-params-for-jruby
                                 {:body         body-reader


### PR DESCRIPTION
Msgpack data, like other binary data, cannot be deserialized to a UTF-8
string. In general, we try to decode all payloads this way when we
receive requests. This commit adds an exception for payloads from
msgpack, sending them as is to Ruby Puppet.

This also updates the unit test concerning binary content types.