### PR TITLE
(SERVER-2100) Install lein-exec plugin when in CI

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -153,7 +153,8 @@
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]]}
-             :ci {:plugins [[lein-pprint "1.1.1"]]}
+             :ci {:plugins [[lein-pprint "1.1.1"]
+                            [lein-exec "0.3.7"]]}
              :voom {:plugins [[lein-voom "0.1.0-20150115_230705-gd96d771" :exclusions [org.clojure/clojure]]]}}
 
   :test-selectors {:integration :integration


### PR DESCRIPTION
The lein-exec plugin is needed for the updated lein release job. This
commit ensures the plugin gets installed for use in Jenkins.