### PR TITLE
(maint) Use puppet5 repo when downloading agents for compat test

### DIFF
--- a/acceptance/suites/pre_suite/puppet5_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet5_compat/70_install_puppet.rb
@@ -23,4 +23,4 @@ if not puppet_version
   puppet_version = default_puppet_version
 end
 
-install_puppet_agent_on(nonmaster_agents, {:puppet_agent_version => puppet_version})
+install_puppet_agent_on(nonmaster_agents, {:puppet_agent_version => puppet_version, :puppet_collection => 'puppet5'})


### PR DESCRIPTION
Previously we were not specifying the repo to use for downloading puppet
5 agents, so the test failed. This commit adds the puppet_collection
option with the 'puppet5' repo.