### PR TITLE
(SERVER-2192) Use environment name string for listing tasks

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -106,7 +106,11 @@ class Puppet::Server::Master
   def getTasks(env)
     environment = @env_loader.get(env)
     unless environment.nil?
-      Puppet::InfoService.tasks_per_environment(environment.name)
+      # Pass the original env string. environment.name is a symbol
+      # while the environment cache is primarily used with strings.
+      # Pass as a string to ensure we re-use a cached environment
+      # if available.
+      Puppet::InfoService.tasks_per_environment(env)
     end
   end
 


### PR DESCRIPTION
When requesting a list of tasks, pass the requested environment as a
string rather than a symbol. The environment cache is primarily used
with string; pass as a string to ensure we re-use a cached environment
if available and avoid registering a cached environment based an a
symbol rather than string name.