### PR TITLE
(PUP-8127) Update matcher for parse errors in environment cache tests

### DIFF
--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -264,9 +264,9 @@
                                "error" (str "This Name has no effect. A value "
                                             "was produced and then forgotten ("
                                             "one or more preceding expressions "
-                                            "may have the wrong form) at "
+                                            "may have the wrong form) (file: "
                                             borked-file
-                                            ":1:1")}
+                                            ", line: 1, column: 1)")}
                               {"path" foo-file,
                                "classes" [{
                                            "name" "foo"


### PR DESCRIPTION
Update assertion for new error format introduced in
https://github.com/puppetlabs/puppet/commit/f31193ee68666c18d336a56532500b9f86b1627c