### PR TITLE
(SERVER-1898) Update version for 2.8.0 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "2.7.3-SNAPSHOT")
+(def ps-version "2.8.0")
 (def tk-jetty9-version "1.8.1")
 
 (defn deploy-info


### PR DESCRIPTION
This commit will automatically trigger CI to build packages in prep for the 2.8.0 release

Should probably wait for https://github.com/puppetlabs/puppetserver/pull/1497 to get merged first