### PR TITLE
(SERVER-2113) Update version to 5.2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "5.2.0-master-SNAPSHOT")
+(def ps-version "5.2.0")
 (def jruby-1_7-version "1.7.27-1")
 (def jruby-9k-version "9.1.15.0-2")
 


### PR DESCRIPTION
This commit updates puppetserver's version to 5.2.0 in preparation for
release.