### PR TITLE
(SERVER-1886)(TK-448) Use non-recursive form of watcher

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def ps-version "2.7.3-SNAPSHOT")
-(def tk-jetty9-version "1.8.0")
+(def tk-jetty9-version "1.8.1")
 
 (defn deploy-info
   [url]
@@ -64,7 +64,7 @@
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-scheduler]
                  [puppetlabs/trapperkeeper-status]
-                 [puppetlabs/trapperkeeper-filesystem-watcher "1.0.1"]
+                 [puppetlabs/trapperkeeper-filesystem-watcher "1.1.0"]
                  [puppetlabs/kitchensink]
                  [puppetlabs/ssl-utils]
                  [puppetlabs/ring-middleware]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -48,11 +48,9 @@
               host-crl-file (.getCanonicalPath (fs/file
                                            (get-in-config
                                              [:puppetserver :hostcrl])))
-              watcher (watch-protocol/create-watcher filesystem-watch-service)]
+              watcher (watch-protocol/create-watcher filesystem-watch-service {:recursive false})]
           (when (not= ca-crl-file host-crl-file)
-            (watch-protocol/add-watch-dir! watcher
-                                           (fs/parent ca-crl-file)
-                                           {:recursive true})
+            (watch-protocol/add-watch-dir! watcher (fs/parent ca-crl-file))
             (watch-protocol/add-callback!
               watcher
               (fn [events]


### PR DESCRIPTION
* This includes commits from https://github.com/puppetlabs/puppetserver/pull/1475, which should be merged first. To review the only intended change for this PR, see the commit `(SERVER-1886)(TK-448) Use non-recursive form of watcher`

* This PR switches to using the non-recursive from of the file system
  watcher for crl reload functionality. Without this, a directory created in
  the SSL dir owned by root would cause the service to fail.

* This is dependent on https://github.com/puppetlabs/trapperkeeper-filesystem-watcher/pull/17 being merged first 