### PR TITLE
(maint) Improve submodule bump

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,12 +100,13 @@ def jenkins_passing_json_parsed
   end
 
   begin
-    jenkins_result_parameters = jenkins_result_parsed['actions'][0]['parameters']
+    jenkins_result_parameters = jenkins_result_parsed['actions'].find{|x| x['_class'] == 'hudson.model.ParametersAction' }['parameters']
+    raise "No parameters found" unless jenkins_result_parameters
   rescue
     abort "ERROR: Could not get lastSuccessfulBuild's actions or parameters for #{JENKINS_BRANCH}"
   end
 
-  jenkins_result_parsed['actions'][0]['parameters']
+  jenkins_result_parameters
 end
 
 def lookup_passing_puppetagent_sha(my_jenkins_passing_json)

--- a/Rakefile
+++ b/Rakefile
@@ -102,8 +102,8 @@ def jenkins_passing_json_parsed
   begin
     jenkins_result_parameters = jenkins_result_parsed['actions'].find{|x| x['_class'] == 'hudson.model.ParametersAction' }['parameters']
     raise "No parameters found" unless jenkins_result_parameters
-  rescue
-    abort "ERROR: Could not get lastSuccessfulBuild's actions or parameters for #{JENKINS_BRANCH}"
+  rescue => e
+    abort "ERROR: Could not get lastSuccessfulBuild's actions or parameters for #{JENKINS_BRANCH}\n\n  #{e}"
   end
 
   jenkins_result_parameters
@@ -112,15 +112,15 @@ end
 def lookup_passing_puppetagent_sha(my_jenkins_passing_json)
   begin
     my_jenkins_passing_json.find{|x| x['name'] == 'SUITE_COMMIT'}['value']
-  rescue
-    abort "ERROR: Could not get lastSuccessfulBuild's SUITE_COMMIT value for #{JENKINS_BRANCH}"
+  rescue => e
+    abort "ERROR: Could not get lastSuccessfulBuild's SUITE_COMMIT value for #{JENKINS_BRANCH}\n\n  #{e}"
   end
 end
 def lookup_passing_puppet_sha(my_jenkins_passing_json)
   begin
     my_jenkins_passing_json.find{|x| x['name'] == 'puppet_COMPONENT_COMMIT'}['value']
-  rescue
-    abort "ERROR: Could not get lastSuccessfulBuild's puppet_COMPONENT_COMMIT value for #{JENKINS_BRANCH}"
+  rescue => e
+    abort "ERROR: Could not get lastSuccessfulBuild's puppet_COMPONENT_COMMIT value for #{JENKINS_BRANCH}\n\n  #{e}"
   end
 end
 


### PR DESCRIPTION
In the master branch we are failing because the assumption in the rake task is that from the parsed JSON returned by jenkins we can find the parameters we need at
```rb
jenkins_result_parsed['actions'][0]['parameters']
```

However our master branch is currently failing because the parameter action is not the first element in the actions. See screen shot below or the output at [the latest failure](https://jenkins-master-prod-1.delivery.puppetlabs.net/job/platform_puppetserver_periodic-singleton_master/7/)

This searches for the correct element in the array instead of assuming it will be in the first position. It also improves the logging of raised exceptions for better debugging in the future. It will need to be merged up to master to fix CI.


<img width="1440" alt="screen shot 2017-08-08 at 11 05 20 pm" src="https://user-images.githubusercontent.com/241423/29107335-8f3c36dc-7c8e-11e7-8daa-35ddcbce41e5.png">
