### PR TITLE
(CPR-553) Migrate puppetserver docker build scripts to the puppetserver repo

### DIFF
--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,0 +1,13 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+def location_for(place)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [{ :git => $1, :branch => $2, :require => false }]
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
+gem 'puppet_docker_tools', *location_for(ENV['PUPPET_DOCKER_LOCATION'] || '~> 0.1')

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:16.04
+
+ENV PUPPET_SERVER_VERSION="5.3.1" DUMB_INIT_VERSION="1.2.1" UBUNTU_CODENAME="xenial" PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH PUPPET_HEALTHCHECK_ENVIRONMENT="production"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.name="Puppet Server (No PuppetDB)" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version=$PUPPET_SERVER_VERSION \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
+      org.label-schema.build-date="2018-05-09T20:11:01Z" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+RUN apt-get update && \
+    apt-get install -y wget=1.17.1-1ubuntu1 && \
+    wget https://apt.puppetlabs.com/puppet5-release-"$UBUNTU_CODENAME".deb && \
+    wget https://github.com/Yelp/dumb-init/releases/download/v"$DUMB_INIT_VERSION"/dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
+    dpkg -i puppet5-release-"$UBUNTU_CODENAME".deb && \
+    dpkg -i dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
+    rm puppet5-release-"$UBUNTU_CODENAME".deb dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
+    apt-get update && \
+    apt-get install --no-install-recommends git -y puppetserver="$PUPPET_SERVER_VERSION"-1"$UBUNTU_CODENAME" && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    gem install --no-rdoc --no-ri r10k
+
+COPY puppetserver /etc/default/puppetserver
+COPY logback.xml /etc/puppetlabs/puppetserver/
+COPY request-logging.xml /etc/puppetlabs/puppetserver/
+
+RUN puppet config set autosign true --section master
+
+COPY docker-entrypoint.sh /
+
+EXPOSE 8140
+
+ENTRYPOINT ["dumb-init", "/docker-entrypoint.sh"]
+CMD ["foreground" ]
+
+HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD \
+  curl --fail -H 'Accept: pson' \
+  --resolve 'puppet:8140:127.0.0.1' \
+  --cert   $(puppet config print hostcert) \
+  --key    $(puppet config print hostprivkey) \
+  --cacert $(puppet config print localcacert) \
+  https://puppet:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
+  |  grep -q '"is_alive":true' \
+  || exit 1
+
+COPY Dockerfile /

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -1,6 +1,11 @@
 FROM ubuntu:16.04
 
-ENV PUPPET_SERVER_VERSION="5.3.1" DUMB_INIT_VERSION="1.2.1" UBUNTU_CODENAME="xenial" PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH PUPPET_HEALTHCHECK_ENVIRONMENT="production"
+ENV PUPPET_SERVER_VERSION="5.3.1"
+ENV DUMB_INIT_VERSION="1.2.1"
+ENV UBUNTU_CODENAME="xenial"
+ENV PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m"
+ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+ENV PUPPET_HEALTHCHECK_ENVIRONMENT="production"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -9,11 +9,11 @@ ENV PUPPET_HEALTHCHECK_ENVIRONMENT="production"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
-      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.url="https://github.com/puppetlabs/puppetserver" \
       org.label-schema.name="Puppet Server (No PuppetDB)" \
       org.label-schema.license="Apache-2.0" \
       org.label-schema.version=$PUPPET_SERVER_VERSION \
-      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver" \
       org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
       org.label-schema.build-date="2018-05-09T20:11:01Z" \
       org.label-schema.schema-version="1.0" \

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG vcs_ref
+ARG build_date
 ENV PUPPET_SERVER_VERSION="5.3.1"
 ENV DUMB_INIT_VERSION="1.2.1"
 ENV UBUNTU_CODENAME="xenial"
@@ -14,8 +16,8 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.license="Apache-2.0" \
       org.label-schema.version=$PUPPET_SERVER_VERSION \
       org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver" \
-      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
-      org.label-schema.build-date="2018-05-09T20:11:01Z" \
+      org.label-schema.vcs-ref=$vcs_ref \
+      org.label-schema.build-date=$build_date \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 

--- a/docker/puppetserver-standalone/docker-entrypoint.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+chown -R puppet:puppet /etc/puppetlabs/puppet/ssl
+chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver/
+
+if test -n "${PUPPETDB_SERVER_URLS}" ; then
+  sed -i "s@^server_urls.*@server_urls = ${PUPPETDB_SERVER_URLS}@" /etc/puppetlabs/puppet/puppetdb.conf
+fi
+
+exec /opt/puppetlabs/bin/puppetserver "$@"

--- a/docker/puppetserver-standalone/docker-entrypoint.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # Configure puppet to use a certificate autosign script (if it exists)
 # AUTOSIGN=true|false|path_to_autosign.conf
-if [[ -n "${AUTOSIGN}" ]]; then
+if test -n "${AUTOSIGN}" ; then
   puppet config set autosign "$AUTOSIGN" --section master
 fi
 

--- a/docker/puppetserver-standalone/docker-entrypoint.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.sh
@@ -7,4 +7,10 @@ if test -n "${PUPPETDB_SERVER_URLS}" ; then
   sed -i "s@^server_urls.*@server_urls = ${PUPPETDB_SERVER_URLS}@" /etc/puppetlabs/puppet/puppetdb.conf
 fi
 
+# Configure puppet to use a certificate autosign script (if it exists)
+# AUTOSIGN=true|false|path_to_autosign.conf
+if [[ -n "${AUTOSIGN}" ]]; then
+  puppet config set autosign "$AUTOSIGN" --section master
+fi
+
 exec /opt/puppetlabs/bin/puppetserver "$@"

--- a/docker/puppetserver-standalone/logback.xml
+++ b/docker/puppetserver-standalone/logback.xml
@@ -1,0 +1,14 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="com.puppetlabs.puppetserver.LoggingPuppetProfiler" level="INFO"/>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/docker/puppetserver-standalone/puppetserver
+++ b/docker/puppetserver-standalone/puppetserver
@@ -1,0 +1,22 @@
+###########################################
+# Init settings for puppetserver
+###########################################
+
+# Location of your Java binary (version 7 or higher)
+JAVA_BIN="/usr/bin/java"
+
+# Modify this if you'd like to change the memory allocation, enable JMX, etc
+JAVA_ARGS=$PUPPETSERVER_JAVA_ARGS
+
+# These normally shouldn't need to be edited if using OS packages
+USER="puppet"
+GROUP="puppet"
+INSTALL_DIR="/opt/puppetlabs/server/apps/puppetserver"
+CONFIG="/etc/puppetlabs/puppetserver/conf.d"
+BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetserver/services.d/,/opt/puppetlabs/server/apps/puppetserver/config/services.d/"
+SERVICE_STOP_RETRIES=60
+
+# START_TIMEOUT can be set here to alter the default startup timeout in
+# seconds.  This is used in System-V style init scripts only, and will have no
+# effect in systemd.
+# START_TIMEOUT=120

--- a/docker/puppetserver-standalone/puppetserver
+++ b/docker/puppetserver-standalone/puppetserver
@@ -15,8 +15,3 @@ INSTALL_DIR="/opt/puppetlabs/server/apps/puppetserver"
 CONFIG="/etc/puppetlabs/puppetserver/conf.d"
 BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetserver/services.d/,/opt/puppetlabs/server/apps/puppetserver/config/services.d/"
 SERVICE_STOP_RETRIES=60
-
-# START_TIMEOUT can be set here to alter the default startup timeout in
-# seconds.  This is used in System-V style init scripts only, and will have no
-# effect in systemd.
-# START_TIMEOUT=120

--- a/docker/puppetserver-standalone/request-logging.xml
+++ b/docker/puppetserver-standalone/request-logging.xml
@@ -1,0 +1,9 @@
+<configuration debug="false" scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%h %l %u %user %date "%r" %s %b %h %a %localPort %D</pattern>
+        </encoder>
+    </appender>
+
+    <appender-ref ref="STDOUT"/>
+</configuration>

--- a/docker/puppetserver-standalone/spec/dockerfile_spec.rb
+++ b/docker/puppetserver-standalone/spec/dockerfile_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'puppet_docker_tools/spec_helper'
 
 CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 

--- a/docker/puppetserver-standalone/spec/dockerfile_spec.rb
+++ b/docker/puppetserver-standalone/spec/dockerfile_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
+
+describe 'Dockerfile' do
+  include_context 'with a docker image'
+
+  it 'uses the correct version of Ubuntu' do
+    os_version = command('cat /etc/lsb-release').stdout
+    expect(os_version).to include('16.04')
+    expect(os_version).to include('Ubuntu')
+  end
+
+  describe package('puppetserver') do
+    it { is_expected.to be_installed }
+  end
+
+  describe user('puppet') do
+    it { should exist }
+  end
+
+  describe file('/opt/puppetlabs/bin/puppetserver') do
+    it { should exist }
+    it { should be_executable }
+  end
+
+  describe 'Dockerfile#config' do
+    it 'should expose the puppetserver port' do
+      expect(@image.json['ContainerConfig']['ExposedPorts']).to include('8140/tcp')
+    end
+  end
+
+  describe 'Dockerfile#running' do
+    include_context 'with a docker container'
+
+    describe process('dumb-init') do
+      its(:user) { should eq 'root' }
+      its(:pid) { should eq 1 }
+      its(:args) { should match(/foreground/) }
+      it { should be_running }
+    end
+
+    describe process('java') do
+      its(:user) { should eq 'puppet' }
+      it { should be_running }
+    end
+
+    describe command('/opt/puppetlabs/bin/puppetserver --help') do
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command('r10k --help') do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+end

--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -1,5 +1,7 @@
 FROM puppet/puppetserver-standalone:5.3.1
 
+ARG vcs_ref
+ARG build_date
 ENV PUPPETDB_TERMINUS_VERSION="5.2.2"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
@@ -9,8 +11,8 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.license="Apache-2.0" \
       org.label-schema.version=$PUPPET_SERVER_VERSION \
       org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver" \
-      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
-      org.label-schema.build-date="2018-05-09T20:11:06Z" \
+      org.label-schema.vcs-ref=$vcs_ref \
+      org.label-schema.build-date=$build_date \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 

--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -1,0 +1,28 @@
+FROM puppet/puppetserver-standalone:5.3.1
+
+ENV PUPPETDB_TERMINUS_VERSION="5.2.2"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.name="Puppet Server" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version=$PUPPET_SERVER_VERSION \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
+      org.label-schema.build-date="2018-05-09T20:11:06Z" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y puppetdb-termini="$PUPPETDB_TERMINUS_VERSION"-1xenial && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN puppet config set storeconfigs_backend puppetdb --section main && \
+    puppet config set storeconfigs true --section main && \
+    puppet config set reports puppetdb --section main
+
+COPY puppetdb.conf /etc/puppetlabs/puppet/
+
+COPY Dockerfile /

--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -4,11 +4,11 @@ ENV PUPPETDB_TERMINUS_VERSION="5.2.2"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
-      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.url="https://github.com/puppetlabs/puppetserver" \
       org.label-schema.name="Puppet Server" \
       org.label-schema.license="Apache-2.0" \
       org.label-schema.version=$PUPPET_SERVER_VERSION \
-      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver" \
       org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
       org.label-schema.build-date="2018-05-09T20:11:06Z" \
       org.label-schema.schema-version="1.0" \

--- a/docker/puppetserver/puppetdb.conf
+++ b/docker/puppetserver/puppetdb.conf
@@ -1,0 +1,3 @@
+[main]
+server_urls = https://puppetdb:8081
+soft_write_failure = true

--- a/docker/puppetserver/spec/dockerfile_spec.rb
+++ b/docker/puppetserver/spec/dockerfile_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'puppet_docker_tools/spec_helper'
 
 CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 

--- a/docker/puppetserver/spec/dockerfile_spec.rb
+++ b/docker/puppetserver/spec/dockerfile_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
+
+describe 'Dockerfile' do
+  include_context 'with a docker image'
+
+  it 'uses the correct version of Ubuntu' do
+    os_version = command('cat /etc/lsb-release').stdout
+    expect(os_version).to include('16.04')
+    expect(os_version).to include('Ubuntu')
+  end
+
+  describe package('puppetserver') do
+    it { is_expected.to be_installed }
+  end
+
+  describe user('puppet') do
+    it { should exist }
+  end
+
+  describe file('/opt/puppetlabs/bin/puppetserver') do
+    it { should exist }
+    it { should be_executable }
+  end
+
+  describe 'Dockerfile#config' do
+    it 'should expose the puppetserver port' do
+      expect(@image.json['ContainerConfig']['ExposedPorts']).to include('8140/tcp')
+    end
+  end
+
+  describe 'Dockerfile#running' do
+    include_context 'with a docker container'
+
+    describe process('dumb-init') do
+      its(:user) { should eq 'root' }
+      its(:pid) { should eq 1 }
+      its(:args) { should match(/foreground/) }
+      it { should be_running }
+    end
+
+    describe process('java') do
+      its(:user) { should eq 'puppet' }
+      it { should be_running }
+    end
+
+    describe command('/opt/puppetlabs/bin/puppetserver --help') do
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command('r10k --help') do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+end


### PR DESCRIPTION
These came from https://github.com/puppetlabs/puppet-in-docker