### PR TITLE
(SERVER-1927) Add /tasks/:module/:task endpoint for detailed task information

### DIFF
--- a/documentation/puppet-api/v3/task_detail.json
+++ b/documentation/puppet-api/v3/task_detail.json
@@ -1,0 +1,63 @@
+{
+  "$schema":     "http://json-schema.org/draft-04/schema#",
+  "title":       "Task detail",
+  "description": "Detailed information about a specific task",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "description": "The contents of the <task name>.json metadata file. This will be empty if the file doesn't exist, or is empty. Otherwise it is allowed to return arbitrary keys here.",
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": true
+    },
+    "files": {
+      "description": "A list of executable files associated with the requested task, and data about them. The data is intended to assist in fetching their contents from the task file-content endpoint.",
+      "type": "array",
+      "items": {
+        "description": "A single file associated with the requested task, and data about it.",
+        "type": "object",
+        "properties": {
+          "filename": {
+            "description": "The name of the file (which should match the second part of the task name) plus its extension.",
+            "type": "string"
+          },
+          "sha256": {
+            "description": "The SHA256 of the contents of the file.",
+            "type": "string"
+          },
+          "size_bytes": {
+            "description": "The size of the file, in bytes.",
+            "type": "number"
+          },
+          "uri": {
+            "description": "Information on how to request the file contents from a Puppet master node. This will only provide a relative path, since clients may want to request from a compile master instead of the primary master.",
+            "type": "object",
+            "properties": {
+              "path": {
+                "description": "A relative URI for accessing the task contents. A client can form the full URI by requesting 'master:port/path?params'.",
+                "type": "string"
+              },
+              "params": {
+                "description": "A map of query params to use when requesting task contents. Required to include in the URI when making a request for task contents.",
+                "type": "object",
+                "properties": {
+                  "environment": {
+                    "description": "The environment the task is in, a required query param on request to task contents.",
+                    "type": "string"
+                  }
+                },
+                "required": ["environment"],
+                "additionalProperties": true
+              }
+            },
+            "required": ["path", "params"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["metadata", "files", "code_id"],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -109,6 +109,10 @@
             tag
             cache-generation-id-before-tag-computed)))
 
+  (get-task-data
+   [this jruby-instance env-name module-name task-name]
+   (.getTaskData jruby-instance env-name module-name task-name))
+
   (get-tasks
     [this jruby-instance env-name]
     (.getTasks jruby-instance env-name))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -597,7 +597,7 @@
                   (environment-class-handler request))
       (comidi/GET ["/environment_modules" [#".*" :rest]] request
                   (environment-module-handler request))
-      (comidi/GET ["/tasks" [#".*" :rest]] request
+      (comidi/GET ["/tasks"] request
                   (all-tasks-handler request))
       (comidi/GET ["/static_file_content/" [#".*" :rest]] request
                   (static-file-content-handler request)))))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -141,6 +141,12 @@
   {:name schema/Str
    :modules [EnvironmentModuleInfo]})
 
+(def TaskData
+  "Response from puppet's TaskInformationService for data on a single
+  task, *after* it has been converted to a Clojure map."
+  {:metadata_file (schema/maybe schema/Str)
+   :files [schema/Str]})
+
 (defn obj-or-ruby-symbol-as-string
   "If the supplied object is of type RubySymbol, returns a string
   representation of the RubySymbol.  Otherwise, just returns the original

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -58,6 +58,10 @@
     [this jruby-instance]
     "Get all module information for all environments")
 
+  (get-task-data
+    [this jruby-instance env-name module-name task-name]
+    "Get information (:metadata_file and :files) for a specific task. Returns a JRuby hash.")
+
   (get-tasks
     [this jruby-instance env-name]
     "Get list of task names and environment information.")

--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -16,6 +16,7 @@ import java.util.List;
  *
  */
 public interface JRubyPuppet {
+    Map getTaskData(String environment, String module, String task);
     List getTasks(String environment);
     Map getClassInfoForEnvironment(String environment);
     List getModuleInfoForEnvironment(String environment);

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -110,6 +110,13 @@ class Puppet::Server::Master
     end
   end
 
+  def getTaskData(environment_name, module_name, task_name)
+    # the 'init' task is special-cased to be just the name of the module,
+    # otherwise we have to request 'module::taskname'
+    qualified_task_name = task_name == 'init' ? module_name : "#{module_name}::#{task_name}"
+    Puppet::InfoService.task_data(environment_name, module_name, qualified_task_name)
+  end
+
   private
 
   def self.getModules(env)

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -180,18 +180,23 @@
   (write-pp-file foo-pp-contents "foo"))
 
 (schema/defn ^:always-validate write-tasks-files :- schema/Str
-  [module-name :- schema/Str
-   task-name :- schema/Str
-   task-file-contents :- schema/Str]
-  (let [metadata-contents {"description" "This is a description. It describes a thing."}
-        module-dir (create-module module-name {})
-        tasks-dir (fs/file module-dir "tasks")
-        metadata-file-path (fs/file tasks-dir task-name ".json")]
-    (create-file metadata-file-path
-                 (json/encode metadata-contents))
-    (create-file (fs/file tasks-dir task-name ".sh")
-                 task-file-contents)
-    (.getCanonicalPath metadata-file-path)))
+  ([module-name :- schema/Str
+    task-name :- schema/Str
+    task-file-contents :- schema/Str
+    task-metadata :- {schema/Str schema/Str}]
+   (let [module-dir (create-module module-name {})
+         tasks-dir (fs/file module-dir "tasks")
+         metadata-file-path (fs/file tasks-dir (str task-name ".json"))]
+     (create-file metadata-file-path
+                  (json/encode task-metadata))
+     (create-file (fs/file tasks-dir (str task-name ".sh"))
+                  task-file-contents)
+     (.getCanonicalPath metadata-file-path)))
+  ([module-name :- schema/Str
+    task-name :- schema/Str
+    task-file-contents :- schema/Str]
+   (write-tasks-files module-name task-name task-file-contents
+                      {"description" "This is a description. It describes a thing."})))
 
 (defn create-env-conf
   [env-dir content]

--- a/test/integration/puppetlabs/services/jruby/tasks_test.clj
+++ b/test/integration/puppetlabs/services/jruby/tasks_test.clj
@@ -11,7 +11,8 @@
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap])
-  (:import (java.io File)))
+  (:import [java.io File]
+           [org.jruby.exceptions RaiseException]))
 
 (use-fixtures :once schema-test/validate-schemas)
 
@@ -21,9 +22,14 @@
    :metadata? schema/Bool
    :number-of-files (schema/pred #(<= % 5))})
 
-(schema/defn gen-task
-  "Assumes tasks dir already exists -- generates a set of task files for a
-  single task."
+(schema/defn gen-empty-task
+  "Assumes tasks dir already exists -- generates a set of task files for
+  a single task. All the generated payload files are empty, and all generated
+  metadata files contain {\"meta\": \"data\"}
+
+  This function exists in addition to the tasks-generating utilities in
+  puppetlabs.puppetserver.testutils primarily because those other utilites only
+  generate things inside a hardcoded conf-dir at 'target/master-conf'."
   [env-dir :- (schema/cond-pre File schema/Str)
    task :- TaskOptions]
   (let [task-name (:name task)
@@ -31,23 +37,33 @@
         task-dir (fs/file env-dir "modules" (:module-name task) "tasks")]
     (fs/mkdirs task-dir)
     (when (:metadata? task)
-      (fs/create (fs/file task-dir (str task-name ".json"))))
+      (spit (fs/file task-dir (str task-name ".json")) "{\"meta\": \"data\"}"))
     (dotimes [n (:number-of-files task)]
       (fs/create (fs/file task-dir (str task-name (nth extensions n ".rb")))))))
 
-(defn gen-tasks
+(defn gen-empty-tasks
   "Tasks is a list of task maps, with keys:
   :name String, file name of task
   :module-name String, name of module task is in
   :metadata? Boolean, whether to generate a metadata file
-  :number-of-files Number, how many executable files to generate for the task (0 or more)"
+  :number-of-files Number, how many executable files to generate for the task (0 or more)
+
+  All generated files are empty, except metadata files, which contain the empty JSON object.
+
+  This function exists in addition to the tasks-generating utilities in
+  puppetlabs.puppetserver.testutils primarily because those other utilites only
+  generate things inside a hardcoded conf-dir at 'target/master-conf'."
   [env-dir tasks]
-  (dorun (map (partial gen-task env-dir) tasks)))
+  (dorun (map (partial gen-empty-task env-dir) tasks)))
 
 (defn create-env
   [env-dir tasks]
   (testutils/create-env-conf env-dir "")
-  (gen-tasks env-dir tasks))
+  (gen-empty-tasks env-dir tasks))
+
+(defn env-dir
+  [code-dir env-name]
+  (fs/file code-dir "environments" env-name))
 
 (defn expected-tasks-info
   [tasks]
@@ -58,30 +74,104 @@
                   (str module-name "::" name))})
        tasks))
 
-(deftest ^:integration all-tasks-test
-  (testing "requesting all tasks"
-    (let [code-dir (ks/temp-dir)
-          conf-dir (ks/temp-dir)
-          config (jruby-testutils/jruby-puppet-tk-config
-                   (jruby-testutils/jruby-puppet-config
-                     {:master-code-dir (.getAbsolutePath code-dir)
-                      :master-conf-dir (.getAbsolutePath conf-dir)}))]
+(schema/defn puppet-tk-config
+  [code-dir :- File, conf-dir :- File]
+  (jruby-testutils/jruby-puppet-tk-config
+   (jruby-testutils/jruby-puppet-config
+    {:master-code-dir (.getAbsolutePath code-dir)
+     :master-conf-dir (.getAbsolutePath conf-dir)})))
 
-      (testutils/create-file (fs/file conf-dir "puppet.conf")
-                             "[main]\nenvironment_timeout=unlimited\nbasemodulepath=$codedir/modules\n")
+(def puppet-conf-file-contents
+  "[main]\nenvironment_timeout=unlimited\nbasemodulepath=$codedir/modules\n")
+
+(deftest ^:integration task-data-test
+  (testing "requesting data about a specific task"
+    (let [code-dir (ks/temp-dir)
+          conf-dir (ks/temp-dir)]
+
+      (testutils/create-file (fs/file conf-dir "puppet.conf") puppet-conf-file-contents)
 
       (tk-bootstrap/with-app-with-config
         app
         jruby-testutils/jruby-service-and-dependencies
-        config
+        (puppet-tk-config code-dir conf-dir)
         (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
               instance (jruby-testutils/borrow-instance jruby-service :test)
               jruby-puppet (:jruby-puppet instance)
-              env-registry (:environment-registry instance)
+              env-1-dir (env-dir code-dir "env1")
+              env-1-tasks [{:name "install"
+                            :module-name "apache"
+                            :metadata? true
+                            :number-of-files 2}
+                           {:name "init"
+                            :module-name "apache"
+                            :metadata? false
+                            :number-of-files 1}]
+              get-task-data (fn [env module task]
+                              (-> (.getTaskData jruby-puppet env module task)
+                                  mc/sort-nested-info-maps))]
 
-              env-dir (fn [env-name]
-                        (fs/file code-dir "environments" env-name))
-              env-1-dir (env-dir "env1")
+          (try (create-env env-1-dir env-1-tasks)
+            (testing "when the environment, module, and task do exist"
+              (testing "with the init task"
+                (let [res (get-task-data "env1" "apache" "init")]
+                  (is (nil? (schema/check mc/TaskData res)))
+                  (is (some (fn [file-path] (.contains file-path "init"))
+                            (:files res)))))
+
+              (testing "with another named task"
+                (let [res (get-task-data "env1" "apache" "install")]
+                  (is (nil? (schema/check mc/TaskData res)))
+                  (is (some (fn [file-path] (.contains file-path "install"))
+                            (:files res))))))
+
+            (testing "when the environment does not exist"
+              (is (thrown-with-msg? RaiseException
+                                    #"(EnvironmentNotFound)"
+                                    (get-task-data "env2" "doesnotmatter" "whatever"))))
+
+            (testing "when the module does not exist"
+              (is (thrown-with-msg? RaiseException
+                                    #"(MissingModule)"
+                                    (get-task-data "env1" "notamodule" "install"))))
+
+            (testing "when the module name is invalid"
+              (is (thrown-with-msg? RaiseException
+                                    #"(MissingModule)"
+                                    (get-task-data "env1" "7!" "install"))))
+
+            (testing "when the task does not exist"
+              (is (thrown-with-msg? RaiseException
+                                    #"(TaskNotFound)"
+                                    (get-task-data "env1" "apache" "recombobulate"))))
+
+            (testing "when the task does not exist"
+              (is (thrown-with-msg? RaiseException
+                                    #"(TaskNotFound)"
+                                    (get-task-data "env1" "apache" "recombobulate"))))
+
+            (testing "when the task name is invalid"
+              (is (thrown-with-msg? RaiseException
+                                    #"(TaskNotFound)"
+                                    (get-task-data "env1" "apache" "&&&"))))
+
+            (finally
+              (jruby-testutils/return-instance jruby-service instance :test))))))))
+
+(deftest ^:integration all-tasks-test
+  (testing "requesting all tasks"
+    (let [code-dir (ks/temp-dir)
+          conf-dir (ks/temp-dir)]
+      (testutils/create-file (fs/file conf-dir "puppet.conf") puppet-conf-file-contents)
+
+      (tk-bootstrap/with-app-with-config
+        app
+        jruby-testutils/jruby-service-and-dependencies
+        (puppet-tk-config code-dir conf-dir)
+        (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+              instance (jruby-testutils/borrow-instance jruby-service :test)
+              jruby-puppet (:jruby-puppet instance)
+              env-1-dir (env-dir code-dir "env1")
               env-1-tasks [{:name "install"
                             :module-name "apache"
                             :metadata? true
@@ -101,8 +191,8 @@
           (try (create-env env-1-dir env-1-tasks)
                (testing "for environment that does exist"
                  (is (= (->> env-1-tasks
-                            expected-tasks-info
-                            (sort-by :name))
+                             expected-tasks-info
+                             (sort-by :name))
                         (->> (get-tasks "env1")
                              mc/sort-nested-info-maps
                              (sort-by :name)))

--- a/test/integration/puppetlabs/services/master/tasks_int_test.clj
+++ b/test/integration/puppetlabs/services/master/tasks_int_test.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.services.master.tasks-int-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
@@ -28,20 +29,27 @@
                   (finally
                     (purge-env-dir)))))
 
+(def request-as-text-with-ssl (assoc testutils/ssl-request-options :as :text))
+
 (defn get-all-tasks
   [env-name]
-  (let [url (str "https://localhost:8140/puppet/v3/"
-                 "tasks")
-        url (if env-name
-              (str url "?environment=" env-name)
-              url)]
+  (let [url (str "https://localhost:8140/puppet/v3/tasks"
+                 (if env-name (str "?environment=" env-name)))]
     (try
-      (http-client/get url
-        (merge
-          testutils/ssl-request-options
-          {:as :text}))
+      (http-client/get url request-as-text-with-ssl)
       (catch Exception e
         (throw (Exception. "tasks http get failed" e))))))
+
+(defn get-task-details
+  "task-name is the task's full name, e.g. 'apache::reboot'."
+  [env-name full-task-name]
+  (let [[module-name task-name]  (str/split full-task-name #"::")
+        url (str "https://localhost:8140/puppet/v3/tasks/" module-name "/" task-name
+                 (if env-name (str "?environment=" env-name)))]
+    (try
+      (http-client/get url request-as-text-with-ssl)
+      (catch Exception e
+        (throw (Exception. "task info http get failed" e))))))
 
 (defn parse-response
   [response]
@@ -51,28 +59,80 @@
   [tasks]
   (sort-by #(get % "name") tasks))
 
+(def puppet-config
+  (-> (bootstrap/load-dev-config-with-overrides {:jruby-puppet {:max-active-instances 1}})
+      (ks/dissoc-in [:jruby-puppet
+                     :environment-class-cache-enabled])))
+
 (deftest ^:integration all-tasks-with-env
-  (testing "full stack smoke test"
+  (testing "full stack tasks listing smoke test"
     (bootstrap/with-puppetserver-running-with-config
       app
-      (-> {:jruby-puppet {:max-active-instances 1}}
-          (bootstrap/load-dev-config-with-overrides)
-          (ks/dissoc-in [:jruby-puppet
-                         :environment-class-cache-enabled]))
-      (let [foo-file (testutils/write-tasks-files "apache" "announce" "echo 'Hi!'")
-            bar-file (testutils/write-tasks-files "graphite" "install" "wheeee")
-            expected-response '({"name" "apache::announce"
-                                 "environment" [{"name" "production"
-                                                "code_id" nil}]}
-                                {"name" "graphite::install"
-                                 "environment" [{"name" "production"
-                                                "code_id" nil}]})
-            response (get-all-tasks "production")]
+      puppet-config
+      (do
+        (testutils/write-tasks-files "apache" "announce" "echo 'Hi!'")
+        (testutils/write-tasks-files "graphite" "install" "wheeee")
+        (let [expected-response '({"name" "apache::announce"
+                                   "environment" [{"name" "production"
+                                                   "code_id" nil}]}
+                                  {"name" "graphite::install"
+                                   "environment" [{"name" "production"
+                                                   "code_id" nil}]})
+              response (get-all-tasks "production")]
+          (testing "a successful status code is returned"
+            (is (= 200 (:status response))
+                (str
+                  "unexpected status code for response, response: "
+                  (ks/pprint-to-string response))))
+          (testing "the expected response body is returned"
+            (is (= expected-response
+                   (sort-tasks (parse-response response))))))))))
+
+(deftest ^:integration task-details
+  (testing "full stack task metadata smoke test"
+    (bootstrap/with-puppetserver-running-with-config
+      app
+      puppet-config
+      (let [metadata {"description" "This is a test task"
+                      "output" "'Hello, world!'"}
+            _ (testutils/write-tasks-files "shell" "poc" "echo 'Hello, world!'" metadata)
+            response (get-task-details "production" "shell::poc")
+            code (:status response)]
         (testing "a successful status code is returned"
-          (is (= 200 (:status response))
-              (str
-                "unexpected status code for response, response: "
-                (ks/pprint-to-string response))))
+          (is (= 200 code)
+              (str "unexpected status code " code " for response: "
+                   (ks/pprint-to-string response))))
+
         (testing "the expected response body is returned"
-          (is (= (sort-tasks expected-response)
-                 (sort-tasks (parse-response response)))))))))
+          (let [expected-response {"metadata" metadata
+                                   "files" [{"filename" "poc.sh"
+                                             "sha256" "f24ce8f82408237beebf1fadd8a3da74ebd44512c02eee5ec24cf536871359f7"
+                                             "size_bytes" 20
+                                             "uri" {"path" "/puppet/v3/file_content/tasks/shell/poc.sh"
+                                                    "params" {"environment" "production"}}}]}]
+            (is (= expected-response (parse-response response)))))
+
+        (testing "the expected error is returned"
+          (let [is-404-with? (fn [pattern env full-task-name]
+                               (let [result (get-task-details env full-task-name)]
+                                 (is (= 404 (:status result)))
+                                 (is (re-find pattern (:body result)))))]
+            (testing "when the environment does not exist"
+              (is-404-with? #"Could not find environment"
+                            "nopers" "shell::poc"))
+
+            (testing "when the module does not exist"
+              (is-404-with? #"Could not find module"
+                            "production" "nomodule::poc"))
+
+            (testing "when the module name is invalid"
+              (is-404-with? #"Could not find module"
+                            "production" "000::poc"))
+
+            (testing "when the task does not exist"
+              (is-404-with? #"Could not find task"
+                            "production" "shell::notask"))
+
+            (testing "when the task name is invalid"
+              (is-404-with? #"Could not find task"
+                            "production" "shell::..."))))))))


### PR DESCRIPTION
The purpose of this endpoint is to take some low-level data from puppet's `TaskInformationService`, flesh it out using some additional logic, and serve it to clients who will (probably) end up fetching an actual task executable from the `tasks` mount point.

The PR is divided into two commits:

1. Add the `getTaskData` method to the `JRubyPuppet` interface, which mostly just passes through to the `TaskInformationService`'s `task_data` method.
2. Add the `describe-task` function, which reads the files from the TaskData and returns the detailed task description, and the `/tasks/:module/:task` endpoint that calls that function.