### PR TITLE
(maint) Bump to puppet6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -112,8 +112,8 @@
                        :java-args ~(str "-Xms2g -Xmx2g "
                                      "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger")
                        :create-dirs ["/opt/puppetlabs/server/data/puppetserver/jars"]
-                       :repo-target "puppet5"
-                       :nonfinal-repo-target "puppet5-nightly"
+                       :repo-target "puppet6"
+                       :nonfinal-repo-target "puppet6-nightly"
                        :bootstrap-source :services-d
                        :logrotate-enabled false}
                 :resources {:dir "tmp/ezbake-resources"}


### PR DESCRIPTION
This commit changes the final and nonfinal repo targets to the puppet6 stream.
Previously, we had only done that in build_defaults, but it's also needed here.