### PR TITLE
(maint) Use default heap size in travis tests

### DIFF
--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-export PUPPETSERVER_HEAP_SIZE=4G
-
-echo "Using heap size: $PUPPETSERVER_HEAP_SIZE"
 echo "Total memory available: $(grep MemTotal /proc/meminfo | awk '{print $2}')"
 
 lein -U test :all


### PR DESCRIPTION
We are currently causing ENOMEM errors in our travis testing from
running Facter 2.x in our CI with JRuby 9k. We expect switching to using
Facter 3 when they implement java support for the gem to fix this issue.

Lowering the heap size should help with the memory consumption of the
forked processes that facter 2 creates. In local testing lowering the
heap caused negligible test run time differences.