### PR TITLE
(SERVER-1972) Support Debian 9 in test setup

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -71,6 +71,7 @@ module PuppetServerExtensions
     [
       /debian-7/,
       /debian-8/,
+      /debian-9/,
       /el/, # includes cent6,7 and redhat6,7
       /ubuntu-12/,
       /ubuntu-14/,


### PR DESCRIPTION
Expect PuppetDB packages on Debian 9 (stretch).

Not quite sure where this needs to be targeted. Also relies on unreleased PuppetDB packages.