### PR TITLE
(SERVER-2034) Add -master back into version string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "5.2.0-SNAPSHOT")
+(def ps-version "5.2.0-master-SNAPSHOT")
 (def jruby-1_7-version "1.7.27-1")
 (def jruby-9k-version "9.1.11.0-1")
 


### PR DESCRIPTION
Some of the automated performance tests search for the latest build with
the word -master in the version string. This broke when -master was
removed from the version string between 5.0.1 and 5.1.0. This commit
adds it back in to get those tests working again.