### PR TITLE
Revert "(SERVER-2098) Remove jrjackson gem"

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -5,3 +5,4 @@ locale 2.1.2
 gettext 3.2.2
 fast_gettext 1.1.2
 hiera-eyaml 2.1.0
+jrjackson 0.4.5


### PR DESCRIPTION
This reverts commit c7cb533eb2df9840d3c5d66dd832a5f6f1b5291a, readding
the JrJackson gem now that we are properly configured to not parse
extreme numbers as BigDecimals.