### PR TITLE
(SERVER-1975) Time JRuby use per-borrow reason

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
@@ -163,6 +163,9 @@
   If the JRuby instance was borrowed to service a HTTP request, then
   the timer name is generated from the sanitized Comidi :route-id.
 
+  If a Clojure Keyword was used as the JRuby borrow reason, then the
+  timer is generated from the Keyword's name and namespace.
+
   Returns a timer named 'other' if the borrow reason does not match
   one of the above cases."
   [{:keys [hostname metric-registry]} :- JRubyMetrics
@@ -180,6 +183,10 @@
                            ;; problems in downstream services that use regexes
                            ;; to search for or select metrics by name.
                            (str/replace #"-\/.*\/" ""))
+                     (keyword? reason)
+                       (if-let [name-space (namespace reason)]
+                         (str name-space "." (name reason))
+                         (name reason))
                      :else "other")]
     (->> timer-name
          (str "jruby.borrow-timer.")

--- a/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
@@ -29,6 +29,7 @@
             [cemerick.url :as url]
             [puppetlabs.testutils.task-coordinator :as coordinator]
             [puppetlabs.services.jruby.jruby-metrics-core :as jruby-metrics-core]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [schema.core :as schema]
             [cheshire.core :as json])
@@ -842,7 +843,25 @@
         (update-expected-values {:requested-count 10
                                  :borrow-count 10
                                  :return-count 10})
-        (is (= (expected-metrics-values) (current-metrics-values)))))))
+        (is (= (expected-metrics-values) (current-metrics-values))))))
+
+  (with-metrics-test-env test-env default-test-config
+    (let [{:keys [coordinator metrics]} test-env]
+      (testing "borrow times are tracked for each comidi route"
+        (async-request coordinator 1 "/foo/bar/async1" :request-complete)
+        (async-request coordinator 2 "/foo/baz/async2" :request-complete)
+        (coordinator/final-result coordinator 1)
+        (coordinator/final-result coordinator 2)
+
+        (let [timers (jruby-metrics-core/borrow-timers metrics)]
+          (doseq [timer-name ["foo-bar-bar" "foo-baz-baz"]
+                  :let [[_ timer] (some (fn [[k v]]
+                                          (when (str/ends-with? k timer-name) [k v]))
+                                        timers)]]
+            (is (some? timer)
+                (str "Timer exists for borrow reason: " timer-name))
+            (is (= 1 (.getCount timer))
+                (str "Timer has a accumulated a count for borrow reason: " timer-name))))))))
 
 (deftest ^:metrics borrow-timeout-test
   (with-metrics-test-env

--- a/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
@@ -846,7 +846,7 @@
         (is (= (expected-metrics-values) (current-metrics-values))))))
 
   (with-metrics-test-env test-env default-test-config
-    (let [{:keys [coordinator metrics]} test-env]
+    (let [{:keys [coordinator jruby-service metrics]} test-env]
       (testing "borrow times are tracked for each comidi route"
         (async-request coordinator 1 "/foo/bar/async1" :request-complete)
         (async-request coordinator 2 "/foo/baz/async2" :request-complete)
@@ -861,7 +861,25 @@
             (is (some? timer)
                 (str "Timer exists for borrow reason: " timer-name))
             (is (= 1 (.getCount timer))
-                (str "Timer has a accumulated a count for borrow reason: " timer-name))))))))
+                (str "Timer has a accumulated a count for borrow reason: " timer-name)))))
+
+      (testing "borrow times are tracked when keywords are given as a request reason"
+        (let [namespaced-kwd ::bar-reason
+              test-namespace (namespace ::bar-reason)]
+          (jruby-service/with-jruby-puppet jruby-instance jruby-service :foo-reason
+            true)
+          (jruby-service/with-jruby-puppet jruby-instance jruby-service namespaced-kwd
+            true)
+
+          (let [timers (jruby-metrics-core/borrow-timers metrics)]
+            (doseq [timer-name ["foo-reason" (str test-namespace ".bar-reason")]
+                    :let [[_ timer] (some (fn [[k v]]
+                                            (when (str/ends-with? k timer-name) [k v]))
+                                          timers)]]
+              (is (some? timer)
+                  (str "Timer exists for borrow reason: " timer-name))
+              (is (= 1 (.getCount timer))
+                  (str "Timer has a accumulated a count for borrow reason: " timer-name)))))))))
 
 (deftest ^:metrics borrow-timeout-test
   (with-metrics-test-env

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -185,6 +185,14 @@
                                           #(not (hit-routes (:route-id %)))
                                           http-metrics)))))))
 
+         (testing "JRuby borrow times are tracked per-reason"
+           (let [jruby-metrics (get-in status [:jruby-metrics :status :experimental :metrics])]
+             (is (contains? jruby-metrics :borrow-timers))
+             (is (= #{:total :puppet-v3-catalog :puppet-v3-node}
+                    (set (keys (:borrow-timers jruby-metrics)))))
+             (doseq [[k v] (:borrow-timers jruby-metrics)]
+               (is (nil? (schema/check jruby-metrics-core/TimerSummary v))))))
+
          (is (= 1 (get-in status [:puppet-profiler :service_status_version])))
          (is (= "running" (get-in status [:puppet-profiler :state])))
          (is (nil? (schema/check puppet-profiler-core/PuppetProfilerStatusV1


### PR DESCRIPTION
The changeset in this PR enhances the JRuby Metrics Service with the ability to time JRuby use per-borrow reason. Prior to these changes, the service only kept a single global borrow timer. This timer could show when JRuby performance was slowing down, but could not reveal whether the slowdown was coming from a specific use such as catalog requests, report uploads or file serving.