### PR TITLE
(maint) Add name to task details response.

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -154,6 +154,7 @@
 (def TaskDetails
   "A filled-in map of information about a task."
   {:metadata {schema/Str schema/Any}
+   :name schema/Str
    :files [{:filename schema/Str
             :sha256 schema/Str
             :size_bytes schema/Int
@@ -377,6 +378,15 @@
      :size_bytes size
      :uri uri}))
 
+(defn full-task-name
+  "Construct a full task name from the two components. If the task's short name
+  is 'init', then the second component is omitted so the task name is just the
+  module's name."
+  [module-name task-shortname]
+  (if (= task-shortname "init")
+    module-name
+    (str module-name "::" task-shortname)))
+
 (schema/defn ^:always-validate
   task-data->task-details :- TaskDetails
   "Fills in a bare TaskData map by examining the files it refers to,
@@ -394,6 +404,7 @@
                          :msg (i18n/tru "The metadata file for the ''{0}'' task was not parseable as JSON"
                                         (str module-name "::" task-name))})))]
     {:metadata (or ?metadata {})
+     :name (full-task-name module-name task-name)
      :files (mapv (partial describe-task-file get-code-content env-name code-id module-name)
                   (:files task-data))}))
 

--- a/test/integration/puppetlabs/services/jruby/tasks_test.clj
+++ b/test/integration/puppetlabs/services/jruby/tasks_test.clj
@@ -222,6 +222,7 @@
               (testing "and the task exists"
                 (testing "with metadata and payload files"
                   (let [expected-info {:metadata {"meta" "data"}
+                                       :name "apache::install_mods"
                                        :files [{:filename "install_mods.rb"
                                                 :sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                                 :size_bytes 0
@@ -232,6 +233,7 @@
 
                 (testing "without a metadata file"
                   (let [expected-info {:metadata {}
+                                       :name "apache"
                                        :files [{:filename "init.rb"
                                                 :sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                                 :size_bytes 0
@@ -242,6 +244,7 @@
 
                 (testing "with no payload files"
                   (let [expected-info {:metadata {"meta" "data"}
+                                       :name "apache::about"
                                        :files []}]
                     (is (= expected-info
                            (get-task-details "production" "apache" "about"))))))
@@ -267,6 +270,7 @@
           (testing "uses static-file-content endpoint when code is available"
             (let [code-fn (fn [_ _ _] (ByteArrayInputStream. (.getBytes "" "UTF-8")))
                   expected-info {:metadata {"meta" "data"}
+                                 :name "apache::install_mods"
                                  :files [{:filename "install_mods.rb"
                                           :sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                           :size_bytes 0
@@ -277,6 +281,7 @@
           (testing "uses file-content endpoint when code content differs from content reported by Puppet"
             (let [code-fn (fn [_ _ _] (ByteArrayInputStream. (.getBytes "some script" "UTF-8")))
                   expected-info {:metadata {"meta" "data"}
+                                 :name "apache::install_mods"
                                  :files [{:filename "install_mods.rb"
                                           :sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                           :size_bytes 0
@@ -287,6 +292,7 @@
           (testing "uses file-content endpoint when code is unavailable"
             (let [code-fn (fn [_ _ _] (throw (Exception. "Versioned code not supported.")))
                   expected-info {:metadata {"meta" "data"}
+                                 :name "apache::install_mods"
                                  :files [{:filename "install_mods.rb"
                                           :sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                                           :size_bytes 0

--- a/test/integration/puppetlabs/services/master/tasks_int_test.clj
+++ b/test/integration/puppetlabs/services/master/tasks_int_test.clj
@@ -111,6 +111,7 @@
 
             (testing "the expected response body is returned"
               (let [expected-response {"metadata" metadata
+                                       "name" "shell::poc"
                                        "files" [{"filename" "poc.sh"
                                                  "sha256" "f24ce8f82408237beebf1fadd8a3da74ebd44512c02eee5ec24cf536871359f7"
                                                  "size_bytes" 20
@@ -168,6 +169,7 @@
 
             (testing "the expected response body is returned"
               (let [expected-response {"metadata" metadata
+                                       "name" "shell::echo"
                                        "files" [{"filename" "echo.sh"
                                                  "sha256" "f24ce8f82408237beebf1fadd8a3da74ebd44512c02eee5ec24cf536871359f7"
                                                  "size_bytes" 20
@@ -189,6 +191,7 @@
 
             (testing "the expected response body is returned"
               (let [expected-response {"metadata" metadata
+                                       "name" "shell::fail"
                                        "files" [{"filename" "fail.sh"
                                                  "sha256" "02ac3362307a6d18d4aa718ffd9a4de31e0233148faf57c6a002c5d6a9c3e57c"
                                                  "size_bytes" 20
@@ -215,6 +218,7 @@
 
             (testing "the expected response body is returned"
               (let [expected-response {"metadata" metadata
+                                       "name" "shell::skip"
                                        "files" [{"filename" "skip.sh"
                                                  "sha256" "f24ce8f82408237beebf1fadd8a3da74ebd44512c02eee5ec24cf536871359f7"
                                                  "size_bytes" 20


### PR DESCRIPTION
Add a 'name' field to the response from the task details endpoint, whose
value is the task's fully-qualified name (which will be just the module
name for the init task).