### PR TITLE
(maint) Merge 5.1.x into master

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -71,6 +71,7 @@ module PuppetServerExtensions
     [
       /debian-7/,
       /debian-8/,
+      /debian-9/,
       /el/, # includes cent6,7 and redhat6,7
       /ubuntu-12/,
       /ubuntu-14/,

--- a/documentation/config_file_logbackxml.markdown
+++ b/documentation/config_file_logbackxml.markdown
@@ -14,7 +14,7 @@ Puppet Server’s logging is routed through the Java Virtual Machine's [Logback 
 
 By default, Puppet Server logs messages and errors to `/var/log/puppetlabs/puppetserver/puppetserver.log`. The default log level is ‘INFO’, and Puppet Server sends nothing to `syslog`. You can change Puppet Server's logging behavior by editing `/etc/puppetlabs/puppetserver/logback.xml`, and you can specify a different Logback config file in [`global.conf`](#globalconf).
 
-Puppet Server picks up changes to `logback.xml` at runtime, so while you can restart the `puppetserver` service for changes to take effect, they should also take effect after a minute or so.
+You can restart the `puppetserver` service for changes to take effect, or enable [configuration scanning](#scan-and-scanperiod) to allow changes to be recognized at runtime.
 
 Puppet Server also relies on Logback to manage, rotate, and archive Server log files. Logback archives Server logs when they exceed 10MB, and when the total size of all Server logs exceeds 1GB, it automatically deletes the oldest logs.
 
@@ -40,20 +40,30 @@ You can also change the logging level for JRuby logging from its defaults of `er
 
 You can change the file to which Puppet Server writes its logs in the `appender` section named `F1`. By default, the location is set to `/var/log/puppetlabs/puppetserver/puppetserver.log`:
 
-~~~ xml
+``` xml
 ...
     <appender name="F1" class="ch.qos.logback.core.FileAppender">
         <file>/var/log/puppetlabs/puppetserver/puppetserver.log</file>
 ...
-~~~
+```
 
 To change this to `/var/log/puppetserver.log`, modify the contents of the `file` element:
 
-~~~ xml
+``` xml
         <file>/var/log/puppetserver.log</file>
-~~~
+```
 
-Note that the user account that owns the Puppet Server process must have write permissions to the destination path.
+The user account that owns the Puppet Server process must have write permissions to the destination path.
+
+#### `scan` and `scanPeriod`
+
+Logback supports noticing and reloading configuration changes without requiring a restart, a feature Logback calls **scanning**. To enable this, set the `scan` and `scanPeriod` attributes in the `<configuration>` element of `logback.xml`.  Scanning can potentially degrade logging performance and is not enabled by default.
+
+``` xml
+<configuration scan="true" scanPeriod="60 seconds">
+```
+
+Due to a [bug in Logback](https://tickets.puppetlabs.com/browse/TK-426), the `scanPeriod` must be set to a value; setting only `scan="true"` will not enable configuration scanning.
 
 ## HTTP request logging
 

--- a/documentation/puppet-api/v3/static_file_content.markdown
+++ b/documentation/puppet-api/v3/static_file_content.markdown
@@ -4,21 +4,21 @@ title: "Puppet Server: Puppet API: Static File Content"
 canonical: "/puppetserver/latest/puppet-api/v3/static_file_content.html"
 ---
 
-[`code-content-command`]: https://docs.puppet.com/puppetserver/latest/config_file_puppetserver.html
-[static catalog]: https://docs.puppet.com/puppet/latest/reference/static_catalogs.html
-[catalog]: https://docs.puppet.com/puppet/latest/reference/subsystem_catalog_compilation.html
-[file resource]: https://docs.puppet.com/puppet/latest/reference/type.html#file
-[environment]: https://docs.puppet.com/puppet/latest/reference/environments.html
-[auth.conf]: https://docs.puppet.com/puppetserver/latest/config_file_auth.html
+[`code-content-command`]: https://puppet.com/docs/puppetserver/latest/config_file_puppetserver.html
+[static catalog]: https://puppet.com/docs/puppet/latest/static_catalogs.html
+[catalog]: https://puppet.com/docs/puppet/latest/subsystem_catalog_compilation.html
+[file resource]: https://puppet.com/docs/puppet/latest/type.html#file
+[environment]: https://puppet.com/docs/puppet/latest/environments.html
+[auth.conf]: https://puppet.com/docs/puppetserver/latest/config_file_auth.html
 
 The `static_file_content` endpoint returns the standard output of a
 [`code-content-command`][] script, which should output the contents of a specific version
 of a [file resource][] that has a `source` attribute with a `puppet:///` URI value. That
-source must be a file from the `files` directory of a module in a specific [environment][].
+source must be a file from the `files` or `tasks` directory of a module in a specific [environment][].
 
 Puppet Agent uses this endpoint only when applying a [static catalog][]. This endpoint
 is available only when the Puppet master is running Puppet Server, not Ruby Puppet masters, such as the
-[deprecated WEBrick Puppet master](https://docs.puppet.com/puppet/latest/reference/services_master_webrick.html).
+[deprecated WEBrick Puppet master](https://puppet.com/docs/puppet/latest/services_master_webrick.html).
 
 ## `GET /puppet/v3/static_file_content/<FILE-PATH>`
 
@@ -29,7 +29,7 @@ request to this endpoint with the required parameters.
 
 The `<FILE-PATH>` segment of the endpoint is required. The path corresponds to the
 requested file's path on the Server relative to the given environment's root directory,
-and must point to a file in the `*/*/files/**` glob. For example, Puppet Server will
+and must point to a file in the `*/*/files/**` or `*/*/tasks/**` glob. For example, Puppet Server will
 inline metadata into static catalogs for file resources sourcing module files located by
 default in
 `/etc/puppetlabs/code/environments/<ENVIRONMENT>/modules/<MODULE NAME>/files/**`.
@@ -50,7 +50,7 @@ requested version in the response body. An unsuccessful request returns an error
 code with a `text/plain` Content-Type header:
 
 -   400: returned when any of the parameters are not provided.
--   403: returned when requesting a file that is not within a module's `files`
+-   403: returned when requesting a file that is not within a module's `files` or `tasks`
 directory.
 -   500: returned when `code-content-command` is not configured on the server, or
 when a requested file or version is not present in a repository.
@@ -93,7 +93,7 @@ is not configured on Puppet Server.
 
 > **Note:** The `code-content-command` and `code-id-command` scripts are not provided in a
 > default installation or upgrade. For more information about these scripts, see the
-> [static catalog documentation](//docs.puppet.com/puppet/latest/reference/static_catalogs.html).
+> [static catalog documentation](https://puppet.com/docs/puppet/latest/static_catalogs.html).
 
 #### Authorization
 

--- a/documentation/puppet-api/v3/task_detail.markdown
+++ b/documentation/puppet-api/v3/task_detail.markdown
@@ -4,8 +4,8 @@ title: "Puppet Server: Puppet API: Task detail"
 canonical: "/puppetserver/latest/puppet-api/v3/task-detail.html"
 ---
 
-[deprecated WEBrick Puppet master]: https://docs.puppet.com/puppet/latest/reference/services_master_webrick.html
-[`environment_timeout`]: https://docs.puppet.com/puppet/latest/reference/config_file_environment.html#environmenttimeout
+[deprecated WEBrick Puppet master]: https://puppet.com/docs/puppet/latest/services_master_webrick.html
+[`environment_timeout`]: https://puppet.com/docs/puppet/latest/config_file_environment.html#environmenttimeout
 
 [`auth.conf`]: ../../config_file_auth.markdown
 [`puppetserver.conf`]: ../../config_file_puppetserver.markdown
@@ -27,15 +27,20 @@ on Ruby Puppet masters, such as the [deprecated WEBrick Puppet master][]. It als
 the Ruby-based Puppet master's authorization methods and configuration. See the
 [Authorization section](#authorization) for more information.
 
+> Note: Tasks file contents in versioned code can be retrieved using the [`static_file_content`](./static_file_content.markdown) endpoint.
+
 ### Does not return entries for task files with invalid names
+
 A task file name has the same restriction as puppet type names and must match
 the regular expression `\A[a-z][a-z0-9_]*\z` (excluding extensions).
 
 ### Returns entries for tasks with no executable files
+
 A task will be listed if only metadata for it exists. How many files are
 associated with a task can be found by querying that task's details.
 
 ### Does read files
+
 This endpoint will read in contents of metadata and other task files, so it may
 be more expensive than the `/tasks` endpoint.
 
@@ -178,8 +183,7 @@ Could not find task 'doesnotexist'
 
 ### Schema
 
-A tasks detail response body conforms to the
-[task detail schema](./task_detail.json).
+A tasks detail response body conforms to the [task detail schema](./task_detail.json).
 
 ### Authorization
 

--- a/documentation/puppet-api/v3/tasks.markdown
+++ b/documentation/puppet-api/v3/tasks.markdown
@@ -4,8 +4,8 @@ title: "Puppet Server: Puppet API: Tasks"
 canonical: "/puppetserver/latest/puppet-api/v3/tasks.html"
 ---
 
-[deprecated WEBrick Puppet master]: https://docs.puppet.com/puppet/latest/reference/services_master_webrick.html
-[`environment_timeout`]: https://docs.puppet.com/puppet/latest/reference/config_file_environment.html#environmenttimeout
+[deprecated WEBrick Puppet master]: https://puppet.com/puppet/latest/services_master_webrick.html
+[`environment_timeout`]: https://puppet.com/docs/puppet/latest/config_file_environment.html#environmenttimeout
 
 [`auth.conf`]: ../../config_file_auth.markdown
 [`puppetserver.conf`]: ../../config_file_puppetserver.markdown
@@ -22,15 +22,20 @@ on Ruby Puppet masters, such as the [deprecated WEBrick Puppet master][]. It als
 the Ruby-based Puppet master's authorization methods and configuration. See the
 [Authorization section](#authorization) for more information.
 
+> Note: Tasks file contents in versioned code can be retrieved using the [`static_file_content`](./static_file_content.markdown) endpoint.
+
 ### Does not return entries for task files with invalid names
-A task file name has the same restriction as puppet type names and must match
+
+A task file name has the same restriction as Puppet type names and must match
 the regular expression `\A[a-z][a-z0-9_]*\z` (excluding extensions).
 
 ### Returns entries for tasks with no executable files
+
 A task will be listed if only metadata for it exists. How many files are
 associated with a task can be found by querying that task's details.
 
 ### Does not read files
+
 This endpoint will not parse metadata or read any other files, only file names.
 
 ### Uses `application/json` Content-Type
@@ -141,8 +146,7 @@ The environment must be purely alphanumeric, not 'bog|us'
 
 ### Schema
 
-A tasks response body conforms to the
-[tasks schema](./tasks.json).
+A tasks response body conforms to the [tasks schema](./tasks.json).
 
 ### Authorization
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -12,6 +12,18 @@ canonical: "/puppetserver/latest/release_notes.html"
 
 For release notes on versions of Puppet Server prior to Puppet Server 5, see [docs.puppet.com](https://docs.puppet.com/puppetserver/2.8/release_notes.html).
 
+## Puppet Server 5.1.4
+
+Released November 6, 2017.
+
+This is a minor feature release of Puppet Server.
+
+### New feature: Serve versioned tasks from static file content endpoint
+
+Tasks available from versioned code will be served via the static file content endpoint, rather than out of Puppet's file serving. This should reduce resources used to serve tasks.
+
+-   [SERVER-1993](https://tickets.puppetlabs.com/browse/SERVER-1993)
+
 ## Puppet Server 5.1.3
 
 Released October 2, 2017.
@@ -23,6 +35,15 @@ This is a bug-fix release of Puppet Server. Puppet Server 5.1.1 and 5.1.2 were n
 Previous versions of Puppet Server set the default logging level to `debug`, then filtered the log output using Logback. Because Puppet generates a very large amount of output in debug mode, this behavior could significantly degrade Puppet Server's performance. Server 5.1.3 resolves this issue by producing `debug` output only when configured to do so. For details about setting logging levels, see [the logback.xml configuration documentation](./config_file_logbackxml.markdown).
 
 -   [SERVER-1922](https://tickets.puppetlabs.com/browse/SERVER-1922)
+
+### Packaging change: Use operating system codename in Debian packages' release field
+
+In Debian and Debian-derivative packages from Puppet Server 5.1.3 onward, the release field changes from "1puppetlabs" to "1<OS CODENAME>". For example, the `puppetserver` package version for Server 5.1.3 on Ubuntu 16.04 (Xenial Xerus) is "5.1.3-1xenial", whereas the package version for Server 5.1.0 was "5.1.0-1puppetlabs1".
+
+This fixes an issue where some repository mirroring tools failed to mirror our repositories because packages with different contents had the same name. This does not otherwise affect the package installation process.
+
+-   [CPR-292](https://tickets.puppetlabs.com/browse/CPR-292)
+-   [CPR-429](https://tickets.puppetlabs.com/browse/CPR-429)
 
 ## Puppet Server 5.1.0
 
@@ -67,7 +88,7 @@ In previous versions of Puppet Server, there was no designed way to add Java JAR
 
 Released June 27, 2017.
 
-This is a major release of Puppet Server, and corresponds with the major release of Puppet 5.0, which also includes many changes and new features relevant to Puppet Server users. 
+This is a major release of Puppet Server, and corresponds with the major release of Puppet 5.0, which also includes many changes and new features relevant to Puppet Server users.
 
 ### Platform changes
 

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,4 +1,9 @@
 ---
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 project: 'puppetserver'
+
+repo_name: 'puppet5'
+nonfinal_repo_name: 'puppet5-nightly'
+repo_link_target: 'puppet'
+nonfinal_repo_link_target: 'puppet-nightly'


### PR DESCRIPTION
This merge up discards updates to the project.clj (version number,
master is pointing to 5.2.0 now) and our puppet source code pins (our
master branch automatically uptakes code from puppet/master).

This does pull in documentation and git history for our 5.1.x releases.

 Conflicts:
	acceptance/config/beaker/options.rb
	project.clj
	ruby/puppet