### PR TITLE
(packaging) Bump version to 5.1.1-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "5.1.0")
+(def ps-version "5.1.1-SNAPSHOT")
 (def jruby-1_7-version "1.7.27-1")
 (def jruby-9k-version "9.1.11.0-1")
 


### PR DESCRIPTION
This commit updates puppetserver's version to the next snapshot version
following the 5.1.0 release.