### PR TITLE
(maint) Bump to ezbake 1.7.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -211,7 +211,7 @@
                                                [puppetlabs/puppetserver ~ps-version :exclusions [puppetlabs/jruby-deps]]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.6.6"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.7.3"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 nil]]}


### PR DESCRIPTION
This commit updates to the latest version of ezbake, which includes packaging#1.0.x. This automation will enable shipping nightlies to weth, which syncs to s3, and will ultimately be served on nightlies.puppet.com.