### PR TITLE
(PUP-7881) Update gettext-setup to version 0.28

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -3,5 +3,5 @@ hocon 1.2.5
 text 1.3.1
 locale 2.1.2
 gettext 3.2.2
-gettext-setup 0.26
+gettext-setup 0.28
 fast_gettext 1.1.0


### PR DESCRIPTION
This update contains code that makes the initial state of the locale
English rather than a random locale selected based on the order in which
translation files were found.