### PR TITLE
(SERVER-2118) Update clj-parent to 1.7.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This update brings in an updated version of tk-jetty9 that allows POST
request response bodies to be gzipped. Since catalog requests are made
with POST requests, catalogs will now come back from the server
gzipped.