### PR TITLE
(maint) Remove bidi pins

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,6 @@
                  [org.yaml/snakeyaml]
                  [commons-lang]
                  [commons-io]
-                 [bidi "2.1.3"]
 
                  [clj-time]
                  [prismatic/schema]
@@ -72,23 +71,18 @@
                  ;; asm dependencies.  Deferring to clj-parent to resolve the version.
                  [org.ow2.asm/asm-all]
 
-                 ;; These are required due to the bidi version specified above, which
-                 ;; differs from the version in clj-parent. If we move back to the
-                 ;; version in clj-parent, the exclusions can safely be removed.
-                 [puppetlabs/trapperkeeper-comidi-metrics nil :exclusions [bidi]]
-                 [puppetlabs/trapperkeeper-status nil :exclusions [bidi]]
-                 [puppetlabs/trapperkeeper-metrics nil :exclusions [bidi]]
-                 [puppetlabs/comidi nil :exclusions [bidi]]
-
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
+                 [puppetlabs/trapperkeeper-comidi-metrics]
+                 [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-scheduler]
+                 [puppetlabs/trapperkeeper-status]
                  [puppetlabs/kitchensink]
                  [puppetlabs/ssl-utils]
                  [puppetlabs/ring-middleware]
                  [puppetlabs/dujour-version-check]
                  [puppetlabs/http-client]
-                 [puppetlabs/comidi "0.3.2"]
+                 [puppetlabs/comidi]
                  [puppetlabs/i18n]
 
                  ;; dependencies for clojurescript dashboard
@@ -152,7 +146,7 @@
                                    [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 nil :classifier "test"]
                                    [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
-                                   [puppetlabs/trapperkeeper-metrics :classifier "test" :scope "test" :exclusions [bidi]]
+                                   [puppetlabs/trapperkeeper-metrics :classifier "test" :scope "test"]
                                    [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
                                    [ring-basic-authentication]
                                    [ring-mock]


### PR DESCRIPTION
Since updating clj-parent to 1.7.0, we no longer need to pin bidi. The
new version of clj-parent brings in the updated dependency.