### PR TITLE
(SERVER-2003) Remove puppetlabs-postgresql pin

### DIFF
--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -22,10 +22,6 @@ test_name 'PuppetDB integration'
 ## report was sent from Puppet Server to PuppetDB
 if !master.is_pe?
   step 'Install PuppetDB module' do
-    # puppetlabs-postgresql 5.2.0 introduced some bad dependency specifications
-    # that broke ordering. When that's resolved we should switch to using the
-    # version of puppetlabs-postgresql that puppetlabs-puppetdb uses.
-    on(master, puppet('module install puppetlabs-postgresql -v 5.1.0'))
     on(master, puppet('module install puppetlabs-puppetdb'))
   end
 


### PR DESCRIPTION
This is a dupe of https://github.com/puppetlabs/puppetserver/pull/1569 since we're not merging up from 2.x to 5.1.x+. Will need to be merged up to master after the merge.