### PR TITLE
(SERVER-2064) Use /bin/sh for commands that use shell characters

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -56,6 +56,30 @@ describe Puppet::Server::Execution do
       expect(result.exitstatus).not_to eq 0
     end
 
+    context "it should support other shellisms" do
+      it "should support pipes" do
+        result = test_execute("echo foo | wc -c")
+        expect(result).to be_a Puppet::Util::Execution::ProcessOutput
+        expect(result.lstrip).to eq "4\n"
+        expect(result.exitstatus).to eq 0
+      end
+
+      it "should support environment variables" do
+        result = test_execute(%(FOO=bar python -c "import os; print os.environ['FOO']"))
+        expect(result).to be_a Puppet::Util::Execution::ProcessOutput
+        expect(result).to eq "bar\n"
+        expect(result.exitstatus).to eq 0
+      end
+
+      it "should support environment newlines" do
+        result = test_execute(%(echo "foo\nbar"))
+        expect(result).to be_a Puppet::Util::Execution::ProcessOutput
+        expect(result.lines.count).to eq 2
+        expect(result.exitstatus).to eq 0
+      end
+    end
+
+
     it "should raise an error if `failonfail` is true and the process returns non-zero" do
       expect {
         test_execute("false", {:failonfail => true})

--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -60,7 +60,7 @@ describe Puppet::Server::Execution do
       it "should support pipes" do
         result = test_execute("echo foo | wc -c")
         expect(result).to be_a Puppet::Util::Execution::ProcessOutput
-        expect(result.lstrip).to eq "4\n"
+        expect(result.strip).to eq "4"
         expect(result.exitstatus).to eq 0
       end
 

--- a/src/ruby/puppetserver-lib/puppet/server/execution.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/execution.rb
@@ -16,6 +16,12 @@ class Puppet::Server::Execution
   end
 
   private
+  # In ruby 1.9 (which jruby 1.7 runs as, `chars` returns an enumerator
+  # [https://ruby-doc.org/core-1.9.3/String.html#method-i-chars], which is
+  # unsuitable for passing to `Regexp.union`, so we explicitly turn it into an
+  # array. In ruby 2.0 and later, `chars` returns an array
+  # [https://ruby-doc.org/core-2.0.0/String.html#method-i-chars], so the `to_a`
+  # call will essentially be a noop.
   SHELL_CHARACTERS = "*?{}[]<>()~&|\\$;'`\"\n#=".chars.to_a
 
   def self.execute(command, options)


### PR DESCRIPTION
Commands that use pipes and other shell characters are currently handled
incorrectly by puppetserver's Puppet::Server::Execution.execute method.
They are parsed by apache commons exec and treated as arguments to the
binary being invoked, which is almost certainly the wrong thing. In
order to allow commands with pipes and other shell characters to be
correctly invoked, this commit brings the execute method into line with
what MRI's Kernel.exec does by default. It checks the command string
against a list of known shell characters and if any are found, it
invokes the command with /bin/sh -c. The list of characters can be found
at https://github.com/ruby/ruby/blob/v2_4_2/process.c#L2166.