### PR TITLE
(maint) Fix mocked Ring requests and JRuby metrics error handling

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
@@ -143,7 +143,9 @@
     (assoc-in instance [:reason :request]
               {:uri (:uri request)
                :request-method (:request-method request)
-               :route-id (get-in request [:route-info :route-id])})
+               :route-id (get-in request
+                                 [:route-info :route-id]
+                                 "unknown-http-request")})
     instance))
 
 (schema/defn ^:always-validate requested-instances-info :- [InstanceRequestInfo]

--- a/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
@@ -304,14 +304,19 @@
 (schema/defn jruby-event-callback
   [metrics :- JRubyMetrics
    event :- jruby-schemas/JRubyEvent]
-  (case (:type event)
-    :instance-requested (track-request-instance! metrics event)
-    :instance-borrowed (track-borrow-instance! metrics event)
-    :instance-returned (track-return-instance! metrics event)
-    :lock-requested (track-lock-requested! metrics (:reason event))
-    :lock-acquired (track-lock-acquired! metrics (:reason event))
-    :lock-released (track-lock-released! metrics (:reason event))
-
+  (if-let [[func & args] (case (:type event)
+                           :instance-requested [track-request-instance! metrics event]
+                           :instance-borrowed [track-borrow-instance! metrics event]
+                           :instance-returned [track-return-instance! metrics event]
+                           :lock-requested [track-lock-requested! metrics (:reason event)]
+                           :lock-acquired [track-lock-acquired! metrics (:reason event)]
+                           :lock-released [track-lock-released! metrics (:reason event)]
+                           nil)]
+    (try
+      (apply func args)
+      (catch Exception e
+        (log/error e (trs "Error ocurred while recording metrics for jruby event type: {0}" (:type event)))
+        (throw e)))
     (throw (IllegalStateException. (trs "Unrecognized jruby event type: {0}" (:type event))))))
 
 (schema/defn ^:always-validate v1-status :- status-core/StatusCallbackResponse

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -241,7 +241,7 @@
                      (str test-resources-dir "/localhost-cert.pem"))
                handler-service (tk-app/get-service app :RequestHandlerService)
                request {:uri "/puppet/v3/environments", :params {}, :headers {},
-                        :request-method :GET, :body "", :ssl-client-cert cert, :content-type ""}
+                        :request-method :get, :body "", :ssl-client-cert cert, :content-type ""}
                ping-environment #(->> request (handler-core/wrap-params-for-jruby) (handler/handle-request handler-service))
                ping-before-stop (ping-environment)
                stop-complete? (future (tk-app/stop app))]

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -76,7 +76,7 @@
 
 (deftest if-none-match-test
   (testing "if-none-match returns expected value when"
-    (let [mock-request (ring-mock/request "get" "env_classes")]
+    (let [mock-request (ring-mock/request :get "env_classes")]
       (testing "header present without '--gzip' suffix"
         (is (= "abc123"
                (if-none-match-from-request

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -54,7 +54,7 @@
   [cert]
   (core/as-jruby-request
     (puppetserver-config true)
-    {:request-method :GET
+    {:request-method :get
      :headers {"x-client-cert" cert}}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -157,7 +157,7 @@
         (testing (str "for allow-header-cert-info " allow-header-cert-info)
           (let [req (core/as-jruby-request
                      (puppetserver-config allow-header-cert-info)
-                     {:request-method :GET
+                     {:request-method :get
                       :authorization {:name "authorization-client"
                                       :authenticated true
                                       :certificate cert-from-authorization}
@@ -189,7 +189,7 @@
       (testing "providing headers but not the puppet server config won't work."
         (let [req (core/as-jruby-request
                    (puppetserver-config false)
-                   {:request-method :GET
+                   {:request-method :get
                     :headers        {"x-client-verify" "SUCCESS"
                                      "x-client-dn"     "CN=puppet"
                                      "x-client-cert"   single-cert-url-encoded}})]
@@ -200,7 +200,7 @@
       (testing "providing headers and allow-header-cert-info to true works"
         (let [req (core/as-jruby-request
                    (puppetserver-config true)
-                   {:request-method :GET
+                   {:request-method :get
                     :headers        {"x-client-verify" "SUCCESS"
                                      "x-client-dn"     "CN=puppet"
                                      "x-client-cert"   single-cert-url-encoded}})]
@@ -213,7 +213,7 @@
       (testing "a malformed DN string fails"
         (let [req (core/as-jruby-request
                    (puppetserver-config true)
-                   {:request-method :GET
+                   {:request-method :get
                     :headers        {"x-client-verify" "SUCCESS"
                                      "x-client-dn"     "invalid-dn"}})]
           (is (not (get req :authenticated)))
@@ -223,7 +223,7 @@
       (testing "Setting the auth header to something other than 'SUCCESS' fails"
         (let [req (core/as-jruby-request
                    (puppetserver-config true)
-                   {:request-method :GET
+                   {:request-method :get
                     :headers        {"x-client-verify" "fail"
                                      "x-client-dn"     "CN=puppet"}})]
           (is (not (get req :authenticated)))
@@ -235,7 +235,7 @@
                      (str test-resources-dir "/localhost.pem"))
               req (core/as-jruby-request
                    (puppetserver-config true)
-                   {:request-method  :GET
+                   {:request-method  :get
                     :ssl-client-cert cert
                     :headers         {"x-client-verify" "SUCCESS"
                                       "x-client-dn"     "CN=puppet"
@@ -251,7 +251,7 @@
                      (str test-resources-dir "/localhost.pem"))
               req (core/as-jruby-request
                    (puppetserver-config false)
-                   {:request-method  :GET
+                   {:request-method  :get
                     :ssl-client-cert cert
                     :headers         {"x-client-verify" "SUCCESS"
                                       "x-client-dn"     "CN=puppet"


### PR DESCRIPTION
The Travis tests for PR #1689 were timing out. Turned out that the cause was validation failing on mocked Ring requests that had previously never been exposed to the schemas in `puppetlabs.services.jruby.jruby-metrics-core`. This PR corrects three issues:

  - The callback function registered by `puppetlabs.services.jruby.jruby-metrics-core` has no error trap. This caused the exceptions thrown by schema to be unlogged which meant that JRuby instances were silently never returned to the pool --- hence the test suite timeout.

  - Several mocked ring requests were using `:GET` or `"get"` as their HTTP request method. Both Comidi and the Ring specs require lower-cased keywords like `:get`.

  - The schema for `jruby-metrics-core/instance-request-info` expects the HTTP request map to include information from a Comidi route handler. This caused mocks that had not been routed through the MasterService to fail.