### PR TITLE
(SERVER-1973) Error on unparseable metadata

### DIFF
--- a/dev-resources/puppetlabs/services/master/tasks_int_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/tasks_int_test/puppet.conf
@@ -2,4 +2,4 @@
 
 certname = localhost
 environmentpath = $confdir/environments
-environment_timeout = unlimited
+environment_timeout = 0

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -183,12 +183,11 @@
   ([module-name :- schema/Str
     task-name :- schema/Str
     task-file-contents :- schema/Str
-    task-metadata :- {schema/Str schema/Str}]
+    task-metadata :- schema/Any]
    (let [module-dir (create-module module-name {})
          tasks-dir (fs/file module-dir "tasks")
          metadata-file-path (fs/file tasks-dir (str task-name ".json"))]
-     (create-file metadata-file-path
-                  (json/encode task-metadata))
+     (create-file metadata-file-path task-metadata)
      (create-file (fs/file tasks-dir (str task-name ".sh"))
                   task-file-contents)
      (.getCanonicalPath metadata-file-path)))
@@ -196,7 +195,7 @@
     task-name :- schema/Str
     task-file-contents :- schema/Str]
    (write-tasks-files module-name task-name task-file-contents
-                      {"description" "This is a description. It describes a thing."})))
+                      (json/encode {"description" "This is a description. It describes a thing."}))))
 
 (defn create-env-conf
   [env-dir content]


### PR DESCRIPTION
Alter the task detail endpoint to return an error if the JSON metadata
for a task is unparseable.

This change is necessary for security reasons: if a task's metadata
restricts the allowed parameters to a task, and there's a typo preventing
that metadata from being parsed, we don't want people to be able to run
the task as if there are no restrictions in place (as would be the case
with an empty metadata object).

Getting the tests to passed required setting the environment_timeout to
zero, as it doesn't create all tasks at once (and an environment_timeout
of unlimited will cache what modules and tasks are found).