### PR TITLE
(SERVER-2024) Clean up puppet install in beaker pre-suite

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -21,12 +21,6 @@ module PuppetServerExtensions
                          nil, "Puppet Server Version",
                          "PUPPETSERVER_VERSION", nil, :string)
 
-    puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION",
-                         "1.10.9",
-                         :string) ||
-                         get_puppet_version
-
     # puppet-agent version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppet-agent/
     puppet_build_version = get_option_value(options[:puppet_build_version],
@@ -46,7 +40,6 @@ module PuppetServerExtensions
       :puppetserver_install_type => install_type,
       :puppetserver_install_mode => install_mode,
       :puppetserver_version => puppetserver_version,
-      :puppet_version => puppet_version,
       :puppet_build_version => puppet_build_version,
       :puppetdb_build_version => puppetdb_build_version,
     }
@@ -99,18 +92,6 @@ module PuppetServerExtensions
     end
 
     value
-  end
-
-  def self.get_puppet_version
-    puppet_submodule = "ruby/puppet"
-    puppet_version = `git --work-tree=#{puppet_submodule} --git-dir=#{puppet_submodule}/.git describe | cut -d- -f1`
-    case puppet_version
-    when /(\d\.\d\.\d)\n/
-      return $1
-    else
-      logger.warn("Failed to discern Puppet version using `git describe` on #{puppet_submodule}")
-      return nil
-    end
   end
 
   def puppetserver_initialize_ssl

--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -32,35 +32,20 @@ def install_puppet_from_msi( host, opts )
   on host, "#{ruby} --version"
 end
 
-step "Install MRI Puppet Agents."
+step "Install MRI Puppet Agents." do
   hosts.each do |host|
     platform = host.platform
-
-    puppet_version = test_config[:puppet_version]
 
     if /windows/.match(platform)
       arch = host[:ruby_arch] || 'x86'
       base_url = ENV['MSI_BASE_URL'] || "http://builds.delivery.puppetlabs.net/puppet-agent/#{test_config[:puppet_build_version]}/artifacts/windows"
       filename = ENV['MSI_FILENAME'] || "puppet-agent-#{arch}.msi"
       install_puppet_from_msi(host, :url => "#{base_url}/#{filename}")
-    elsif puppet_version
-      install_package host, 'puppet-agent'
     else
-      puppet_version = test_config[:puppet_version]
-
-      variant, _, _, _ = host['platform'].to_array
-
-      case variant
-      when /^(debian|ubuntu)$/
-        puppet_version += "-1puppetlabs1"
-        install_package host, "puppet-agent=#{puppet_version}"
-      when /^(redhat|el|centos)$/
-        install_package host, 'puppet-agent', puppet_version
-      end
-
+      install_package host, 'puppet-agent'
     end
-
   end
+end
 
 step "Upgrade nss to version that is hopefully compatible with jdk version puppetserver will use." do
   nss_package=nil


### PR DESCRIPTION
The logic around installing puppet-agent on the agent nodes during test
setup had suffered a series of refactors that left some nonsense logic
in place. This commit updates that pre-suite to no longer check the
`puppet_version` variable, which a) referred to puppet itself, not the
agent, and b) was unnecessary for install because the version getting
installed is determined by which dev repo gets installed in a previous
step.

The install logic for Windows correctly uses `puppet_build_version` and
was left unchanged.