### PR TITLE
(PUP-8249) Remove gettext-setup and update fast_gettext

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -3,5 +3,4 @@ hocon 1.2.5
 text 1.3.1
 locale 2.1.2
 gettext 3.2.2
-gettext-setup 0.28
-fast_gettext 1.1.0
+fast_gettext 1.1.1


### PR DESCRIPTION
This commit updates the fast_gettext version to 1.1.1, which contains a
file encoding bug fix. It also removes gettext-setup, which has ceased
to be a puppet runtime dependency.