### PR TITLE
(maint) Set environment_timeout to 0 in tasks tests

### DIFF
--- a/dev-resources/puppetlabs/services/master/environment_classes_int_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/environment_classes_int_test/puppet.conf
@@ -2,4 +2,4 @@
 
 certname = localhost
 environmentpath = $confdir/environments
-environment_timeout = unlimited
+environment_timeout = 0

--- a/dev-resources/puppetlabs/services/master/environment_modules_int_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/environment_modules_int_test/puppet.conf
@@ -2,4 +2,4 @@
 
 certname = localhost
 environmentpath = $confdir/environments
-environment_timeout = unlimited
+environment_timeout = 0

--- a/test/integration/puppetlabs/services/jruby/tasks_test.clj
+++ b/test/integration/puppetlabs/services/jruby/tasks_test.clj
@@ -22,7 +22,7 @@
      :master-conf-dir (.getAbsolutePath conf-dir)})))
 
 (def puppet-conf-file-contents
-  "[main]\nenvironment_timeout=unlimited\nbasemodulepath=$codedir/modules\n")
+  "[main]\nenvironment_timeout=0\nbasemodulepath=$codedir/modules\n")
 
 (def ^:dynamic *code-dir* nil)
 (def ^:dynamic *jruby-service* nil)
@@ -93,7 +93,6 @@
 
 (defn create-env
   [env-dir tasks]
-  (testutils/create-env-conf env-dir "")
   (gen-empty-tasks env-dir tasks))
 
 (defn env-dir


### PR DESCRIPTION
Previously environment_timeout was set to unlimited in the tasks tests.
Due to a puppet bug, we still saw new environments as they were created.
Once that bug was fixed, new environments would not be seen with it set
to unlimited because they would not be created until after puppet had
started up. Now we set it to 0 to ensure new environments are seen.