### PR TITLE
 (SERVER-1922) Defer settting Puppet log level, use logback

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/config_spec.rb
@@ -1,6 +1,27 @@
 require 'puppet/server/config'
 
 describe Puppet::Server::Config do
+  context "initializing Puppet Server" do
+    context "setting the Puppet log level from logback" do
+      let(:logger) do
+        stub("Logger", isDebugEnabled: false, isInfoEnabled: true, isWarnEnabled: false, isErrorEnabled: false)
+      end
+
+      before :each do
+        Puppet::Server::Logger.expects(:get_logger).returns(logger)
+        Puppet::Server::Config.initialize_puppet_server({})
+      end
+
+      it "the puppet log level (Puppet[:log_level]) is set from logback" do
+        expect(Puppet[:log_level]).to eq('info')
+      end
+
+      it "the puppet log level (Puppet::Util::Log.level) is set from logback" do
+        expect(Puppet::Util::Log.level).to eq(:info)
+      end
+    end
+  end
+
   context "SSL context" do
     it "is configured with :localcacert and not :cacert" do
       Puppet[:hostcert] = "spec/fixtures/localhost-cert.pem"

--- a/spec/puppet-server-lib/puppet/jvm/config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/config_spec.rb
@@ -1,27 +1,6 @@
 require 'puppet/server/config'
 
 describe Puppet::Server::Config do
-  context "initializing Puppet Server" do
-    context "setting the Puppet log level from logback" do
-      let(:logger) do
-        stub("Logger", isDebugEnabled: false, isInfoEnabled: true, isWarnEnabled: false, isErrorEnabled: false)
-      end
-
-      before :each do
-        Puppet::Server::Logger.expects(:get_logger).returns(logger)
-        Puppet::Server::Config.initialize_puppet_server({})
-      end
-
-      it "the puppet log level (Puppet[:log_level]) is set from logback" do
-        expect(Puppet[:log_level]).to eq('info')
-      end
-
-      it "the puppet log level (Puppet::Util::Log.level) is set from logback" do
-        expect(Puppet::Util::Log.level).to eq(:info)
-      end
-    end
-  end
-
   context "SSL context" do
     it "is configured with :localcacert and not :cacert" do
       Puppet[:hostcert] = "spec/fixtures/localhost-cert.pem"

--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -3,22 +3,7 @@ require 'puppet/server/puppet_config'
 describe 'Puppet::Server::PuppetConfig' do
   context "When puppet has had settings initialized" do
     before :each do
-      mock_puppet_config = {}
-      Puppet::Server::PuppetConfig.initialize_puppet(mock_puppet_config)
-    end
-
-    describe "the puppet log level (Puppet[:log_level])" do
-      subject { Puppet[:log_level] }
-      it 'is set to debug (the highest) so messages make it to logback' do
-        expect(subject).to eq('debug')
-      end
-    end
-
-    describe "the puppet log level (Puppet::Util::Log.level)" do
-      subject { Puppet::Util::Log.level }
-      it 'is set to debug (the highest) so messages make it to logback' do
-        expect(subject).to eq(:debug)
-      end
+      Puppet::Server::PuppetConfig.initialize_puppet({})
     end
 
     describe '(PUP-5482) Puppet[:always_retry_plugins]' do

--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -1,6 +1,27 @@
 require 'puppet/server/puppet_config'
 
 describe 'Puppet::Server::PuppetConfig' do
+  context "initializing Puppet Server" do
+    context "setting the Puppet log level from logback" do
+      let(:logger) do
+        stub("Logger", isDebugEnabled: false, isInfoEnabled: true, isWarnEnabled: false, isErrorEnabled: false)
+      end
+
+      before :each do
+        Puppet::Server::Logger.expects(:get_logger).returns(logger)
+        Puppet::Server::PuppetConfig.initialize_puppet({})
+      end
+
+      it "the puppet log level (Puppet[:log_level]) is set from logback" do
+        expect(Puppet[:log_level]).to eq('info')
+      end
+
+      it "the puppet log level (Puppet::Util::Log.level) is set from logback" do
+        expect(Puppet::Util::Log.level).to eq(:info)
+      end
+    end
+  end
+
   context "When puppet has had settings initialized" do
     before :each do
       Puppet::Server::PuppetConfig.initialize_puppet({})

--- a/src/ruby/puppetserver-lib/puppet/server/logger.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/logger.rb
@@ -27,6 +27,11 @@ end
 class Puppet::Server::Logger
   def self.init_logging
     Puppet::Util::Log.newdestination(:logback)
+  end
+
+  # @note This must be called after Puppet settings are configured; otherwise
+  #   the default log level will overwrite this setting.
+  def self.set_log_level_from_logback
     Puppet[:log_level] = level_from_logback(get_logger)
   end
 

--- a/src/ruby/puppetserver-lib/puppet/server/logger.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/logger.rb
@@ -27,5 +27,25 @@ end
 class Puppet::Server::Logger
   def self.init_logging
     Puppet::Util::Log.newdestination(:logback)
+    Puppet[:log_level] = level_from_logback(get_logger)
+  end
+
+  def self.level_from_logback(logger)
+    case
+    when logger.isDebugEnabled()
+      'debug'
+    when logger.isInfoEnabled()
+      'info'
+    when logger.isWarnEnabled()
+      'warning'
+    when logger.isErrorEnabled()
+      'err'
+    else
+      'notice'
+    end
+  end
+
+  def self.get_logger
+    LoggerFactory.getLogger("puppetserver")
   end
 end

--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -1,4 +1,5 @@
 require 'puppet/server'
+require 'puppet/server/logger'
 
 class Puppet::Server::PuppetConfig
   def self.initialize_puppet(puppet_config)
@@ -20,6 +21,8 @@ class Puppet::Server::PuppetConfig
         end
     )
     Puppet[:trace] = true
+
+    Puppet::Server::Logger.set_log_level_from_logback
 
     # (SERVER-410) Cache features in puppetserver for performance.  Avoiding
     # the cache is intended for agents to reload features mid-catalog-run.

--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -29,9 +29,6 @@ class Puppet::Server::PuppetConfig
       Puppet[:always_retry_plugins] = false
     end
 
-    # Crank Puppet's log level all the way up and just control it via logback.
-    Puppet[:log_level] = "debug"
-
     master_run_mode = Puppet::Util::RunMode[:master]
     app_defaults = Puppet::Settings.app_defaults_for_run_mode(master_run_mode).
         merge({:name => "master",


### PR DESCRIPTION
In the early days of Puppetserver, the Puppet log level was maxed out in
order to pass all filtering control to logback. This approach didn't
take into account the potential cost of generating log messages and in
the real world can have performance implications.

This pull request resolves this problem by using the logback
puppetserver log level to set the Puppet log level. Because there is not
a 1:1 mapping of logback levels to Puppet levels the notice log level
cannot be set; if notice level information is needed then the info level
must be set.

When Puppetserver is booting, it first configures the Ruby/JVM bindings
which includes tying logback in as a log destination, and then
configures Puppet. Because Puppet itself is configured after
Puppetserver it's possible for the default Puppet log level to overwrite
the logback derived log level. This commit defers the log level
configuration until Puppet has been initialized to ensure that the
logback determined level takes precedence.