### PR TITLE
(SERVER-2098) Remove jrjackson gem

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -5,4 +5,3 @@ locale 2.1.2
 gettext 3.2.2
 fast_gettext 1.1.2
 hiera-eyaml 2.1.0
-jrjackson 0.4.5


### PR DESCRIPTION
We ran into some issues with JrJackson's handling Ruby's BigDecimal
type, that causes numbers in scientific notation to be rendered to JSON
as strings, breaking our schema validation. Until this can be resolved,
we can't use the Jackson backend in Puppet Server, so this commit
removes the wrapper gem. MultiJson will now just select the built-in
JSON gem.