### PR TITLE
(SERVER-2157) Re-bundle JRuby jar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
 (def ps-version "6.0.0-master-SNAPSHOT")
-(def jruby-version "9.1.16.0-1")
 
 (defn deploy-info
   [url]
@@ -65,7 +64,7 @@
                  [net.logstash.logback/logstash-logback-encoder]
 
                  [puppetlabs/jruby-utils "2.0.0"]
-                 [puppetlabs/jruby-deps ~jruby-version]
+                 [puppetlabs/jruby-deps "9.1.16.0-1"]
 
                  ;; JRuby 1.7.x and trapperkeeper (via core.async) both bring in
                  ;; asm dependencies.  Deferring to clj-parent to resolve the version.
@@ -119,8 +118,7 @@
                        :logrotate-enabled false}
                 :resources {:dir "tmp/ezbake-resources"}
                 :config-dir "ezbake/config"
-                :system-config-dir "ezbake/system-config"
-                :additional-uberjars [[puppetlabs/jruby-deps ~jruby-version]]}
+                :system-config-dir "ezbake/system-config"}
 
   :deploy-repositories [["releases" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-releases__local/")]
                         ["snapshots" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/")]]
@@ -208,7 +206,7 @@
                                                ;; brings in its own version, and older versions of
                                                ;; lein depend on clojure 1.6.
                                                [org.clojure/clojure nil]
-                                               [puppetlabs/puppetserver ~ps-version :exclusions [puppetlabs/jruby-deps]]
+                                               [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
                       :plugins [[puppetlabs/lein-ezbake "1.8.1"]]

--- a/resources/ext/cli_defaults/cli-defaults.sh.erb
+++ b/resources/ext/cli_defaults/cli-defaults.sh.erb
@@ -1,10 +1,7 @@
 INSTALL_DIR="/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>"
 
-JRUBY_JAR="${JRUBY_JAR:-${INSTALL_DIR}/jruby-9k.jar}"
-
-if [ ! -e "$JRUBY_JAR" ]; then
-  echo "Unable to find specified JRUBY_JAR: ${JRUBY_JAR}" 1>&2
-  return 1
+if [ -n "$JRUBY_JAR" ]; then
+  echo "Warning: the JRUBY_JAR setting is no longer needed and will be ignored." 1>&2
 fi
 
-CLASSPATH="${CLASSPATH}:${JRUBY_JAR}:/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/jars/*"
+CLASSPATH="${CLASSPATH}:/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/jars/*"


### PR DESCRIPTION
This commit updates puppetserver's build process to start bundling its
JRuby jar again, now that we are only supporting JRuby 9k. If the
JRUBY_JAR setting is used, either at the command line or in the init
config, a warning will be issued indicating that it is no longer needed.