### PR TITLE
(SERVER-2066) Add hiera-eyaml gem to list of installed gems

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -5,3 +5,4 @@ locale 2.1.2
 gettext 3.2.2
 gettext-setup 0.28
 fast_gettext 1.1.0
+hiera-eyaml 2.1.0


### PR DESCRIPTION
This commits adds the hiera-eyaml gem to the list of gems that get
installed with puppetserver. This makes it easier for users to take
advantage of the eyaml encrypted backend for hiera.