### PR TITLE
(maint) Only auto-build cljs when building packages

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -136,7 +136,6 @@
                                         :optimizations :none
                                         :pretty-print  true
                                         :main "puppetlabs.puppetserver.dashboard.production"}}}}
-  :hooks [leiningen.cljsbuild]
 
   :profiles {:dev {:source-paths  ["dev"]
                    :dependencies  [[org.clojure/tools.namespace]
@@ -210,6 +209,7 @@
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
                       :plugins [[puppetlabs/lein-ezbake "1.8.1"]]
+                      :hooks [leiningen.cljsbuild]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 nil]]}


### PR DESCRIPTION
Previously we built our cljs assests every time we started up the repl,
which adds an annoying amount of time to developing on Puppet Server's
main application.

This patch moves to only automatically compiling our cljs assests when
building packages. When doing development on the cljs assests the
developer should be able to manually build the assests with `lein
cljsbuild`.