### PR TITLE
(SERVER-1925) List all tasks

### DIFF
--- a/dev-resources/puppetlabs/services/master/tasks_int_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/tasks_int_test/puppet.conf
@@ -1,0 +1,5 @@
+[main]
+
+certname = localhost
+environmentpath = $confdir/environments
+environment_timeout = unlimited

--- a/documentation/puppet-api/v3/tasks.json
+++ b/documentation/puppet-api/v3/tasks.json
@@ -1,0 +1,38 @@
+{
+  "$schema":     "http://json-schema.org/draft-04/schema#",
+  "title":       "Tasks list",
+  "description": "List of task objects in a Puppet code environment",
+  "type":        "array",
+  "items": {
+    "title": "Task",
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "Name of the task object. Takes the form of '<module>::<task file name>'. Tasks with invalid characters in their files' names will not be listed.",
+        "type": "string"
+      },
+      "environment": {
+        "description": "A list of environments the task was found in. Will only contain one object when a specific environment is requested, which is all that is currently supported.",
+        "type": "array",
+        "items": {
+          "description": "The environment that the task was found in.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The name of the environment the task was found in.",
+              "type": "string"
+            },
+            "code_id": {
+              "description": "The code_id for the environment, if it exists. Not yet implemented, so will always return null.",
+              "type": "null"
+            }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": ["name", "environment"],
+    "additionalProperties": false
+  }
+}

--- a/documentation/puppet-api/v3/tasks.markdown
+++ b/documentation/puppet-api/v3/tasks.markdown
@@ -1,0 +1,159 @@
+---
+layout: default
+title: "Puppet Server: Puppet API: Tasks"
+canonical: "/puppetserver/latest/puppet-api/v3/tasks.html"
+---
+
+[deprecated WEBrick Puppet master]: https://docs.puppet.com/puppet/latest/reference/services_master_webrick.html
+[`environment_timeout`]: https://docs.puppet.com/puppet/latest/reference/config_file_environment.html#environmenttimeout
+
+[`auth.conf`]: ../../config_file_auth.markdown
+[`puppetserver.conf`]: ../../config_file_puppetserver.markdown
+
+The tasks API provides access to task information stored in modules. Tasks are
+files stored in `tasks` subdirectory of a module. A task consists of an
+executable file, with an optional metadata file with the same name with an
+added '.json' extension. For example, the "install" task in a module "apache" could
+consist of the executable file `install.rb` and the metadata file
+`install.json`. This task would have the display name "apache::install".
+
+This endpoint is available only when the Puppet master is running Puppet Server, not
+on Ruby Puppet masters, such as the [deprecated WEBrick Puppet master][]. It also ignores
+the Ruby-based Puppet master's authorization methods and configuration. See the
+[Authorization section](#authorization) for more information.
+
+### Does not return entries for task files with invalid names
+A task file name has the same restriction as puppet type names and must match
+the regular expression `\A[a-z][a-z0-9_]*\z` (excluding extensions).
+
+### Returns entries for tasks with no executable files
+A task will be listed if only metadata for it exists. How many files are
+associated with a task can be found by querying that task's details.
+
+### Does not read files
+This endpoint will not parse metadata or read any other files, only file names.
+
+### Uses `application/json` Content-Type
+
+The Content-Type in the response to an task API query is
+`application/json`.
+
+## `GET /puppet/v3/tasks?environment=:environment`
+
+(Introduced in Puppet Server 5.1.0.)
+
+Making a request with no query parameters is not supported and returns an HTTP 400 (Bad
+Request) response.
+
+### Supported HTTP Methods
+
+GET
+
+### Supported Formats
+
+JSON
+
+### Query Parameters
+
+Provide one parameter to the GET request:
+
+* `environment`: Only the task information pertaining to the specified
+environment will be returned for the call.
+
+### Responses
+
+#### GET request with results
+
+```
+GET /puppet/v3/tasks?environment=env
+
+HTTP/1.1 200 OK
+Etag: b02ede6ecc432b134217a1cc681c406288ef9224
+Content-Type: application/json
+
+[
+  {
+    "name":"apache::install",
+    "environment":[
+      {
+        "name":"env",
+        "code_id":null
+      }
+    ]
+  },
+  {
+    "name":"dashboard::configure",
+    "environment":[
+      {
+        "name":"env",
+        "code_id":null
+      }
+    ]
+  }
+]
+```
+
+#### Environment does not exist
+
+If you send a request with an environment parameter that doesn't correspond to the name of a
+directory environment on the server, the server returns an HTTP 404 (Not Found) error:
+
+```
+GET /puppet/v3/tasks?environment=doesnotexist
+
+HTTP/1.1 404 Not Found
+
+Could not find environment 'doesnotexist'
+```
+
+#### No environment given
+
+```
+GET /puppet/v3/tasks
+
+HTTP/1.1 400 Bad Request
+
+You must specify an environment parameter.
+```
+
+#### Environment parameter specified with no value
+
+```
+GET /puppet/v3/tasks?environment=
+
+HTTP/1.1 400 Bad Request
+
+The environment must be purely alphanumeric, not ''
+```
+
+#### Environment includes non-alphanumeric characters
+
+If the environment parameter in your request includes any characters that are
+not `A-Z`, `a-z`, `0-9`, or `_` (underscore), the server returns an HTTP 400 (Bad Request) error:
+
+```
+GET /puppet/v3/tasks?environment=bog|us
+
+HTTP/1.1 400 Bad Request
+
+The environment must be purely alphanumeric, not 'bog|us'
+```
+
+### Schema
+
+An tasks response body conforms to the
+[tasks schema](./tasks.json).
+
+### Authorization
+
+Unlike other Puppet master service-based API endpoints, the tasks API is
+provided exclusively by Puppet Server. All requests made to the tasks API are
+authorized using the Trapperkeeper-based [`auth.conf`][] feature introduced in
+Puppet Server 2.2.0, and ignores the older Ruby-based authorization process and
+configuration. The value of the `use-legacy-auth-conf` setting in the
+`jruby-puppet` configuration section of [`puppetserver.conf`][] is ignored for
+requests to the tasks API, because the Ruby-based authorization process is not
+equipped to authorize these requests.
+
+For more information about the Puppet Server authorization process and configuration
+settings, see the [`auth.conf` documentation][`auth.conf`].

--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -137,6 +137,15 @@ authorization: {
             name: "puppetlabs static file content"
         },
         {
+            match-request: {
+                path: "/puppet/v3/tasks"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppet tasks information"
+        },
+        {
             # Allow all users access to the experimental endpoint
             # which currently only provides a dashboard web ui.
             match-request: {

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -109,6 +109,10 @@
             tag
             cache-generation-id-before-tag-computed)))
 
+  (get-tasks
+    [this jruby-instance env-name]
+    (.getTasks jruby-instance env-name))
+
   (flush-jruby-pool!
    [this]
    (let [service-context (tk-services/service-context this)

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -420,10 +420,11 @@
   (fn [request]
     (let [environment (jruby-request/get-environment-from-request request)]
       (if-let [task-info-for-env
-               (jruby-protocol/get-tasks jruby-service
-                                         (:jruby-instance
-                                           request)
-                                         environment)]
+               (sort-nested-info-maps
+                 (jruby-protocol/get-tasks jruby-service
+                                           (:jruby-instance
+                                             request)
+                                           environment))]
         (all-tasks-response! task-info-for-env
                              environment
                              jruby-service)

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -325,7 +325,7 @@
   Returns environment as a list of objects for an eventual future in which
   tasks for all environments can be requested, and a given task will list all
   the environments it is found in."
-  [info-from-jruby :- List
+  [info-from-jruby :- [{schema/Any schema/Any}]
    environment :- schema/Str
    jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)]
   (let [format-task (fn [task-object]
@@ -335,9 +335,9 @@
     (->> (map format-task info-from-jruby)
          (middleware-utils/json-response 200))))
 
-(defn environment-not-found
+(schema/defn environment-not-found :- ringutils/RingResponse
   "Ring handler to provide a standard error when an environment is not found."
-  [environment]
+  [environment :- schema/Str]
   (rr/not-found (i18n/tru "Could not find environment ''{0}''" environment)))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -58,6 +58,10 @@
     [this jruby-instance]
     "Get all module information for all environments")
 
+  (get-tasks
+    [this jruby-instance env-name]
+    "Get list of task names and environment information.")
+
   (flush-jruby-pool!
     [this]
     "Flush all the current JRuby instances and repopulate the pool.")

--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -16,6 +16,7 @@ import java.util.List;
  *
  */
 public interface JRubyPuppet {
+    List getTasks(String environment);
     Map getClassInfoForEnvironment(String environment);
     List getModuleInfoForEnvironment(String environment);
     Map getModuleInfoForAllEnvironments();

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -102,6 +102,14 @@ class Puppet::Server::Master
     Puppet::Server::Config.terminate_puppet_server
   end
 
+   # @return [Array, nil] an array of hashes describing tasks
+  def getTasks(env)
+    environment = @env_loader.get(env)
+    unless environment.nil?
+      Puppet::InfoService.tasks_per_environment(environment.name)
+    end
+  end
+
   private
 
   def self.getModules(env)

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -125,7 +125,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Interacting with puppet code and catalogs
 
-(schema/defn ^:always-validate module-dir
+(schema/defn ^:always-validate module-dir :- File
   [env-name :- schema/Str
    module-name :- schema/Str]
   (fs/file conf-dir "environments" env-name "modules" module-name))

--- a/test/integration/puppetlabs/services/jruby/tasks_test.clj
+++ b/test/integration/puppetlabs/services/jruby/tasks_test.clj
@@ -1,0 +1,116 @@
+(ns puppetlabs.services.jruby.tasks-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env]
+            [puppetlabs.services.master.master-core :as mc]
+            [me.raynes.fs :as fs]
+            [cheshire.core :as cheshire]
+            [schema.core :as schema]
+            [schema.test :as schema-test]
+            [puppetlabs.puppetserver.testutils :as testutils]
+            [puppetlabs.trapperkeeper.app :as tk-app]
+            [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap]))
+
+(use-fixtures :once schema-test/validate-schemas)
+
+(def TaskOptions
+  {:name schema/Str
+   :module-name schema/Str
+   :metadata? schema/Bool
+   :number-of-files schema/Num})
+
+(defn make-task-dir
+  [env-dir mod-name]
+  (fs/file env-dir "modules" mod-name "tasks"))
+
+(schema/defn gen-task
+  "Assumes tasks dir already exists -- generates a set of task files for a
+  single task."
+  [env-dir task :- TaskOptions]
+  (let [task-name (:name task)
+        extensions (cycle '(".rb" "" ".sh" ".exe" ".py"))
+        task-dir (make-task-dir env-dir (:module-name task))]
+    (fs/mkdirs task-dir)
+    (when (:metadata? task)
+      (fs/create (fs/file task-dir (str task-name ".json"))))
+    (dotimes [n (:number-of-files task)]
+      (fs/create (fs/file task-dir (str task-name (nth extensions n ".rb")))))))
+
+(defn gen-tasks
+  "Tasks is a list of task maps, with keys:
+  :name String, file name of task
+  :module-name String, name of module task is in
+  :metadata? Boolean, whether to generate a metadata file
+  :number-of-files Number, how many executable files to generate for the task (0 or more)"
+  [env-dir tasks]
+  (dorun (map (partial gen-task env-dir) tasks)))
+
+(defn create-env
+  [env-dir tasks]
+  (testutils/create-env-conf env-dir "")
+  (gen-tasks env-dir tasks))
+
+(defn expected-tasks-info
+  [tasks]
+  (->> tasks
+       (map (fn [{:keys [name module-name]}]
+              {:module {:name module-name}
+               :name (if (= "init" name)
+                       module-name
+                       (str module-name "::" name))}))))
+
+(deftest ^:integration all-tasks-test
+  (testing "requesting all tasks"
+    (let [code-dir (ks/temp-dir)
+          conf-dir (ks/temp-dir)
+          config (jruby-testutils/jruby-puppet-tk-config
+                   (jruby-testutils/jruby-puppet-config
+                     {:master-code-dir (.getAbsolutePath code-dir)
+                      :master-conf-dir (.getAbsolutePath conf-dir)}))]
+
+      (tk-bootstrap/with-app-with-config
+        app
+        jruby-testutils/jruby-service-and-dependencies
+        config
+        (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+              instance (jruby-testutils/borrow-instance jruby-service :test)
+              jruby-puppet (:jruby-puppet instance)
+              env-registry (:environment-registry instance)
+              _ (testutils/create-file (fs/file conf-dir "puppet.conf")
+                                       "[main]\nenvironment_timeout=unlimited\nbasemodulepath=$codedir/modules\n")
+
+              env-dir (fn [env-name]
+                        (fs/file code-dir "environments" env-name))
+              env-1-dir (env-dir "env1")
+              env-1-tasks [{:name "install"
+                            :module-name "apache"
+                            :metadata? true
+                            :number-of-files 2}
+                           {:name "init"
+                            :module-name "apache"
+                            :metadata? false
+                            :number-of-files 1}
+                           {:name "configure"
+                            :module-name "django"
+                            :metadata? true
+                            :number-of-files 0}]
+
+              get-tasks (fn [env]
+                          (.getTasks jruby-puppet env))]
+
+          (try (create-env env-1-dir env-1-tasks)
+               (testing "for environment that does exist"
+                 (is (= (-> env-1-tasks
+                            expected-tasks-info
+                            set)
+                        (-> (get-tasks "env1")
+                            mc/sort-nested-info-maps
+                            set))
+                     "Unexpected info retrieved for 'env1'"))
+
+               (testing "for environment that does not exist"
+                 (is (nil? (get-tasks "env2"))))
+
+               (finally
+                 (jruby-testutils/return-instance jruby-service instance :test))))))))

--- a/test/integration/puppetlabs/services/master/tasks_int_test.clj
+++ b/test/integration/puppetlabs/services/master/tasks_int_test.clj
@@ -8,7 +8,7 @@
             [me.raynes.fs :as fs]))
 
 (def test-resources-dir
-  "./dev-resources/puppetlabs/services/master/environment_classes_int_test")
+  "./dev-resources/puppetlabs/services/master/tasks_int_test")
 
 (defn purge-env-dir
   []
@@ -47,6 +47,10 @@
   [response]
   (-> response :body cheshire/parse-string))
 
+(defn sort-tasks
+  [tasks]
+  (sort-by #(get % "name") tasks))
+
 (deftest ^:integration all-tasks-with-env
   (testing "full stack smoke test"
     (bootstrap/with-puppetserver-running-with-config
@@ -70,5 +74,5 @@
                 "unexpected status code for response, response: "
                 (ks/pprint-to-string response))))
         (testing "the expected response body is returned"
-          (is (= expected-response
-                 (parse-response response))))))))
+          (is (= (sort-tasks expected-response)
+                 (sort-tasks (parse-response response)))))))))

--- a/test/integration/puppetlabs/services/master/tasks_int_test.clj
+++ b/test/integration/puppetlabs/services/master/tasks_int_test.clj
@@ -1,0 +1,74 @@
+(ns puppetlabs.services.master.tasks-int-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
+            [puppetlabs.puppetserver.testutils :as testutils]
+            [cheshire.core :as cheshire]
+            [me.raynes.fs :as fs]))
+
+(def test-resources-dir
+  "./dev-resources/puppetlabs/services/master/environment_classes_int_test")
+
+(defn purge-env-dir
+  []
+  (-> testutils/conf-dir
+      (fs/file "environments")
+      fs/delete-dir))
+
+(use-fixtures :once
+              (testutils/with-puppet-conf
+               (fs/file test-resources-dir "puppet.conf")))
+
+(use-fixtures :each
+              (fn [f]
+                (purge-env-dir)
+                (try
+                  (f)
+                  (finally
+                    (purge-env-dir)))))
+
+(defn get-all-tasks
+  [env-name]
+  (let [url (str "https://localhost:8140/puppet/v3/"
+                 "tasks")
+        url (if env-name
+              (str url "?environment=" env-name)
+              url)]
+    (try
+      (http-client/get url
+        (merge
+          testutils/ssl-request-options
+          {:as :text}))
+      (catch Exception e
+        (throw (Exception. "tasks http get failed" e))))))
+
+(defn parse-response
+  [response]
+  (-> response :body cheshire/parse-string))
+
+(deftest ^:integration all-tasks-with-env
+  (testing "full stack smoke test"
+    (bootstrap/with-puppetserver-running-with-config
+      app
+      (-> {:jruby-puppet {:max-active-instances 1}}
+          (bootstrap/load-dev-config-with-overrides)
+          (ks/dissoc-in [:jruby-puppet
+                         :environment-class-cache-enabled]))
+      (let [foo-file (testutils/write-tasks-files "apache" "announce" "echo 'Hi!'")
+            bar-file (testutils/write-tasks-files "graphite" "install" "wheeee")
+            expected-response '({"name" "apache::announce"
+                                 "environment" [{"name" "production"
+                                                "code_id" nil}]}
+                                {"name" "graphite::install"
+                                 "environment" [{"name" "production"
+                                                "code_id" nil}]})
+            response (get-all-tasks "production")]
+        (testing "a successful status code is returned"
+          (is (= 200 (:status response))
+              (str
+                "unexpected status code for response, response: "
+                (ks/pprint-to-string response))))
+        (testing "the expected response body is returned"
+          (is (= expected-response
+                 (parse-response response))))))))


### PR DESCRIPTION
This PR adds an endpoint that lists all tasks found in modules in a given environment. It queries Puppet's InfoService class to find this information. This will be consumed directly by orchestrator in PE, which will relay information to clients like the PE console or a command line tool so users know the tasks they have available to choose from. This endpoint is very similar to the environment_classes endpoint (although less complex), so much of the approach was copied from that code.

Task information is accessible for anyone with a valid certificate signed by the Puppet CA.

I wanted to get this up for review ASAP, so I don't have pre-docs yet. Currently working on them.