### PR TITLE
(TK-149)(SERVER-1866) catch ioexception in java 7 crl reload test

### DIFF
--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -14,7 +14,8 @@
     [puppetlabs.puppetserver.certificate-authority :as ca]
     [me.raynes.fs :as fs]
     [puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service :as filesystem-watch-service])
-   (:import (org.apache.http ConnectionClosedException)))
+   (:import (org.apache.http ConnectionClosedException)
+            (java.io IOException)))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/certificate_authority/certificate_authority_int_test")
@@ -330,7 +331,10 @@
                                            (client-request)
                                            false
                                            (catch ConnectionClosedException e
-                                             true))]
+                                             true)
+                                           ;; Some Java 7 implementations return this instead:
+                                           (catch IOException e
+                                             (= "Connection reset by peer" (.getMessage e))))]
          (is (loop [times 30]
                (cond
                  (ssl-exception-for-request?) true


### PR DESCRIPTION
In testing, some java platforms on java 7 appear to return a "Connection reset
by peer" IOException instead of a ConnectionClosedException. Update the crl
reload test to accept either to ensure we pass on Java 7 in CI.

Signed-off-by: Moses Mendoza <moses@puppet.com>