### PR TITLE
(SERVER-1954) Roll bidi back to 1.23.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,6 +47,7 @@
                  [org.yaml/snakeyaml]
                  [commons-lang]
                  [commons-io]
+                 [bidi "1.23.1"]
 
                  [clj-time]
                  [prismatic/schema]
@@ -71,18 +72,22 @@
                  ;; asm dependencies.  Deferring to clj-parent to resolve the version.
                  [org.ow2.asm/asm-all]
 
+                 ;; These are required due to the bidi version specified above, which
+                 ;; differs from the version in clj-parent. If we move back to the
+                 ;; version in clj-parent, the exclusions can safely be removed.
+                 [puppetlabs/trapperkeeper-comidi-metrics nil :exclusions [bidi]]
+                 [puppetlabs/trapperkeeper-status nil :exclusions [bidi]]
+                 [puppetlabs/trapperkeeper-metrics nil :exclusions [bidi]]
+                 [puppetlabs/comidi nil :exclusions [bidi]]
+
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
-                 [puppetlabs/trapperkeeper-comidi-metrics]
-                 [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-scheduler]
-                 [puppetlabs/trapperkeeper-status]
                  [puppetlabs/kitchensink]
                  [puppetlabs/ssl-utils]
                  [puppetlabs/ring-middleware]
                  [puppetlabs/dujour-version-check]
                  [puppetlabs/http-client]
-                 [puppetlabs/comidi]
                  [puppetlabs/i18n]
 
                  ;; dependencies for clojurescript dashboard
@@ -146,7 +151,7 @@
                                    [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 nil :classifier "test"]
                                    [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
-                                   [puppetlabs/trapperkeeper-metrics :classifier "test" :scope "test"]
+                                   [puppetlabs/trapperkeeper-metrics :classifier "test" :scope "test" :exclusions [bidi]]
                                    [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
                                    [ring-basic-authentication]
                                    [ring-mock]

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -667,3 +667,13 @@
                       metric-name)))))
          (finally
            (jruby-testutils/return-instance jruby-service jruby-instance :http-report-processor-metrics-test)))))))
+
+(deftest encoded-spaces-test
+  (testing "Encoded spaces should be routed correctly"
+    (bootstrap-testutils/with-puppetserver-running
+     _
+     {:jruby-puppet {:max-active-instances 1
+                     :master-conf-dir master-service-test-runtime-dir}}
+     ;; SERVER-1954 - In bidi 1.25.0 and later, %20 in a URL would cause a 500 to be raised here instead
+     (let [resp (http-get "/puppet/v3/enviro%20nment")]
+       (is (= 404 (:status resp)))))))


### PR DESCRIPTION
Starting in bidi 1.25.0, paths that contain invalid URI characters throw
an exception. Unfortunately, puppetserver uses tk-jetty9 and explicitly
tells tk-jetty9 to normalize URIs before handing them to the routing
layer. This means paths with encoded spaces are passed to bidi decoded,
and then have an exception raised, which in turn causes puppetserver to
return a 500. As this is undesireable behavior, this commit rolls the
bidi version in use to 1.23.1, which still allows decoded strings.