### PR TITLE
(PE-23484) Disable FOSS PuppetDB integration test when running against PE

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -4,7 +4,7 @@ skip_test unless matching_puppetdb_platform.length > 0
 
 
 test_name 'PuppetDB setup'
-sitepp = '/tmp/configure_puppetdb.pp'
+sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
 
 teardown do
   on(master, "rm -f #{sitepp}")
@@ -37,5 +37,7 @@ node default {
 SITEPP
 
   on(master, "chmod 644 #{sitepp}")
-  on master, puppet_apply(sitepp), :acceptable_exit_codes =>[0,2]
+  with_puppet_running_on(master, {}) do
+    on(master, puppet_agent("--test --server #{master}"), :acceptable_exit_codes => [0,2])
+  end
 end

--- a/acceptance/suites/tests/00_smoke/master_starts_if_agent_run_before_ssl_files_inited.rb
+++ b/acceptance/suites/tests/00_smoke/master_starts_if_agent_run_before_ssl_files_inited.rb
@@ -24,9 +24,7 @@ teardown do
   end
 
   # Re-enable PuppetDB facts terminus
-  on(master, puppet("config set --section master route_file /etc/puppetlabs/puppet/routes.yaml"))
-  on(master, puppet("config set --section master reports puppetdb"))
-  on(master, puppet("config set --section master storeconfigs true"))
+  on(master, puppet("config set route_file /etc/puppetlabs/puppet/routes.yaml"))
 
   step 'Restore the original server SSL config' do
     on(master, "rm -rf #{ssldir}")
@@ -38,10 +36,8 @@ teardown do
 
 end
 
-step 'Disable reporting to PuppetDB while we munge certs' do
-  on(master, puppet("config set --section master route_file /tmp/nonexistent.yaml"))
-  on(master, puppet("config set --section master reports store"))
-  on(master, puppet("config set --section master storeconfigs false"))
+step 'Disable facts reporting to PuppetDB while we munge certs' do
+  on(master, puppet("config set route_file /tmp/nonexistant.yaml"))
 end
 
 step 'Ensure puppetserver has been stopped before nuking SSL directory' do

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -19,6 +19,7 @@
 # acceptance/suites/pre_suite/foss/95_install_pdb.rb using the same conditional
 matching_puppetdb_platform = puppetdb_supported_platforms.select { |r| r =~ master.platform }
 skip_test unless matching_puppetdb_platform.length > 0
+skip_test if master.is_pe?
 
 require 'json'
 require 'time'

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -50,6 +50,15 @@ EOM
 end
 
 with_puppet_running_on(master, {}) do
+  step 'Enable PuppetDB' do
+    apply_manifest_on(master, <<EOM)
+class{'puppetdb::master::config':
+  enable_reports          => true,
+  manage_report_processor => true,
+}
+EOM
+  end
+
   step 'Run agent to generate exported resources' do
     # This test compiles a catalog using a differnt certname so that
     # later runs can test collection.


### PR DESCRIPTION
Previously we were installing PuppetDB in the FOSS test presuite and
then configuring it in the PuppetDB integration test. This configuring
caused the PuppetDB integration test to fail when ran in PE. Originally,
the effort to put the PuppetDB installation in the presuite was so that
it could be both installed and configured there and the test suite would
run in a more real world like scenario.

Consequently, we attempted to make the presuite both install and
configure PuppetDB and make the PuppetDB test work regardless of the
install type. After several attempts, it's become apparent that the work
to do would require re-writing a considerable number of tests within the
Puppet project as well.

This patch reverts configuring PuppetDB in the presuite, moving the
configuration of it back to the integration test itself, which is now
configured to skip when run against PE.