### PR TITLE
(SERVER-1954) Update clj-parent with new bidi

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.6.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.6.2"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit updates clj-parent to 1.6.1, which contains bidi 2.1.3. This
update fixes a bug with parsing URIs with spaces.