### PR TITLE
(SERVER-2076) Update clj-parent to 1.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.4.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit updates clj-parent to 1.7.0, which contains a version of
jackson-databind with a fix for CVE-2017-15095.