### PR TITLE
(SERVER-2025) Record metrics for max-queued-requests

### DIFF
--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -59,12 +59,12 @@
    metrics-service :- (schema/protocol jruby-metrics/JRubyMetricsService)
    max-queued-requests :- schema/Int
    max-retry-delay :- schema/Int]
-  (fn [request]
-    (let [metrics-map (jruby-metrics/get-metrics metrics-service)
-          requested-count (-> metrics-map :requested-instances deref count)]
-      (if (>= requested-count max-queued-requests)
-        (let [err-msg (i18n/trs "The number of requests waiting for a JRuby instance has exceeded the limit allowed by the max-queued-requests setting.")
-              response (output-error request {:msg err-msg} 503)]
+  (let [metrics-map (jruby-metrics/get-metrics metrics-service)
+        {:keys [requested-instances]} metrics-map
+        err-msg (i18n/trs "The number of requests waiting for a JRuby instance has exceeded the limit allowed by the max-queued-requests setting.")]
+    (fn [request]
+      (if (>= (count @requested-instances) max-queued-requests)
+        (let [response (output-error request {:msg err-msg} 503)]
           (if (pos? max-retry-delay)
             (assoc-in response [:headers "Retry-After"]
                       (-> (rand) (* max-retry-delay) int str))


### PR DESCRIPTION
This patch adds a new JRuby metric, `queue-limit-hit-meter`, that counts the
number of times the `max-queued-requests` limit was hit and provides
one minute, five minute and fifteen minute measurements on the rate at which
the hits are occurring. This metric can be used to monitor the amount of
traffic that Puppet Server is rejecting due to the `max-queued-request` limit.

The count and five minute rate are also added to the status output for the
JRuby service.