### PR TITLE
(PUP-8141) Set digest_algorithm to md5 in puppet_config.rb

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -42,6 +42,14 @@ class Puppet::Server::PuppetConfig
                :facts_terminus => 'yaml'})
     Puppet.settings.initialize_app_defaults(app_defaults)
 
+    ################################################
+    ### BEGIN HACKY HACK WORKAROUND FOR PUP-8356 ###
+    ################################################
+    # digest_algorithm and supported_checksum_types must be overridden here until
+    # https://tickets.puppetlabs.com/browse/PUP-8356 is resolved and the puppet
+    # submodule is updated to include it. at that point these calls can be safely
+    # removed.
+    #
     # (PUP-8141) Without these settings, puppetserver will call out to facter,
     # which will in turn load all facts, which will in turn fail horribly on
     # osx looking for cfpropertylist, which won't exist. This is only true
@@ -53,6 +61,10 @@ class Puppet::Server::PuppetConfig
     if unset(:supported_checksum_types)
       Puppet[:supported_checksum_types] = ['md5', 'sha256', 'sha384', 'sha512', 'sha224']
     end
+
+    ################################################
+    #### END HACKY HACK WORKAROUND FOR PUP-8356 ####
+    ################################################
 
     Puppet.info("Puppet settings initialized; run mode: #{Puppet.run_mode.name}")
 


### PR DESCRIPTION
In puppet, in order to better support fips, the digest_algorithm
defaults to the value of a fips fact. This fact does not exist in ruby
facter, which puppetserver uses for unit/integration tests. When the
fact doesn't exist, facter is run to populate all facts. This fails on
osx, which requires the cfpropertylist gem, which won't be present. In
order to avoid this problem, this commit explicitly sets the
digest_algorithm during startup to avoid requiring the fact at all.