### PR TITLE
(SERVER-2022) Don't run pdb tests if pdb isn't there

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -2,7 +2,6 @@
 matching_puppetdb_platform = puppetdb_supported_platforms.select { |r| r =~ master.platform }
 skip_test unless matching_puppetdb_platform.length > 0
 
-require 'json'
 
 test_name 'PuppetDB setup'
 sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -9,6 +9,14 @@
 ## API and asserting the agent's report timestamp is not null. This means that
 ## PuppetDB successfully received the agent's report sent from Puppet Server.
 ## We can just run the agent that's on the master for this.
+#
+
+# We only run this test if we'll have puppetdb installed, which is gated in
+# acceptance/suites/pre_suite/foss/95_install_pdb.rb using the same conditional
+matching_puppetdb_platform = puppetdb_supported_platforms.select { |r| r =~ master.platform }
+skip_test unless matching_puppetdb_platform.length > 0
+
+require 'json'
 
 step 'Submit agent report to PuppetDB via server' do
   with_puppet_running_on(master, {}) do


### PR DESCRIPTION
PDB installation is gated on a list of supported platforms, which
differs(ed?) from the platforms that puppetserver builds and tests for.
Previously the pdb smoke tests were unconditionally run, even if pdb
wouldn't be there. This commit limits them both to only the platforms
listed in the puppetdb_supported_platforms method.