### PR TITLE
(SERVER-2054) [#puppethack] Add support for PUT /puppet/v3/facts

### DIFF
--- a/dev-resources/puppetlabs/services/master/master_service_test/confdir/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/master_service_test/confdir/puppet.conf
@@ -1,6 +1,7 @@
 [master]
 certname = localhost
 node_terminus = exec
+facts_terminus = yaml
 external_nodes = "/bin/sh ./dev-resources/puppetlabs/services/master/master_service_test/enc.sh"
 reports = http
 

--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -117,6 +117,17 @@ authorization: {
             name: "puppetlabs report"
         },
         {
+            # Allow nodes to update their own facts
+            match-request: {
+                path: "^/puppet/v3/facts/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs facts"
+        },
+        {
             match-request: {
                 path: "/puppet/v3/status"
                 type: path

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -736,6 +736,8 @@
                (request-handler (assoc request :include-code-id? true)))
    (comidi/POST ["/catalog/" [#".*" :rest]] request
                 (request-handler (assoc request :include-code-id? true)))
+   (comidi/PUT ["/facts/" [#".*" :rest]] request
+               (request-handler request))
    (comidi/PUT ["/report/" [#".*" :rest]] request
                (request-handler request))
    (comidi/GET ["/environment/" [#".*" :environment]] request


### PR DESCRIPTION
This patch adds a comidi handler to the routing tree of the MasterService that
responds to PUT requests for `/puppet/v3/facts`.