### PR TITLE
(SERVER-249) Enable loading user-supplied JARs when puppetserver starts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -112,6 +112,7 @@
                        :build-type "foss"
                        :java-args ~(str "-Xms2g -Xmx2g "
                                      "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger")
+                       :create-dirs ["/opt/puppetlabs/server/data/puppetserver/jars"]
                        :repo-target "PC1"
                        :bootstrap-source :services-d
                        :logrotate-enabled false}

--- a/resources/ext/cli_defaults/cli-defaults.sh.erb
+++ b/resources/ext/cli_defaults/cli-defaults.sh.erb
@@ -7,4 +7,4 @@ if [ ! -e "$JRUBY_JAR" ]; then
   return 1
 fi
 
-CLASSPATH="${CLASSPATH}:${JRUBY_JAR}"
+CLASSPATH="${CLASSPATH}:${JRUBY_JAR}:/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/jars/*"


### PR DESCRIPTION
This configures EZBake to create a directory for users to place JARs in, and adds that directory to the classpath setup that runs when the user starts puppetserver.