### PR TITLE
(SERVER-1993) Add support for serving tasks via static-file-content

### DIFF
--- a/dev-resources/puppetlabs/services/master/tasks_int_test/echo
+++ b/dev-resources/puppetlabs/services/master/tasks_int_test/echo
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+echo $@

--- a/dev-resources/puppetlabs/services/master/tasks_int_test/hello_world
+++ b/dev-resources/puppetlabs/services/master/tasks_int_test/hello_world
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo -n "echo 'Hello, world!'"

--- a/dev-resources/puppetlabs/services/master/tasks_int_test/warn_echo_and_error
+++ b/dev-resources/puppetlabs/services/master/tasks_int_test/warn_echo_and_error
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+echo $@
+echo $@ 1>&2
+exit 1

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.4.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.4.3"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -40,6 +40,9 @@
                                         (master-core/root-routes handle-request
                                                                  (partial identity)
                                                                  jruby-service
+                                                                 (fn [_ _ _]
+                                                                   (throw (IllegalStateException.
+                                                                            (i18n/trs "Versioned code not supported."))))
                                                                  (constantly nil)
                                                                  false))
           master-route-handler (comidi/routes->handler master-routes)

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -89,7 +89,7 @@
    [:AuthorizationService wrap-with-authorization-check]
    [:SchedulerService interspaced]
    [:StatusService register-status]
-   [:VersionedCodeService get-code-content]]
+   [:VersionedCodeService get-code-content current-code-id]]
   (init
    [this context]
    (core/validate-memory-requirements!)
@@ -119,6 +119,7 @@
                                                use-legacy-auth-conf
                                                jruby-service
                                                get-code-content
+                                               current-code-id
                                                handle-request
                                                (get-auth-handler)
                                                environment-class-cache-enabled)

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -196,6 +196,11 @@
           (is (= 200 (:status response)))
           (is (= "application/octet-stream" (get-in response [:headers "content-type"])))
           (is (= "test foobar modules/foo/files/bar.txt\n" (:body response)))))
+      (testing "the /static_file_content endpoint successfully streams task content"
+        (let [response (testutils/get-static-file-content "modules/foo/tasks/bar.txt?code_id=foobar&environment=test")]
+          (is (= 200 (:status response)))
+          (is (= "application/octet-stream" (get-in response [:headers "content-type"])))
+          (is (= "test foobar modules/foo/tasks/bar.txt\n" (:body response)))))
       (testing (str "the /static_file_content endpoint successfully streams file content "
                     "from directories other than /modules")
         (let [response (testutils/get-static-file-content "site/foo/files/bar.txt?code_id=foobar&environment=test")]
@@ -254,7 +259,7 @@
                              "environment=test&code_id=foobar"))]
           (is (= 403 (:status response)))
           (is (= (str "Request Denied: A /static_file_content request must be "
-                      "a file within the files directory of a module.")
+                      "a file within the files or tasks directory of a module.")
                  (:body response)))))
       (testing "the /static_file_content endpoint returns an error (400) for attempted traversals"
         (let [response (testutils/get-static-file-content "modules/foo/files/bar/../../../..?environment=test&code_id=foobar")]

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -33,6 +33,7 @@
   [request-handler puppet-version jruby-service]
   (-> (root-routes request-handler ring/wrap-params
                    jruby-service
+                   (fn [___] (throw (IllegalStateException. "Versioned code not supported.")))
                    (constantly nil)
                    true)
       (comidi/routes->handler)


### PR DESCRIPTION
Supports serving tasks via the static-file-content endpoint, and uses it in the tasks API when files are available via the endpoint.

Restructures tests to use a `with-running-server` fixture to simplify setup.

Blocked on a release with https://github.com/puppetlabs/clj-parent/pull/84.