### PR TITLE
(docs) Puppet Server 5.1 release notes and docs updates

### DIFF
--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -102,6 +102,12 @@ puppetlabs.services.ca.certificate-authority-service/certificate-authority-servi
 #puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
 ~~~
 
+## Adding Java JARs
+
+Starting with Puppet Server 5.1.0, you can provide Java JARs to be loaded upon Puppet Server's startup.
+
+When launched, Server automatically loads any JARs placed in `/opt/puppetlabs/server/data/puppetserver/jars` into the `classpath`. JARs placed here will not be modified or removed when upgrading Puppet Server.
+
 ## Configuring the JRuby Version
 
 By default, Puppet Server uses a version of the JRuby 1.7.x series, running in a mode which conforms to MRI/Ruby language version 1.9. Starting with the Puppet Server 5.0 release, however, you can configure Puppet Server to instead use the JRuby 9k series (9.x.y.z). The Ruby language version supported by each JRuby 9k release is expected to evolve over time, tracking newer Ruby 2.x language versions. For example, the JRuby 9.1.8.0 release conforms to Ruby language version 2.3.1, whereas 9.1.9.0 conforms to Ruby language version 2.3.3.

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -35,7 +35,6 @@ Puppet Server is the next-generation application for managing Puppet agents.
     * [Monitoring Puppet Server metrics](./puppet_server_metrics.markdown)
         * [HTTP client metrics](./http_client_metrics.markdown)
     * [Tuning guide](./tuning_guide.markdown)
-    * [Monitoring Puppet Server metrics](./puppet_server_metrics.markdown)
     * [Applying metrics to improve performance](./puppet_server_metrics_performance.markdown)
     * [Scaling Puppet Server](./scaling_multiple_masters.markdown)
     * [Restarting Puppet Server](./restarting.markdown)

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -14,7 +14,7 @@ For release notes on versions of Puppet Server prior to Puppet Server 5, see [do
 
 ## Puppet Server 5.1.0
 
-Released September 12, 2017
+Released September 13, 2017
 
 This is a feature and bug-fix release of Puppet Server.
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -20,7 +20,7 @@ This is a feature and bug-fix release of Puppet Server.
 
 ### New Feature: Automatic CRL refresh on certificate revocation
 
-Puppet Server 5.1.0 includes the ability to automatically refresh the certificate revocation list (CRL) in the running SSL context when any changes to that file have occurred, namely the addition of a revoked certificate. Prior to this release, revoking an agent's certificate required restarting the Puppet Server process before that revocation would be honored and the agent denied authentication. Revocation is now effective within milliseconds and does not require restarting server.
+Puppet Server 5.1.0 includes the ability to automatically refresh the certificate revocation list (CRL) when any changes to that file have occurred, namely the addition of a revoked certificate. Prior to this release, revoking an agent's certificate required [restarting or reloading](./restarting.markdown) the Puppet Server process before that revocation would be honored and the agent denied authentication. Revocation is now effective within milliseconds and does not require restarting server.
 
 -   [SERVER-1933](https://tickets.puppetlabs.com/browse/SERVER-1933) / [TK-451](https://tickets.puppetlabs.com/browse/TK-451)
 
@@ -36,7 +36,7 @@ Both the backlog limit and `Retry-After` period are configurable, as the `max-qu
 
 ### New Feature: Autosigning supports CA certificate bundles
 
-Previous version of Puppet Server did not support autosigning with CA certificate bundles; it required PEM streams to contain a single certificate. Puppet Server 5.1.0 adds support for autosigning with CA certificate bundles.
+Previous version of Puppet Server did not support autosigning with certificate authority (CA) certificate bundles, which contain multiple certificates. When attempting to pass a bundle, Server would output an error indicating that "the PEM stream must contain exactly 1 certificate". Puppet Server 5.1.0 adds support for autosigning with CA certificate bundles.
 
 -   [SERVER-1315](https://tickets.puppetlabs.com/browse/SERVER-1315)
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -24,16 +24,6 @@ Puppet Server 5.1.0 includes the ability to automatically refresh the certificat
 
 -   [SERVER-1933](https://tickets.puppetlabs.com/browse/SERVER-1933) / [TK-451](https://tickets.puppetlabs.com/browse/TK-451)
 
-### New Feature: Puppet agents retry requests on a configurable delay if Puppet Server is busy
-
-When a group of Puppet agents start their Puppet runs together, they can form a "thundering herd" capable of exceeding Puppet Server's available resources. This results in a growing backlog of requests from Puppet agents waiting for a JRuby instance to become free before their request can be processed. If this backlog exceeds the size of the Server's Jetty thread pool, other requests (such as status checks) start timing out. (For more information about JRubies and Server performance, see [Applying metrics to improve performance](https://docs.puppet.com/puppetserver/latest/puppet_server_metrics_performance.html#measuring-capacity-with-jrubies).)
-
-In previous versions of Puppet Server, administrators had to manually remediate this situation by separating groups of agent requests, for instance through rolling restarts. In Server 5.1.0, administrators can optionally have Server return a 503 response containing a `Retry-After` header to requests when the JRuby backlog exceeds a certain limit, causing agents to pause before retrying the request.
-
-Both the backlog limit and `Retry-After` period are configurable, as the `max-queued-requests` and `max-retry-delay` settings respectively under the `jruby-puppet` configuration in [puppetserver.conf][]. Both settings' default values do not change Puppet Server's behavior compared to Server 5.0.0, so to take advantage of this feature in Puppet Server 5.1.0, you must specify your own values for `max-queued-requests` and `max-retry-delay`. For details, see the [puppetserver.conf][] documentation.
-
--   [SERVER-1767](https://tickets.puppetlabs.com/browse/SERVER-1767)
-
 ### New Feature: Autosigning supports CA certificate bundles
 
 Previous version of Puppet Server did not support autosigning with certificate authority (CA) certificate bundles, which contain multiple certificates. When attempting to pass a bundle, Server would output an error indicating that "the PEM stream must contain exactly 1 certificate". Puppet Server 5.1.0 adds support for autosigning with CA certificate bundles.


### PR DESCRIPTION
-   Add Server 5.1.0 release notes.
-   Remove a redundant line from the documentation index.

Changes to be made in other PRs:

-   _config.yml updates to publish the docs to docs.puppet.com.