### PR TITLE
(CPR-515) Only run config tasks on install, not upgrades

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -20,7 +20,7 @@ ezbake: {
                # has probably the way to do it for now.  There might be a better
                # way to get rid of the hard-coded paths here, but I don't
                # know it.
-               postinst: [
+               postinst-install: [
                  "install --owner={{user}} --group={{user}} -d /opt/puppetlabs/server/data/puppetserver/jruby-gems",
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master vardir  /opt/puppetlabs/server/data/puppetserver",
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master logdir  /var/log/puppetlabs/puppetserver",
@@ -42,7 +42,7 @@ ezbake: {
                   "bash ./ext/build-scripts/install-vendored-gems.sh"
                 ]
                # see redhat comments on why this is terrible
-               postinst: [
+               postinst-install: [
                  "install --owner={{user}} --group={{user}} -d /opt/puppetlabs/server/data/puppetserver/jruby-gems",
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master vardir  /opt/puppetlabs/server/data/puppetserver",
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master logdir  /var/log/puppetlabs/puppetserver",


### PR DESCRIPTION
This depends on https://github.com/puppetlabs/ezbake/pull/472 to enable
setting tasks that run on package install, but not upgrade.

This should address the issue of package upgrades overwriting custom
config values.