### PR TITLE
(SERVER-1912) Update gettext-setup gem to latest version (0.26)

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -3,5 +3,5 @@ hocon 1.2.5
 text 1.3.1
 locale 2.1.2
 gettext 3.2.2
-gettext-setup 0.10
+gettext-setup 0.26
 fast_gettext 1.1.0


### PR DESCRIPTION
This version of the gem has the `translation_repository` method whose
absence is causing errors when loading modules.