### PR TITLE
(PE-23484) Update PDB smoke test to work with existing installs

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -4,7 +4,7 @@ skip_test unless matching_puppetdb_platform.length > 0
 
 
 test_name 'PuppetDB setup'
-sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
+sitepp = '/tmp/configure_puppetdb.pp'
 
 teardown do
   on(master, "rm -f #{sitepp}")
@@ -37,7 +37,5 @@ node default {
 SITEPP
 
   on(master, "chmod 644 #{sitepp}")
-  with_puppet_running_on(master, {}) do
-    on(master, puppet_agent("--test --server #{master}"), :acceptable_exit_codes => [0,2])
-  end
+  on master, puppet_apply(sitepp), :acceptable_exit_codes =>[0,2]
 end

--- a/acceptance/suites/tests/00_smoke/master_starts_if_agent_run_before_ssl_files_inited.rb
+++ b/acceptance/suites/tests/00_smoke/master_starts_if_agent_run_before_ssl_files_inited.rb
@@ -24,7 +24,9 @@ teardown do
   end
 
   # Re-enable PuppetDB facts terminus
-  on(master, puppet("config set route_file /etc/puppetlabs/puppet/routes.yaml"))
+  on(master, puppet("config set --section master route_file /etc/puppetlabs/puppet/routes.yaml"))
+  on(master, puppet("config set --section master reports puppetdb"))
+  on(master, puppet("config set --section master storeconfigs true"))
 
   step 'Restore the original server SSL config' do
     on(master, "rm -rf #{ssldir}")
@@ -36,8 +38,10 @@ teardown do
 
 end
 
-step 'Disable facts reporting to PuppetDB while we munge certs' do
-  on(master, puppet("config set route_file /tmp/nonexistant.yaml"))
+step 'Disable reporting to PuppetDB while we munge certs' do
+  on(master, puppet("config set --section master route_file /tmp/nonexistent.yaml"))
+  on(master, puppet("config set --section master reports store"))
+  on(master, puppet("config set --section master storeconfigs false"))
 end
 
 step 'Ensure puppetserver has been stopped before nuking SSL directory' do

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -50,15 +50,6 @@ EOM
 end
 
 with_puppet_running_on(master, {}) do
-  step 'Enable PuppetDB' do
-    apply_manifest_on(master, <<EOM)
-class{'puppetdb::master::config':
-  enable_reports          => true,
-  manage_report_processor => true,
-}
-EOM
-  end
-
   step 'Run agent to generate exported resources' do
     # This test compiles a catalog using a differnt certname so that
     # later runs can test collection.


### PR DESCRIPTION
Previously, our PDB installation was using `with_puppet_running_on` which
caused the updated puppet.conf that PDB configured to not be saved
between runs. The PDB smoke test then re-ran the PDB module installation
code to get the puppet.conf updates. That PDB installation code
conflicts with PE, so there were failures when running that smoke test
in our PE pipelines (ie. it was tightly coupled to the FOSS pre-suite).

This updates the FOSS suite to leave the puppet.conf in place once it is
configured for PDB, removes the code from the smoke test that was
attempting to re-apply the module installation code, and updates a test
that was not correctly accounting for PDB being installed and
configured.