### PR TITLE
(SERVER-1974) Add additional compiler metrics to status output

### DIFF
--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -6,9 +6,8 @@
 ## agent run reports.
 ##
 ## This test validates communication is successful by querying the PuppetDB HTTP
-## API and asserting the agent's report timestamp is not null. This means that
-## PuppetDB successfully received the agent's report sent from Puppet Server.
-## We can just run the agent that's on the master for this.
+## API and asserting that an updated factset, catalog and report from an agent
+## run made it into PuppetDB.
 #
 
 # We only run this test if we'll have puppetdb installed, which is gated in
@@ -17,16 +16,34 @@ matching_puppetdb_platform = puppetdb_supported_platforms.select { |r| r =~ mast
 skip_test unless matching_puppetdb_platform.length > 0
 
 require 'json'
+require 'time'
 
-step 'Submit agent report to PuppetDB via server' do
-  with_puppet_running_on(master, {}) do
+run_timestamp = nil
+
+with_puppet_running_on(master, {}) do
+  step 'Enable PuppetDB' do
+    apply_manifest_on(master, <<EOM)
+class{'puppetdb::master::config':
+  enable_reports          => true,
+  manage_report_processor => true,
+}
+EOM
+  end
+
+  step 'Run agent to trigger data submission to PuppetDB' do
+    run_timestamp = Time.now.utc
     on(master, puppet_agent("--test --server #{master}"), :acceptable_exit_codes => [0,2])
   end
 end
 
-step 'Validate server sent agent report to PuppetDB' do
+step 'Validate server sent agent data to PuppetDB' do
   fqdn = on(master, '/opt/puppetlabs/bin/facter fqdn').stdout.chomp
   query = "curl http://localhost:8080/pdb/query/v4/nodes/#{fqdn}"
   response = JSON.parse(on(master, query).stdout.chomp)
-  assert(response['report_timestamp'] != nil)
+  %w[facts_timestamp catalog_timestamp report_timestamp].each do |dataset|
+    assert_operator(Time.iso8601(response[dataset]),
+                    :>,
+                    run_timestamp,
+                   "#{dataset} updated in PuppetDB")
+  end
 end

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -7,7 +7,9 @@
 ##
 ## This test validates communication is successful by querying the PuppetDB HTTP
 ## API and asserting that an updated factset, catalog and report from an agent
-## run made it into PuppetDB.
+## run made it into PuppetDB. Additionally, the STDOUT of the agent run is
+## tested for the presence of a Notify resource that was exported by another
+## node.
 #
 
 # We only run this test if we'll have puppetdb installed, which is gated in
@@ -17,8 +19,29 @@ skip_test unless matching_puppetdb_platform.length > 0
 
 require 'json'
 require 'time'
+require 'securerandom'
 
 run_timestamp = nil
+master_fqdn = on(master, '/opt/puppetlabs/bin/facter fqdn').stdout.chomp
+random_string = SecureRandom.urlsafe_base64.freeze
+
+step 'Configure site.pp for PuppetDB' do
+  sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
+  create_remote_file(master, sitepp, <<EOM)
+node 'resource-exporter.test' {
+  @@notify{'#{random_string}': }
+}
+
+node '#{master_fqdn}' {
+  Notify<<| title == '#{random_string}' |>>
+}
+EOM
+  on(master, "chmod 644 #{sitepp}")
+
+  teardown do
+    on(master, "rm -f #{sitepp}")
+  end
+end
 
 with_puppet_running_on(master, {}) do
   step 'Enable PuppetDB' do
@@ -30,15 +53,33 @@ class{'puppetdb::master::config':
 EOM
   end
 
+  step 'Run agent to generate exported resources' do
+    # This test compiles a catalog using a differnt certname so that
+    # later runs can test collection.
+    on(master, puppet('cert', 'generate', 'resource-exporter.test'))
+
+    teardown do
+      on(master, puppet('node', 'deactivate', 'resource-exporter.test'))
+      on(master, puppet('cert', 'clean', 'resource-exporter.test'))
+    end
+
+    on(master, puppet_agent('--test', '--noop',
+                            '--server', master_fqdn,
+                            '--certname', 'resource-exporter.test'),
+              :acceptable_exit_codes => [0,2])
+  end
+
   step 'Run agent to trigger data submission to PuppetDB' do
     run_timestamp = Time.now.utc
-    on(master, puppet_agent("--test --server #{master}"), :acceptable_exit_codes => [0,2])
+    on(master, puppet_agent("--test --server #{master_fqdn}"), :acceptable_exit_codes => [0,2]) do
+      assert_match(/Notice: #{random_string}/, stdout,
+                  'Puppet run collects exported Notify')
+    end
   end
 end
 
 step 'Validate server sent agent data to PuppetDB' do
-  fqdn = on(master, '/opt/puppetlabs/bin/facter fqdn').stdout.chomp
-  query = "curl http://localhost:8080/pdb/query/v4/nodes/#{fqdn}"
+  query = "curl http://localhost:8080/pdb/query/v4/nodes/#{master_fqdn}"
   response = JSON.parse(on(master, query).stdout.chomp)
   %w[facts_timestamp catalog_timestamp report_timestamp].each do |dataset|
     assert_operator(Time.iso8601(response[dataset]),

--- a/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
+++ b/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
@@ -25,6 +25,7 @@ public class MetricsPuppetProfiler implements PuppetProfiler {
     private static final Pattern RESOURCE_PATTERN = Pattern.compile(".*\\.compiler\\.evaluate_resource\\.([\\w\\d_]+\\[([\\w\\d_]+::)*[\\w\\d_]+\\])$");
     private static final Pattern CATALOG_PATTERN = Pattern.compile(".*\\.compiler\\.(static_compile_postprocessing|static_compile|compile|find_node)$");
     private static final Pattern INLINING_PATTERN = Pattern.compile(".*\\.compiler\\.static_compile_inlining\\.(.*)$");
+    private static final Pattern PUPPETDB_PATTERN = Pattern.compile(".*\\.puppetdb\\.(resource\\.search|facts\\.encode|command\\.submit\\.replace facts|catalog\\.munge|command\\.submit\\.replace catalog|report\\.convert_to_wire_format_hash|command\\.submit\\.store report|query)$");
 
 
     public MetricsPuppetProfiler(String hostname, MetricRegistry registry) {
@@ -66,6 +67,10 @@ public class MetricsPuppetProfiler implements PuppetProfiler {
 
     public Map<String, Timer> getInliningTimers() {
         return getTimers(INLINING_PATTERN);
+    }
+
+    public Map<String, Timer> getPuppetDBTimers() {
+        return getTimers(PUPPETDB_PATTERN);
     }
 
     @Override

--- a/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
+++ b/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
@@ -23,7 +23,7 @@ public class MetricsPuppetProfiler implements PuppetProfiler {
 
     private static final Pattern FUNCTION_PATTERN = Pattern.compile(".*\\.functions\\.([\\w\\d_]+)$");
     private static final Pattern RESOURCE_PATTERN = Pattern.compile(".*\\.compiler\\.evaluate_resource\\.([\\w\\d_]+\\[([\\w\\d_]+::)*[\\w\\d_]+\\])$");
-    private static final Pattern CATALOG_PATTERN = Pattern.compile(".*\\.compiler\\.(static_compile_postprocessing|static_compile|compile)$");
+    private static final Pattern CATALOG_PATTERN = Pattern.compile(".*\\.compiler\\.(static_compile_postprocessing|static_compile|compile|find_node)$");
     private static final Pattern INLINING_PATTERN = Pattern.compile(".*\\.compiler\\.static_compile_inlining\\.(.*)$");
 
 


### PR DESCRIPTION
This patch adds some additional patterns to the MetricsPuppetProfiler class and extends the `catalog-metrics` arrary reported by `status/v1/services/puppet-profiler` to include:

  - `find_node`: Measures the time it took for the External Node Classifier to return node data during compilation.

A new `puppetdb-metrics` array is also present and will be populated if PuppetDB is used. Metrics included here are:

  - `query`: Time spent waiting for PuppetDB to return query results.
  - `resource_search`: Time spent waiting for PuppetDB to collect exported resources.
  - `facts_encode`: Time spent in the Ruby terminus transforming fact data for PuppetDB.
  - `command_submit_replace_facts`: Time spent waiting for PuppetDB to accept fact data.
  - `catalog_munge`: Time spent in the Ruby terminus transforming catalog data for PuppetDB.
  - `command_submit_replace_catalog`: Time spent waiting for PuppetDB to accept catalog data.
  - `report_convert_to_wire_format_hash `: Time spent in the Ruby terminus transforming report data for PuppetDB.
  - `command_submit_store_report`: Time spent waiting for PuppetDB to accept report data.

Having these measurements available allows metrics from the `status/` API to show whether the ENC or PuppetDB are bottlenecking catalog compilation.