### PR TITLE
(PUP-8659) Remove JrJackson

### DIFF
--- a/resources/ext/build-scripts/gem-list.txt
+++ b/resources/ext/build-scripts/gem-list.txt
@@ -5,4 +5,3 @@ locale 2.1.2
 gettext 3.2.2
 fast_gettext 1.1.2
 hiera-eyaml 2.1.0
-jrjackson 0.4.5


### PR DESCRIPTION
JrJackson seems to coerce non-UTF8 strings into UTF8 when generating
JSON, rather than raising and execption like the built in JSON module
does.

Puppet relies on this behavior to correctly downgrade to PSON when
there is binary data in the catalog/facts/report.

This remove JrJackson until we can sort out how to properly serialize
binary data with Jackson.