### PR TITLE
(RE-10172) Update to ezbake 1.1.13

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -149,7 +149,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.1.11"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.1.13"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]]}


### PR DESCRIPTION
Built successfully at http://builds.delivery.puppetlabs.net/puppetserver/2.8.2.SNAPSHOT.2018.03.09T1116/, locally running through acceptance tests right now