### PR TITLE
(SERVER-2154) Add Puppet 5 compat tests

### DIFF
--- a/acceptance/suites/pre_suite/puppet5_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet5_compat/70_install_puppet.rb
@@ -1,0 +1,26 @@
+require 'puppetserver/acceptance/compat_utils'
+
+# zypper installs of puppet-agent for SLES will fail if the package can't be
+# validated with the Puppet GPG key.  Beaker doesn't implicitly install the
+# Puppet GPG key so need to install it before trying to install the
+# puppet-agent.
+step "Install Updated Puppet GPG key for Any SLES Agents."
+
+nonmaster_agents.each { |agent|
+  variant = agent['platform'].variant
+  if variant == 'sles'
+    on(agent, 'rpmkeys --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppet')
+  end
+}
+
+step "Install Legacy Puppet Agents."
+
+default_puppet_version = '5.5.0'
+puppet_version = ENV['PUPPET_LEGACY_VERSION']
+if not puppet_version
+  logger.info "PUPPET_LEGACY_VERSION is not set!"
+  logger.info "  using default value of #{default_puppet_version}"
+  puppet_version = default_puppet_version
+end
+
+install_puppet_agent_on(nonmaster_agents, {:puppet_agent_version => puppet_version})

--- a/acceptance/suites/puppet4_tests/puppet4_version_test.rb
+++ b/acceptance/suites/puppet4_tests/puppet4_version_test.rb
@@ -8,9 +8,9 @@ on(legacy_agents, puppet("--version")) do
   assert_match(/\A4\./, stdout, "puppet --version does not start with major version 4.")
 end
 
-step "Check that Puppet Server has Puppet 5.x installed"
+step "Check that Puppet Server has Puppet 6.x installed"
 on(master, puppet("--version")) do
-  assert_match(/\A[56]/, stdout, "puppet --version does not start with major version 5.x or 6.x")
+  assert_match(/\A6/, stdout, "puppet --version does not start with major version 6.x")
 end
 
 step "Check that the agent on the master runs against the master"

--- a/acceptance/suites/puppet5_tests/puppet5_version_test.rb
+++ b/acceptance/suites/puppet5_tests/puppet5_version_test.rb
@@ -3,9 +3,9 @@ test_name "Testing Master/Agent backwards compatibility"
 # Agent running on the master is current, not legacy.
 legacy_agents = agents.reject { |agent| agent == master }
 
-step "Check that legacy agents have Puppet 3.x installed"
+step "Check that legacy agents have Puppet 5.x installed"
 on(legacy_agents, puppet("--version")) do
-  assert(stdout.start_with? "3.", "puppet --version does not start with major version 3.")
+  assert_match(/\A5\./, stdout, "puppet --version does not start with major version 5.")
 end
 
 step "Check that Puppet Server has Puppet 6.x installed"


### PR DESCRIPTION
This commit adds tests for compatability between Puppet 5 agents and a
Puppet 6 master, similar to the existing compat tests for Puppet 3 and
4.