### PR TITLE
(maint) Remove bindaddress config tests

### DIFF
--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -508,7 +508,7 @@
            jruby-puppet (:jruby-puppet jruby-instance)]
        (try
          (testing "Various data types"
-           (is (= "0.0.0.0" (.getSetting jruby-puppet "bindaddress")))
+           (is (= "ldap" (.getSetting jruby-puppet "ldapserver")))
            (is (= 8140 (.getSetting jruby-puppet "masterport")))
            (is (= false (.getSetting jruby-puppet "onetime"))))
          (finally

--- a/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -31,7 +31,7 @@
                                               keyword))]
        (try
          (testing "usage of get-puppet-config-value"
-           (is (= "0.0.0.0" (get-puppet-config-value jruby-puppet :bindaddress)))
+           (is (= "ldap" (get-puppet-config-value jruby-puppet :ldapserver)))
            (is (= 8140 (get-puppet-config-value jruby-puppet :masterport)))
            (is (= false (get-puppet-config-value jruby-puppet :onetime)))
            (is (= true (get-puppet-config-value jruby-puppet :autoflush)))


### PR DESCRIPTION
Some clojure tests were inspecting setting information coming from
Puppet and Ruby to verify that the information could be fetched, but
this failed when Puppet itself changed a default value. This commit
changes the tested values to another string type value to check the same
code paths so we don't have to have tests depending on what version
of Puppet is in use.