### PR TITLE
(maint) Remove deprecated setting in tests

### DIFF
--- a/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/puppet.conf
+++ b/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/puppet.conf
@@ -3,6 +3,5 @@
 certname = localhost
 environmentpath = $confdir/environments
 environment_timeout = unlimited
-app_management = true
 trusted_oid_mapping_file = ./dev-resources/puppetlabs/general_puppet/general_puppet_int_test/custom_trusted_oid_mapping.yaml
 csr_attributes = ./dev-resources/puppetlabs/general_puppet/general_puppet_int_test/csr_attributes.yaml


### PR DESCRIPTION
In puppet 5 app_management doesn't do anything and this is just
producing useless warnings.