### PR TITLE
(maint) Revert "(maint) Add build_tar: FALSE to build_defaults"

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,4 +2,3 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 project: 'puppetserver'
-build_tar: FALSE


### PR DESCRIPTION
This reverts commit 755a06aa627bbf2c9f82bc1698ebdbe4f971891c.
The FOSS_ONLY setting (used for shipping) was not properly retrieving tarballs,
but our ship process was still attempting to sign tarballs, causing the ship to
fail. This setting was added to prevent the attempted signing, but now that we
have fixed the underlying problem, this setting is no longer needed.