### PR TITLE
(maint) Update to latest jruby-utils

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "1.0.0"]
+                 [puppetlabs/jruby-utils "1.1.0"]
                  [puppetlabs/jruby-deps ~jruby-1_7-version]
 
                  ;; JRuby 1.7.x and trapperkeeper (via core.async) both bring in

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -167,7 +167,10 @@
                                     nil)]
 
       (testing "jruby-config default values are used if not provided"
-        (is (= :off (:compile-mode initialized-jruby-config)))
+        ; jruby-utils defaults to jit when running 9k
+        (if jruby-schemas/using-jruby-9k?
+          (is (= :jit (:compile-mode initialized-jruby-config)))
+          (is (= :off (:compile-mode initialized-jruby-config))))
         (is (= jruby-core/default-borrow-timeout (:borrow-timeout initialized-jruby-config)))
         (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:max-active-instances initialized-jruby-config)))
         (is (= 0 (:max-borrows-per-instance initialized-jruby-config))))


### PR DESCRIPTION
The latest jruby-utils release includes a change that will enable jit
compile-mode automatically when using jruby 9k, which is desireable.