### PR TITLE
(docs) Revise "and/or" in docs content

### DIFF
--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -59,7 +59,7 @@ update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
     If you're running Puppet under Apache, you'll instead need to disable the puppetmaster vhost and restart the Apache service. The exact method for this depends on what your Puppet master vhost file is called and how you enabled it. For full documentation, see the [Passenger guide][passengerguide].
 
     -   On a Debian system, the command might be something like `sudo a2dissite puppetmaster`.
-    -   On RHEL/CentOS systems, the command might be something like `sudo mv /etc/httpd/conf.d/puppetmaster.conf ~/`. Alternatively, you can delete the file instead of moving it.
+    -   On RHEL or CentOS systems, the command might be something like `sudo mv /etc/httpd/conf.d/puppetmaster.conf ~/`. Alternatively, you can delete the file instead of moving it.
 
     After you've disabled the vhost, restart Apache, which is a service called either `httpd` or `apache2`, depending on your OS.
 
@@ -95,8 +95,8 @@ By default, Puppet Server is configured to use 2GB of RAM. However, if you want 
 
 ### Location
 
-* For RHEL/CentOS, open `/etc/sysconfig/puppetserver`
-* For Debian/Ubuntu, open `/etc/default/puppetserver`
+* For RHEL or CentOS, open `/etc/sysconfig/puppetserver`
+* For Debian or Ubuntu, open `/etc/default/puppetserver`
 
 ### Settings
 

--- a/documentation/puppet_conf_setting_diffs.markdown
+++ b/documentation/puppet_conf_setting_diffs.markdown
@@ -38,7 +38,7 @@ This is true regardless of the configuration of the `ssl-` settings in
 
 ### [`cacrl`](https://puppet.com/docs/puppet/latest/configuration.html#cacrl)
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in
 [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the
 file at `ssl-crl-path` as the CRL for authenticating clients via SSL. If at least
 one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set,
@@ -72,7 +72,7 @@ Puppet Server does not use this setting.
 
 ### [`hostcert`](https://puppet.com/docs/puppet/latest/configuration.html#hostcert)
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in
 [webserver.conf](./configuration.markdown#webserverconf), Puppet Server presents the file at `ssl-cert` to clients as the server certificate via
 SSL.
 
@@ -88,7 +88,7 @@ location of the server host certificate to generate.
 
 ### [`hostcrl`](https://puppet.com/docs/puppet/latest/configuration.html#hostcrl)
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in
 [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the
 file at `ssl-crl-path` as the CRL for authenticating clients via SSL. If at least
 one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set,
@@ -107,7 +107,7 @@ regardless of the `ssl-` settings in webserver.conf.
 
 ### [`hostprivkey`](https://puppet.com/docs/puppet/latest/configuration.html#hostprivkey)
 
-If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, or `ssl-crl-path` in
 [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the file at `ssl-key` as the server private key during SSL transactions.
 
 If at least one of the `ssl-` settings in webserver.conf is set but `ssl-key`


### PR DESCRIPTION
Originally PR #1685 by @kayayarai.

For clarity, revise instances of "and/or" and other similar constructs (such as "RHEL/CentOS") in the documentation to remove the slash.