### PR TITLE
(maint) Run tests against jruby 9k as well as 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: clojure
 lein: 2.7.1
 dist: trusty
-jdk:
-- openjdk8
-- oraclejdk8
+matrix:
+  include:
+  - env: JRUBY_VERSION=9k
+    jdk: openjdk8
+  - env: JRUBY_VERSION=1.7
+    jdk: oraclejdk8
 script:
-  - "./ext/travisci/test.sh"
+  - ./ext/travisci/test.sh
   - $TRAVIS_BUILD_DIR/ext/travisci/secscan.sh "$TRAVIS_BUILD_DIR/src/clj" "clj"
 sudo: required
 notifications:

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,8 @@ PUPPET_AGENT_BRANCH = ENV['PUPPET_AGENT_BRANCH'] || '5.3.x'
 
 TEST_GEMS_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_gems')
 TEST_BUNDLE_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_bundle')
+# Used for `rake spec` to also run specs against jruby9k
+profile = "with-profile +jruby9k" if ENV["JRUBY_VERSION"] == "9k"
 
 RAKE_ROOT = File.expand_path(File.dirname(__FILE__))
 
@@ -165,7 +167,7 @@ namespace :spec do
       ## Line 2 programmatically runs 'gem install bundler' via the gem command that comes with JRuby
       gem_install_bundler = <<-CMD
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-      lein run -m org.jruby.Main \
+      lein #{profile} run -m org.jruby.Main \
       -e 'load "META-INF/jruby.home/bin/gem"' install -i '#{TEST_GEMS_DIR}' --no-rdoc --no-ri bundler --source '#{GEM_SOURCE}'
       CMD
       sh gem_install_bundler
@@ -181,7 +183,7 @@ namespace :spec do
       PATH='#{TEST_GEMS_DIR}/bin:#{path}' \
       BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-      lein run -m org.jruby.Main \
+      lein #{profile} run -m org.jruby.Main \
         -S bundle install --without extra development --path='#{TEST_BUNDLE_DIR}' --retry=3
       CMD
       sh bundle_install
@@ -201,7 +203,7 @@ task :spec => ["spec:init"] do
   run_rspec_with_jruby = <<-CMD
     BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
     GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-    lein run -m org.jruby.Main \
+    lein #{profile} run -m org.jruby.Main \
       -I'#{PUPPET_LIB}' -I'#{PUPPET_SPEC}' -I'#{FACTER_LIB}' -I'#{PUPPET_SERVER_RUBY_SRC}' \
       ./spec/run_specs.rb
   CMD

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -2,11 +2,17 @@
 
 set -e
 
-export PUPPETSERVER_HEAP_SIZE=5G
+export PUPPETSERVER_HEAP_SIZE=4G
 
 echo "Using heap size: $PUPPETSERVER_HEAP_SIZE"
 echo "Total memory available: $(grep MemTotal /proc/meminfo | awk '{print $2}')"
 
-lein test :all
+if [ "${JRUBY_VERSION}" = "1.7" ]; then
+  echo "Running tests with default JRuby (1.7-based)"
+  lein -U test :all
+elif [ "${JRUBY_VERSION}" = "9k" ]; then
+  echo "Running tests with JRuby 9k"
+  lein -U with-profile +jruby9k test :all
+fi
 
-rake spec
+rake spec JRUBY_VERSION=${JRUBY_VERSION}


### PR DESCRIPTION
Previously we would only run travis and specs against the default jruby.
This is undesirable as we would like to catch test failures against 9k
before merging, so this commit adds a matrix to the travis configuration
to run against both jruby versions. The Rakefile is also updated to
support running specs against jruby9k.