### PR TITLE
(SERVER-2036) Clarify http-client configuration

### DIFF
--- a/dev/puppetserver.conf.sample
+++ b/dev/puppetserver.conf.sample
@@ -81,7 +81,10 @@ jruby-puppet: {
     environment-class-cache-enabled: true
 }
 
-# settings related to HTTP client requests made by Puppet Server
+# Settings related to HTTP client requests made by Puppet Server.
+# These settings only apply to client connections using the Puppet::Network::HttpPool
+# classes. Client connections using net/http or net/https directly will not be
+# configured with these settings automatically.
 http-client: {
     # A list of acceptable protocols for making HTTP requests
     #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]

--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -120,6 +120,9 @@ jruby-puppet: {
 }
 
 # Settings related to HTTP client requests made by Puppet Server.
+# These settings only apply to client connections using the Puppet::Network::HttpPool
+# classes. Client connections using net/http or net/https directly will not be
+# configured with these settings automatically.
 http-client: {
     # A list of acceptable protocols for making HTTP requests
     #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]


### PR DESCRIPTION
This commit makes it clear that the http-client configuration will not
affect requests using ruby's net/http libraries directly. Previously
that clarity was absent.