### PR TITLE
(maint) Correct ezbake version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -212,7 +212,7 @@
                                                [puppetlabs/puppetserver ~ps-version :exclusions [puppetlabs/jruby-deps]]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.1.13"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.8.1"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 nil]]}


### PR DESCRIPTION
The wrong version of ezbake got carried up in the last merge-up. This
commit corrects it to 1.8.1.