### PR TITLE
(SERVER-2187) Remove the hiera-eyaml gem

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -4,5 +4,4 @@ text 1.3.1
 locale 2.1.2
 gettext 3.2.2
 fast_gettext 1.1.2
-hiera-eyaml 2.1.0
 jrjackson 0.4.5


### PR DESCRIPTION
With PA-1925, hiera-eyaml now ships with the agent package in the
shared gem directory.