### PR TITLE
(maint) Add Puppet 6 to compatibility tests

### DIFF
--- a/acceptance/suites/puppet3_tests/puppet3_version_test.rb
+++ b/acceptance/suites/puppet3_tests/puppet3_version_test.rb
@@ -10,7 +10,7 @@ end
 
 step "Check that Puppet Server has Puppet 4.x or 5.x installed"
 on(master, puppet("--version")) do
-  assert_match(/\A[45]/, stdout, "puppet --version does not start with major version 4.x or 5.x")
+  assert_match(/\A[456]/, stdout, "puppet --version does not start with major version 4.x, 5.x, or 6.x")
 end
 
 step "Check that the agent on the master runs against the master"

--- a/acceptance/suites/puppet4_tests/puppet4_version_test.rb
+++ b/acceptance/suites/puppet4_tests/puppet4_version_test.rb
@@ -10,7 +10,7 @@ end
 
 step "Check that Puppet Server has Puppet 5.x installed"
 on(master, puppet("--version")) do
-  assert_match(/\A5\./, stdout, "puppet --version does not start with major version 5")
+  assert_match(/\A[56]/, stdout, "puppet --version does not start with major version 5.x or 6.x")
 end
 
 step "Check that the agent on the master runs against the master"


### PR DESCRIPTION
This commits add Puppet 6 as an acceptable version to the "modern"
agents in compatibility tests.