### PR TITLE
(SERVER-2147) Update docs with new 9k instructions

### DIFF
--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -144,8 +144,13 @@ The init configuration file location depends on your operating system.
     ```
     Jun 01 19:58:16 myhost puppetserver[24001]: Unable to find specified JRUBY_JAR:/opt/puppetlabs/server/apps/puppetserver/jruby-wrong.jar
     ```
+2.  Set other configuration options for better performance
 
-2.  Restart the `puppetserver` service.
+    To ensure good performance with JRuby 9k, the following settings should also be updated:
+    * In `puppetserver.conf`, `jruby-puppet.compile-mode` should be set to `jit`. This setting must be switched back when reverting to 1.7.
+    * Add `-XX:ReservedCodeCacheSize=512m` to `JAVA_ARGS`, typically defined in `/etc/sysconfig/puppetserver`. This scales up the JVM's code cache to the size needed by JRuby 9k. This setting also behaves well when using JRuby 1.7, so it is safe to leave this setting on if you are switching back and forth.
+
+3.  Restart the `puppetserver` service.
 
     You must fully restart the service to use the new JRuby version. A service reload or `kill -HUP` reload is not sufficient.
 
@@ -171,7 +176,7 @@ The init configuration file location depends on your operating system.
 
 ### Reverting to the default JRuby, 1.7.x
 
-1.  To return to using JRuby 1.7.x, open the init config file and remove the `JRUBY_JAR` line that had been previously been added to enable the use of JRuby 9k.
+1.  To return to using JRuby 1.7.x, open the init config file and remove the `JRUBY_JAR` line that had been previously been added to enable the use of JRuby 9k. In `puppetserver.conf`, set `jruby-puppet.compile-mode` to `off`.
 
 2.  Restart the `puppetserver` service.
 


### PR DESCRIPTION
This commit adds some additional configuration instructions for those
enabling JRuby 9k. These settings were determined via extensive Gatling
testing to chase down performance degradations when running with 9k.