### PR TITLE
(maint) Fix incorrect field name "SHA256" in task API doc

### DIFF
--- a/documentation/puppet-api/v3/task_detail.markdown
+++ b/documentation/puppet-api/v3/task_detail.markdown
@@ -94,7 +94,7 @@ Content-Type: application/json
   },
   "files": [
     {"filename": "taskname.rb",
-      "SHA256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "size_bytes": 1024,
       "uri:" {
         "path": "/puppet/v3/file_content/tasks/module/taskname.rb",


### PR DESCRIPTION
This field is actually called "sha256" vs. "SHA256".