### PR TITLE
(SERVER-2160) Update jruby-utils to 2.0.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def ps-version "6.0.0-master-SNAPSHOT")
-(def jruby-version "9.1.15.0-2")
+(def jruby-version "9.1.16.0-1")
 
 (defn deploy-info
   [url]
@@ -64,7 +64,7 @@
                  ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "1.1.0"]
+                 [puppetlabs/jruby-utils "2.0.0"]
                  [puppetlabs/jruby-deps ~jruby-version]
 
                  ;; JRuby 1.7.x and trapperkeeper (via core.async) both bring in


### PR DESCRIPTION
This commit updates jruby-utils to 2.0.0, a version that has dropped
JRuby 1.7-specific logic. It also updates the JRuby version to
9.1.16.0-1, in line with our other branches and dependencies.