### PR TITLE
(SERVER-1866) add docs, release notes

### DIFF
--- a/documentation/crl_refresh.markdown
+++ b/documentation/crl_refresh.markdown
@@ -1,0 +1,27 @@
+---
+layout: default
+title: "Puppet Server: Automatic CRL refresh"
+canonical: "/puppetserver/latest/crl_refresh.html"
+---
+
+Starting in version 2.8.0, Puppet Server can automatically reload an updated CRL into the running SSL context, so that the revocation of an agent's certificate no longer requires a restart of the service to take effect. Prior versions required an explicit restart or reload of this service to reload the CRL, resulting in some small amount of downtime to effect the revocation of a certificate. With automatic CRL refresh enabled, revocation is now transparent and requires no service downtime.
+
+### Enabling
+
+To enable automatic CRL refresh, modify your Puppet Server services bootstrap configuration file to include the following line:
+
+`puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service`
+
+This line should already exist, commented out, in the default ca.cfg shipped in Puppet Server 2.8.0, but if you are upgrading and have modified your ca.cfg, adding this line manually may be required. See [Service Bootstraping](./configuration.markdown#service-bootstrapping) for information on how to update your Puppet Server's services bootstrap configuration.
+
+### Java Compatiblity
+
+_This feature is only recommended for systems running Java 8._ It exhibited some instability when Puppet Server was running on systems running Java 7. We believe this is possibly due to bugs and platform-specific behavior in the underlying Java file system watcher implementation that were addressed in Java 8 but not in Java 7.
+
+### Implementation
+
+Automatic CRL refresh leverages the the [trapperkeeper file system watcher](https://github.com/puppetlabs/trapperkeeper-filesystem-watcher) to watch for changes to the CRL file, and loads the updated CRL on change.
+
+### Contributors
+
+Thanks to Jeremy Barlow, who laid the groundwork for this feature in Puppet Server.

--- a/documentation/crl_refresh.markdown
+++ b/documentation/crl_refresh.markdown
@@ -4,11 +4,11 @@ title: "Puppet Server: Automatic CRL refresh"
 canonical: "/puppetserver/latest/crl_refresh.html"
 ---
 
-Starting in version 2.8.0, Puppet Server can automatically reload an updated CRL into the running SSL context, so that the revocation of an agent's certificate no longer requires a restart of the service to take effect. Prior versions required an explicit restart or reload of this service to reload the CRL, resulting in some small amount of downtime to effect the revocation of a certificate. With automatic CRL refresh enabled, revocation is now transparent and requires no service downtime.
+Starting in version 2.8.0, Puppet Server can automatically reload an updated CRL into the running SSL context, so that the revocation of an agent's certificate no longer requires a restart of the service to take effect. Prior versions required an explicit restart or reload of this service to reload the CRL, resulting in some small amount of downtime to revoke a certificate. With automatic CRL refresh enabled, revocation is now transparent and requires no service downtime.
 
 ### Enabling
 
-To enable automatic CRL refresh, modify your Puppet Server services bootstrap configuration file to include the following line:
+To enable automatic CRL refresh, modify your Puppet Server services bootstrap configuration file, (`/etc/puppetlabs/puppetserver/services.d/ca.cfg` by default) to include the following line:
 
 `puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service`
 
@@ -20,7 +20,7 @@ _This feature is only recommended for systems running Java 8._ It exhibited some
 
 ### Implementation
 
-Automatic CRL refresh leverages the the [trapperkeeper file system watcher](https://github.com/puppetlabs/trapperkeeper-filesystem-watcher) to watch for changes to the CRL file, and loads the updated CRL on change.
+Automatic CRL refresh leverages the [trapperkeeper file system watcher](https://github.com/puppetlabs/trapperkeeper-filesystem-watcher) to watch for changes to the CRL file, and loads the updated CRL on change.
 
 ### Contributors
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -12,6 +12,20 @@ canonical: "/puppetserver/latest/release_notes.html"
 
 For release notes on versions of Puppet Server prior to Puppet Server 2.5, see [docs.puppet.com](https://docs.puppet.com/puppetserver/2.4/release_notes.html).
 
+## Puppet Server 2.8.0
+
+Released August 31, 2017
+
+This is a feature release of Puppet Server.
+
+> **Warning:** If you're upgrading from Puppet Server 2.4 or earlier and have modified `bootstrap.cfg`, `/etc/sysconfig/puppetserver`, or `/etc/default/puppetserver`, see the [Puppet Server 2.5 release notes first](#potential-breaking-issues-when-upgrading-with-a-modified-bootstrapcfg) **before upgrading** for instructions on avoiding potential failures.
+
+-   [SERVER-1866](https://tickets.puppetlabs.com/browse/SERVER-1866) / [TK-149](https://tickets.puppetlabs.com/browse/TK-149)
+
+### New Feature: Automatic CRL refresh on certificate revocation
+
+Puppet Server 2.8.0 includes the ability to automatically refresh the CRL in the running SSL context when any changes to that file have occurred, namely the addition of a revoked certificate. Prior to this release, revoking an agent's certificate required restarting the Puppet Server process before that revocation would be honored and the agent denied authentication. Now revocation will be effective psuedo-immediately (some threshold of milliseconds) without requiring a restart of the server. This feature is disabled by default in Puppet Server 2.8.0. See [automatic CRL refresh](./crl_refresh.markdown) for details on enabling.
+
 ## Puppet Server 2.7.2
 
 Released December 6, 2016.

--- a/ezbake/config/services.d/ca.cfg
+++ b/ezbake/config/services.d/ca.cfg
@@ -2,4 +2,6 @@
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
 # To disable the CA service, comment out the above line and uncomment the line below
 #puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
-
+# To enable automatic CRL reloading, uncomment line below
+# Only recommended on systems running Java 8 or later
+#puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service


### PR DESCRIPTION
This PR addresses two issues:

First, add documentation for automatic CRL refresh to the documentation directory and prepare for the 2.8.0 release with an updated release notes entry.

Second, Documentation suggests that users only configure services in /etc/puppetlabs/puppetserver/conf.d, not the config directory in /opt/puppetlabs. This commit adds a commented out entry for the file system watcher to the existing ca.cfg user configuration. While not in the `ca` namespace, since this setting affects the behavior of the CA it makes sense to place here rather than create a new additional file.