### PR TITLE
(SERVER-1866)(TK-149) Make crl reloading optional in puppetserver 2.x

### DIFF
--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -12,7 +12,9 @@ puppetlabs.trapperkeeper.services.authorization.authorization-service/authorizat
 puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
-puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service
+# To enable automatic CRL reloading, uncomment the line below
+# Only recommended on systems running Java 8 or later
+#puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service
 
 # To enable the CA service, leave the following line uncommented
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service

--- a/ezbake/system-config/services.d/bootstrap.cfg
+++ b/ezbake/system-config/services.d/bootstrap.cfg
@@ -12,4 +12,6 @@ puppetlabs.trapperkeeper.services.authorization.authorization-service/authorizat
 puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
 puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
-puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service
+# To enable automatic CRL reloading, uncomment line below
+# Only recommended on systems running Java 8 or later
+#puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -12,10 +12,11 @@
 
 (tk/defservice certificate-authority-service
   CaService
-  [[:PuppetServerConfigService get-config get-in-config]
-   [:WebroutingService add-ring-handler get-route]
-   [:AuthorizationService wrap-with-authorization-check]
-   [:FilesystemWatchService create-watcher]]
+  {:required [[:PuppetServerConfigService get-config get-in-config]
+              [:WebroutingService add-ring-handler get-route]
+              [:AuthorizationService wrap-with-authorization-check]]
+   :optional [FilesystemWatchService]}
+
   (init
    [this context]
    (let [path (get-route this)
@@ -23,14 +24,7 @@
          puppet-version (get-in-config [:puppetserver :puppet-version])
          custom-oid-file (get-in-config [:puppetserver :trusted-oid-mapping-file])
          oid-mappings (ca/get-oid-mappings custom-oid-file)
-         auth-handler (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))
-         ca-crl-file (.getCanonicalPath (fs/file
-                                         (get-in-config
-                                          [:puppetserver :cacrl])))
-         host-crl-file (.getCanonicalPath (fs/file
-                                           (get-in-config
-                                            [:puppetserver :hostcrl])))
-         watcher (create-watcher)]
+         auth-handler (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))]
      (ca/validate-settings! settings)
      (ca/initialize! settings)
      (log/info (i18n/trs "CA Service adding a ring handler"))
@@ -45,20 +39,32 @@
          auth-handler
          puppet-version)
        {:normalize-request-uri true})
-     (when (not= ca-crl-file host-crl-file)
-       (watch-protocol/add-watch-dir! watcher
-                                      (fs/parent ca-crl-file)
-                                      {:recursive true})
-       (watch-protocol/add-callback!
-        watcher
-        (fn [events]
-          (when (some #(and (:changed-path %)
-                            (= (.getCanonicalPath (:changed-path %))
-                               ca-crl-file))
-                      events)
-            (ca/retrieve-ca-crl! ca-crl-file host-crl-file)))))
-     (assoc context :auth-handler auth-handler
-                    :watcher watcher)))
+     (-> context
+         (assoc :auth-handler auth-handler)
+         ((fn [context]
+           (if-let [filesystem-watch-service
+                      (tk-services/maybe-get-service this :FilesystemWatchService)]
+              (let [ca-crl-file (.getCanonicalPath (fs/file
+                                                (get-in-config
+                                                  [:puppetserver :cacrl])))
+                    host-crl-file (.getCanonicalPath (fs/file
+                                                  (get-in-config
+                                                    [:puppetserver :hostcrl])))
+                    watcher (watch-protocol/create-watcher filesystem-watch-service)]
+                (when (not= ca-crl-file host-crl-file)
+                  (watch-protocol/add-watch-dir! watcher
+                                                  (fs/parent ca-crl-file)
+                                                  {:recursive true})
+                  (watch-protocol/add-callback!
+                    watcher
+                    (fn [events]
+                      (when (some #(and (:changed-path %)
+                                        (= (.getCanonicalPath (:changed-path %))
+                                          ca-crl-file))
+                                  events)
+                        (ca/retrieve-ca-crl! ca-crl-file host-crl-file)))))
+                (assoc context :watcher watcher))
+            context))))))
 
   (initialize-master-ssl!
    [this master-settings certname]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -18,51 +18,51 @@
    :optional [FilesystemWatchService]}
 
   (init
-   [this context]
-   (let [path (get-route this)
-         settings (ca/config->ca-settings (get-config))
-         puppet-version (get-in-config [:puppetserver :puppet-version])
-         custom-oid-file (get-in-config [:puppetserver :trusted-oid-mapping-file])
-         oid-mappings (ca/get-oid-mappings custom-oid-file)
-         auth-handler (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))
-         context' (assoc context :auth-handler auth-handler)]
-     (ca/validate-settings! settings)
-     (ca/initialize! settings)
-     (log/info (i18n/trs "CA Service adding a ring handler"))
-     (add-ring-handler
-       this
-       (core/get-wrapped-handler
-         (-> (core/web-routes settings)
-             ((partial comidi/context path))
-             comidi/routes->handler)
-         settings
-         path
-         auth-handler
-         puppet-version)
-       {:normalize-request-uri true})
-       (if-let [filesystem-watch-service
-                 (tk-services/maybe-get-service this :FilesystemWatchService)]
-         (let [ca-crl-file (.getCanonicalPath (fs/file
+    [this context]
+    (let [path (get-route this)
+          settings (ca/config->ca-settings (get-config))
+          puppet-version (get-in-config [:puppetserver :puppet-version])
+          custom-oid-file (get-in-config [:puppetserver :trusted-oid-mapping-file])
+          oid-mappings (ca/get-oid-mappings custom-oid-file)
+          auth-handler (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))
+          context' (assoc context :auth-handler auth-handler)]
+      (ca/validate-settings! settings)
+      (ca/initialize! settings)
+      (log/info (i18n/trs "CA Service adding a ring handler"))
+      (add-ring-handler
+        this
+        (core/get-wrapped-handler
+          (-> (core/web-routes settings)
+              ((partial comidi/context path))
+              comidi/routes->handler)
+          settings
+          path
+          auth-handler
+          puppet-version)
+        {:normalize-request-uri true})
+      (if-let [filesystem-watch-service
+               (tk-services/maybe-get-service this :FilesystemWatchService)]
+        (let [ca-crl-file (.getCanonicalPath (fs/file
+                                         (get-in-config
+                                           [:puppetserver :cacrl])))
+              host-crl-file (.getCanonicalPath (fs/file
                                            (get-in-config
-                                             [:puppetserver :cacrl])))
-               host-crl-file (.getCanonicalPath (fs/file
-                                             (get-in-config
-                                               [:puppetserver :hostcrl])))
-               watcher (watch-protocol/create-watcher filesystem-watch-service)]
-           (when (not= ca-crl-file host-crl-file)
-             (watch-protocol/add-watch-dir! watcher
-                                             (fs/parent ca-crl-file)
-                                             {:recursive true})
-             (watch-protocol/add-callback!
-               watcher
-               (fn [events]
-                 (when (some #(and (:changed-path %)
-                                   (= (.getCanonicalPath (:changed-path %))
-                                     ca-crl-file))
-                             events)
-                   (ca/retrieve-ca-crl! ca-crl-file host-crl-file)))))
-           (assoc context' :watcher watcher))
-       context')))
+                                             [:puppetserver :hostcrl])))
+              watcher (watch-protocol/create-watcher filesystem-watch-service)]
+          (when (not= ca-crl-file host-crl-file)
+            (watch-protocol/add-watch-dir! watcher
+                                           (fs/parent ca-crl-file)
+                                           {:recursive true})
+            (watch-protocol/add-callback!
+              watcher
+              (fn [events]
+                (when (some #(and (:changed-path %)
+                                  (= (.getCanonicalPath (:changed-path %))
+                                      ca-crl-file))
+                        events)
+                  (ca/retrieve-ca-crl! ca-crl-file host-crl-file)))))
+          (assoc context' :watcher watcher))
+        context')))
 
   (initialize-master-ssl!
    [this master-settings certname]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -24,7 +24,8 @@
          puppet-version (get-in-config [:puppetserver :puppet-version])
          custom-oid-file (get-in-config [:puppetserver :trusted-oid-mapping-file])
          oid-mappings (ca/get-oid-mappings custom-oid-file)
-         auth-handler (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))]
+         auth-handler (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))
+         context' (assoc context :auth-handler auth-handler)]
      (ca/validate-settings! settings)
      (ca/initialize! settings)
      (log/info (i18n/trs "CA Service adding a ring handler"))
@@ -39,32 +40,29 @@
          auth-handler
          puppet-version)
        {:normalize-request-uri true})
-     (-> context
-         (assoc :auth-handler auth-handler)
-         ((fn [context]
-           (if-let [filesystem-watch-service
-                      (tk-services/maybe-get-service this :FilesystemWatchService)]
-              (let [ca-crl-file (.getCanonicalPath (fs/file
-                                                (get-in-config
-                                                  [:puppetserver :cacrl])))
-                    host-crl-file (.getCanonicalPath (fs/file
-                                                  (get-in-config
-                                                    [:puppetserver :hostcrl])))
-                    watcher (watch-protocol/create-watcher filesystem-watch-service)]
-                (when (not= ca-crl-file host-crl-file)
-                  (watch-protocol/add-watch-dir! watcher
-                                                  (fs/parent ca-crl-file)
-                                                  {:recursive true})
-                  (watch-protocol/add-callback!
-                    watcher
-                    (fn [events]
-                      (when (some #(and (:changed-path %)
-                                        (= (.getCanonicalPath (:changed-path %))
-                                          ca-crl-file))
-                                  events)
-                        (ca/retrieve-ca-crl! ca-crl-file host-crl-file)))))
-                (assoc context :watcher watcher))
-            context))))))
+       (if-let [filesystem-watch-service
+                 (tk-services/maybe-get-service this :FilesystemWatchService)]
+         (let [ca-crl-file (.getCanonicalPath (fs/file
+                                           (get-in-config
+                                             [:puppetserver :cacrl])))
+               host-crl-file (.getCanonicalPath (fs/file
+                                             (get-in-config
+                                               [:puppetserver :hostcrl])))
+               watcher (watch-protocol/create-watcher filesystem-watch-service)]
+           (when (not= ca-crl-file host-crl-file)
+             (watch-protocol/add-watch-dir! watcher
+                                             (fs/parent ca-crl-file)
+                                             {:recursive true})
+             (watch-protocol/add-callback!
+               watcher
+               (fn [events]
+                 (when (some #(and (:changed-path %)
+                                   (= (.getCanonicalPath (:changed-path %))
+                                     ca-crl-file))
+                             events)
+                   (ca/retrieve-ca-crl! ca-crl-file host-crl-file)))))
+           (assoc context' :watcher watcher))
+       context')))
 
   (initialize-master-ssl!
    [this master-settings certname]

--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -58,6 +58,16 @@
        ~config
        ~@body)))
 
+(defmacro with-puppetserver-running-with-additional-services
+  [app extra-services config-overrides & body]
+  (let [config (load-dev-config-with-overrides config-overrides)]
+    `(let [services# (into (tk-bootstrap/parse-bootstrap-config! ~dev-bootstrap-file) ~extra-services)]
+      (tk-testutils/with-app-with-config
+        ~app
+        services#
+        ~config
+        ~@body))))
+
 (defmacro with-puppetserver-running-with-config
   [app config & body]
   `(let [services# (tk-bootstrap/parse-bootstrap-config! ~dev-bootstrap-file)]

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -12,7 +12,8 @@
     [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.ssl-utils.core :as ssl-utils]
     [puppetlabs.puppetserver.certificate-authority :as ca]
-    [me.raynes.fs :as fs])
+    [me.raynes.fs :as fs]
+    [puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service :as filesystem-watch-service])
    (:import (org.apache.http ConnectionClosedException)))
 
 (def test-resources-dir
@@ -268,8 +269,9 @@
            (is (= "Not Found" (:body response)))))))))
 
 (deftest ^:integration crl-reloaded-without-server-restart
-  (bootstrap/with-puppetserver-running
+  (bootstrap/with-puppetserver-running-with-additional-services
    app
+   [filesystem-watch-service/filesystem-watch-service]
    {:webserver
     {:ssl-cert (str bootstrap/master-conf-dir "/ssl/certs/localhost.pem")
      :ssl-key (str bootstrap/master-conf-dir "/ssl/private_keys/localhost.pem")
@@ -336,3 +338,63 @@
                  :else (do
                          (Thread/sleep 500)
                          (recur (dec times)))))))))))
+
+(deftest ^:integration crl-not-reloaded-without-watcher-service
+  (bootstrap/with-puppetserver-running
+   app
+   {:webserver
+    {:ssl-cert (str bootstrap/master-conf-dir "/ssl/certs/localhost.pem")
+     :ssl-key (str bootstrap/master-conf-dir "/ssl/private_keys/localhost.pem")
+     :ssl-ca-cert (str bootstrap/master-conf-dir "/ssl/ca/ca_crt.pem")
+     :ssl-crl-path (str bootstrap/master-conf-dir "/ssl/crl.pem")}}
+   (let [key-pair (ssl-utils/generate-key-pair)
+         subject "crl_reload"
+         subject-dn (ssl-utils/cn subject)
+         public-key (ssl-utils/get-public-key key-pair)
+         private-key (ssl-utils/get-private-key key-pair)
+         private-key-file (ks/temp-file)
+         csr (ssl-utils/generate-certificate-request key-pair
+                                                     subject-dn)
+         options {:ssl-cert (str bootstrap/master-conf-dir
+                                 "/ssl/ca/ca_crt.pem")
+                  :ssl-key (str bootstrap/master-conf-dir
+                                "/ssl/ca/ca_key.pem")
+                  :ssl-ca-cert (str bootstrap/master-conf-dir
+                                    "/ssl/ca/ca_crt.pem")
+                  :as :text}
+         _ (ssl-utils/key->pem! private-key private-key-file)
+         _ (ssl-utils/obj->pem! csr (str bootstrap/master-conf-dir
+                                       "/ssl/ca/requests/"
+                                       subject
+                                       ".pem"))
+         cert-status-request (fn [action]
+                               (http-client/put
+                                (str "https://localhost:8140/"
+                                     "puppet-ca/v1/certificate_status/"
+                                     subject)
+                                (merge options
+                                       {:body (str "{\"desired_state\": \""
+                                                   action
+                                                   "\"}")
+                                        :headers {"content-type"
+                                                  "application/json"}})))
+         client-request #(http-client/get
+                          "https://localhost:8140/status/v1/services"
+                          (merge options
+                                 {:ssl-key (str private-key-file)
+                                  :ssl-cert (str bootstrap/master-conf-dir
+                                                 "/ssl/ca/signed/"
+                                                 subject
+                                                 ".pem")}))]
+     (testing "node certificate request can be signed successfully"
+       (let [sign-response (cert-status-request "signed")]
+         (is (= 204 (:status sign-response)))))
+     (testing "node request before revocation is successful"
+       (let [node-response-before-revoke (client-request)]
+         (is (= 200 (:status node-response-before-revoke)))))
+     (testing "node certificate can be revoked successfully"
+       (let [revoke-response (cert-status-request "revoked")]
+         (is (= 204 (:status revoke-response)))))
+     (testing "node request after revocation is successful because service has not been reloaded"
+       (let [node-response-before-revoke (client-request)]
+         (is (= 200 (:status node-response-before-revoke))))))))


### PR DESCRIPTION
* We encountered issues with the file system watcher service running on Java 7.
  The puppet server 2.x line was previousy updated to use the file system watch
  service for automatic crl reload functionality. However, the 2.x supports
  Java 7. To avoid potentially destabilizing installs, especially so late in
  the 2 series, make the file system watcher optional, defaulting to off. Users
  can enable for Java 8 installs if desired by adding the file system watch
  service to the bootstrap.cfg.
* Add a test that validates that the puppet server will not automatically
  reload the crl if the file system watcher service has not been included in
  the bootstrap.cfg.
* In order to facilitate this, we add a new test helper macro that allows you
  to specify an additional set of services to be included along the default set
  loaded from dev/bootstrap.cfg. We update the previous test to use this new
  helper to explicitly include the file system watcher service in the bootstrap
  and validate that crl reload behavior, and then we do *not* include it in a
  separate test to validate that the previously expected behavior remains
  intact.
* We comment out the service in dev/bootstrap.cfg to ensure it is not loaded by
  other tests. This will only be for the 2.x series - in later series we will
  load the service by default.