### PR TITLE
(SERVER-1954) Bump jruby-utils to 0.12.0

### DIFF
--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -78,6 +78,10 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
     * `compile-mode`: Optional, experimental. Used to control JRuby's "CompileMode", which may improve performance. The default value is `off`, which is the most conservative value. A value of `jit` enables JRuby's "just-in-time" compilation of Ruby code. A value of `force` causes JRuby to attempt to pre-compile all Ruby code.
 
+    * `profiling-mode`: Optional. Used to enable JRuby's profiler and set it to one of the supported modes. The default value is `off`, but it can be set to one of `api`, `flat`, `graph`, `html`, `json`, `off`, and `service`. See [ruby-prof](https://github.com/ruby-prof/ruby-prof/blob/master/README.rdoc#reports) for details on what the various modes do.
+
+    * `profiling-output-file`: Optional. Used to set the output file to direct JRuby profiler output. Should be a fully qualified path writable by the service user. If not set will default to a random name inside the service working directory.
+
 * The `profiler` settings configure profiling:
 
     * `enabled`: If this is set to `true`, Puppet Server enables profiling for the Puppet Ruby code. The default is `true`.

--- a/project.clj
+++ b/project.clj
@@ -65,7 +65,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "0.10.0"]
+                 [puppetlabs/jruby-utils "0.12.0"]
                  [puppetlabs/jruby-deps ~jruby-1_7-version]
 
                  ;; JRuby 1.7.x and trapperkeeper (via core.async) both bring in

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -45,10 +45,12 @@
             service-config (get-config service)]
 
         (is (= (-> (:jruby-puppet service-config)
-                   (dissoc :master-conf-dir))
+                   (dissoc :master-conf-dir)
+                   (dissoc :profiler-output-file))
                (-> (:jruby-puppet (jruby-testutils/jruby-puppet-tk-config
                                     (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))
-                   (dissoc :master-conf-dir))))
+                   (dissoc :master-conf-dir)
+                   (dissoc :profiler-output-file))))
         (is (= (:webserver service-config) {:port 8081}))
         (is (= (:my-config service-config) {:foo "bar"}))
         (is (= (set (keys (:puppetserver service-config)))


### PR DESCRIPTION
This commit updates jruby-utils to 0.12.0, which changes the encoding
settings for the JRuby scripting containers to be UTF-8 by default,
instead of US-ASCII. This avoids a corner-case bug when interpolating
translated strings containing Unicode characters.