### PR TITLE
(SERVER-2024) Merge 2.x -> 5.1.x, remove puppet_version from options file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -114,19 +114,12 @@ def lookup_passing_puppet_sha(my_jenkins_passing_json)
   end
 end
 
-def git_passing_puppet_version
-   #FIXME: this should be updated when the package yaml file contains the metadata we need
-   #  we have to replace the hyphens with dots because, vanagon
-  `cd #{PUPPET_SUBMODULE_PATH}; git describe`.strip.gsub(/-/,'.')
-end
-
-def replace_puppet_pins(passing_puppetagent_sha, passing_puppet_version)
+def replace_puppet_pins(passing_puppetagent_sha)
   # read beaker options hash from its file
-  puts("replacing puppet sha and version in #{BEAKER_OPTIONS_FILE} " \
-       "with agent sha: #{passing_puppetagent_sha} and puppet version: #{passing_puppet_version}")
+  puts("replacing puppet-agent SHA in #{BEAKER_OPTIONS_FILE} " \
+       "with #{passing_puppetagent_sha}")
   beaker_options_from_file = eval(File.read(BEAKER_OPTIONS_FILE))
-  # add puppet version values
-  beaker_options_from_file[:puppet_version]       = passing_puppet_version
+  # add puppet-agent version value
   beaker_options_from_file[:puppet_build_version] = passing_puppetagent_sha
   File.write(BEAKER_OPTIONS_FILE, beaker_options_from_file.pretty_inspect)
 end
@@ -140,17 +133,17 @@ namespace :puppet_submodule do
       "git checkout #{lookup_passing_puppet_sha(my_jenkins_passing_json)}"
     puts("checking out known passing puppet version in submodule: `#{git_checkout_command}`")
     system(git_checkout_command)
-    # replace puppet version and sha pins in beaker options file
-    replace_puppet_pins(lookup_passing_puppetagent_sha(my_jenkins_passing_json), git_passing_puppet_version)
+    # replace puppet-agent sha pin in beaker options file
+    replace_puppet_pins(lookup_passing_puppetagent_sha(my_jenkins_passing_json))
   end
   desc 'commit and push; CAUTION: WILL commit and push, upstream, local changes to the puppet submodule and acceptance options'
   task :commit_push do
     git_commit_command = "git checkout #{PUPPETSERVER_BRANCH} && git add #{PUPPET_SUBMODULE_PATH} " \
-      "&& git add #{BEAKER_OPTIONS_FILE} && git commit -m '(maint) update puppet submodule version and pins'"
+      "&& git add #{BEAKER_OPTIONS_FILE} && git commit -m '(maint) update puppet submodule version and agent pin'"
     git_push_command = "git checkout #{PUPPETSERVER_BRANCH} && git push origin HEAD:#{PUPPETSERVER_BRANCH}"
-    puts "committing submodule and pins via: `#{git_commit_command}`"
+    puts "committing submodule and agent pin via: `#{git_commit_command}`"
     system(git_commit_command)
-    puts "pushing submodule and pins via: `#{git_push_command}`"
+    puts "pushing submodule and agent pin via: `#{git_push_command}`"
     system(git_push_command)
   end
   desc 'update puppet versions and commit and push; CAUTION: WILL commit and push, upstream, local changes to the puppet submodule and acceptance options'

--- a/acceptance/config/beaker/options.rb
+++ b/acceptance/config/beaker/options.rb
@@ -11,5 +11,4 @@
  "puppetserver-confdir"=>"/etc/puppetlabs/puppetserver/conf.d",
  "puppetserver-config"=>
   "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
- :puppet_version=>"5.3.5.336.g72c8432",
  :puppet_build_version=>"3948804e1b86b739b11895f92eb052e7001ea52e"}

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -23,13 +23,6 @@ module PuppetServerExtensions
                          nil, "Puppet Server Version",
                          "PUPPETSERVER_VERSION", nil, :string)
 
-    # This value now comes from the beaker options file, or PUPPET_VERSION env var
-    #   the beaker options file can have this value updated via the rake task
-    puppet_version = get_option_value(options[:puppet_version],
-                         nil, "Puppet Version", "PUPPET_VERSION",
-                         "5.0.0.131.g88cc135",
-                         :string)
-
     # puppet-agent version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppet-agent/
     # This value now come from the beaker options file, or PUPPET_BUILD_VERSION env var
@@ -51,7 +44,6 @@ module PuppetServerExtensions
       :puppetserver_install_type => install_type,
       :puppetserver_install_mode => install_mode,
       :puppetserver_version => puppetserver_version,
-      :puppet_version => puppet_version,
       :puppet_build_version => puppet_build_version,
       :puppetdb_build_version => puppetdb_build_version,
     }

--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -32,35 +32,20 @@ def install_puppet_from_msi( host, opts )
   on host, "#{ruby} --version"
 end
 
-step "Install MRI Puppet Agents."
+step "Install MRI Puppet Agents." do
   hosts.each do |host|
     platform = host.platform
-
-    puppet_version = test_config[:puppet_version]
 
     if /windows/.match(platform)
       arch = host[:ruby_arch] || 'x86'
       base_url = ENV['MSI_BASE_URL'] || "http://builds.delivery.puppetlabs.net/puppet-agent/#{test_config[:puppet_build_version]}/artifacts/windows"
       filename = ENV['MSI_FILENAME'] || "puppet-agent-#{arch}.msi"
       install_puppet_from_msi(host, :url => "#{base_url}/#{filename}")
-    elsif puppet_version
-      install_package host, 'puppet-agent'
     else
-      puppet_version = test_config[:puppet_version]
-
-      variant, _, _, _ = host['platform'].to_array
-
-      case variant
-      when /^(debian|ubuntu)$/
-        puppet_version += "-1puppetlabs1"
-        install_package host, "puppet-agent=#{puppet_version}"
-      when /^(redhat|el|centos)$/
-        install_package host, 'puppet-agent', puppet_version
-      end
-
+      install_package host, 'puppet-agent'
     end
-
   end
+end
 
 step "Upgrade nss to version that is hopefully compatible with jdk version puppetserver will use." do
   nss_package=nil


### PR DESCRIPTION
This contains both the merge-up of the pre-suite cleanup from 2.x, as well as some additional cleanup to remove the puppet version field from the beaker options file, only present on 5.1.x and above.