### PR TITLE
(maint) Update puppet-agent min required version to 5.5.0

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -7,7 +7,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["puppet-agent >= 4.99.0"],
+      redhat: { dependencies: ["puppet-agent >= 5.5.0"],
                 build-dependencies: ["%{open_jdk}"],
                 # Install some gems
                 install: [
@@ -35,7 +35,7 @@ ezbake: {
                ]
              }
 
-      debian: { dependencies: ["puppet-agent (>= 4.99.0)"],
+      debian: { dependencies: ["puppet-agent (>= 5.5.0)"],
                 build-dependencies: ["openjdk-8-jre-headless"],
                 # Install some gems
                 install: [


### PR DESCRIPTION
Puppet Server 6 needs to be installed with an agent >= 5.5.0, which
provides the shared gem dir that it relies upon for gems shared between
the agent and the JRuby server.