### PR TITLE
(SERVER-1954) Update comidi to 0.3.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
                  [org.yaml/snakeyaml]
                  [commons-lang]
                  [commons-io]
-                 [bidi "1.23.1"]
+                 [bidi "2.1.3"]
 
                  [clj-time]
                  [prismatic/schema]
@@ -88,6 +88,7 @@
                  [puppetlabs/ring-middleware]
                  [puppetlabs/dujour-version-check]
                  [puppetlabs/http-client]
+                 [puppetlabs/comidi "0.3.2"]
                  [puppetlabs/i18n]
 
                  ;; dependencies for clojurescript dashboard


### PR DESCRIPTION
This commit updates comidi to a version that is compatible with bidi
2.1.3, in which the bug with parsing URIs with spaces has been fixed.
This allows us to roll our bidi version forward to a working version,
instead of pinning back.