### PR TITLE
(maint) Update puppet-agent pin to 1.10.8.31.g445a971

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -23,7 +23,7 @@ module PuppetServerExtensions
 
     puppet_version = get_option_value(options[:puppet_version],
                          nil, "Puppet Version", "PUPPET_VERSION",
-                         "1.10.8",
+                         "1.10.8.31.g445a971",
                          :string) ||
                          get_puppet_version
 
@@ -32,7 +32,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "1.10.8",
+                         "445a9718fc68a7e7ebbeb405b28cdffd1a575db6",
                          :string)
 
     # puppetdb version corresponds to packaged development version located at:


### PR DESCRIPTION
A defect in the Puppet agent acceptance tests was causing spurious
failures in CI; this commit updates the Puppet submodule commit and
Puppet agent pins to pick up the acceptance test fix and keep all of the
packaging in sync.