### PR TITLE
(CPR-557) Add script to build puppetserver docker images

### DIFF
--- a/distelli-manifest.yml
+++ b/distelli-manifest.yml
@@ -1,0 +1,4 @@
+release-engineering/puppetserver:
+  Build:
+    - docker login -u "$DISTELLI_DOCKER_USERNAME" -p "$DISTELLI_DOCKER_PW" "$DISTELLI_DOCKER_ENDPOINT"
+    - '(cd docker && /bin/bash -x ./ci/build)'

--- a/docker/ci/build
+++ b/docker/ci/build
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -eux
+
+BUNDLER_PATH=.bundle/gems
+
+: ===
+: === bundle install to get ready
+: ===
+bundle install --path $BUNDLER_PATH
+
+: ===
+: === pull updated base images
+: ===
+bundle exec puppet-docker update-base-images ubuntu:16.04
+
+# Haven't yet figured out how to run a container with a mounted file in pipelines
+# will probably end up adding an image with hadolint preloaded and update the
+# lint commands to optionally use a local installation if I don't hear back that
+# this is possible.
+#: ===
+#: === run linter on the docker files
+#: ===
+#bundle exec puppet-docker lint puppetserver-standalone
+#bundle exec puppet-docker lint puppetserver
+
+: ===
+: === build and test puppetserver-standalone
+: ===
+bundle exec puppet-docker rev-labels puppetserver-standalone
+bundle exec puppet-docker build puppetserver-standalone --repository pcr-internal.puppet.net/release-engineering
+bundle exec puppet-docker spec puppetserver-standalone
+
+: ===
+: === build and test puppetserver
+: ==
+bundle exec puppet-docker rev-labels puppetserver
+bundle exec puppet-docker build puppetserver --repository pcr-internal.puppet.net/release-engineering
+bundle exec puppet-docker spec puppetserver
+
+: ==
+: == push containers
+: ==
+bundle exec puppet-docker push puppetserver-standalone --repository pcr-internal.puppet.net/release-engineering
+bundle exec puppet-docker push puppetserver --repository pcr-internal.puppet.net/release-engineering
+
+: ===
+: === SUCCESS
+: ===

--- a/docker/ci/build
+++ b/docker/ci/build
@@ -4,6 +4,34 @@ set -eux
 
 BUNDLER_PATH=.bundle/gems
 
+function build_and_test_image() {
+  container_name=$1
+
+  # Haven't yet figured out how to run a container with a mounted file in pipelines
+  # will probably end up adding an image with hadolint preloaded and update the
+  # lint commands to optionally use a local installation if I don't hear back that
+  # this is possible.
+  #: ===
+  #: === run linter on the docker files
+  #: ===
+  # bundle exec puppet-docker lint $container_name
+
+  : ===
+  : === build and test $container_name
+  : ===
+  bundle exec puppet-docker rev-labels $container_name
+  bundle exec puppet-docker build $container_name --repository pcr-internal.puppet.net/release-engineering
+  bundle exec puppet-docker spec $container_name
+}
+
+function push_image() {
+  container_name=$1
+  : ===
+  : === push $container_name
+  : ===
+  bundle exec puppet-docker push $container_name --repository pcr-internal.puppet.net/release-engineering
+}
+
 : ===
 : === bundle install to get ready
 : ===
@@ -14,35 +42,21 @@ bundle install --path $BUNDLER_PATH
 : ===
 bundle exec puppet-docker update-base-images ubuntu:16.04
 
-# Haven't yet figured out how to run a container with a mounted file in pipelines
-# will probably end up adding an image with hadolint preloaded and update the
-# lint commands to optionally use a local installation if I don't hear back that
-# this is possible.
-#: ===
-#: === run linter on the docker files
-#: ===
-#bundle exec puppet-docker lint puppetserver-standalone
-#bundle exec puppet-docker lint puppetserver
+container_list=(puppetserver-standalone puppetserver)
 
 : ===
-: === build and test puppetserver-standalone
+: === build and test all the images before we push anything
 : ===
-bundle exec puppet-docker rev-labels puppetserver-standalone
-bundle exec puppet-docker build puppetserver-standalone --repository pcr-internal.puppet.net/release-engineering
-bundle exec puppet-docker spec puppetserver-standalone
+for container in ${container_list[@]}; do
+  build_and_test_image $container
+done
 
 : ===
-: === build and test puppetserver
-: ==
-bundle exec puppet-docker rev-labels puppetserver
-bundle exec puppet-docker build puppetserver --repository pcr-internal.puppet.net/release-engineering
-bundle exec puppet-docker spec puppetserver
-
-: ==
-: == push containers
-: ==
-bundle exec puppet-docker push puppetserver-standalone --repository pcr-internal.puppet.net/release-engineering
-bundle exec puppet-docker push puppetserver --repository pcr-internal.puppet.net/release-engineering
+: === push all the images
+: ===
+for container in ${container_list[@]}; do
+  push_image $container
+done
 
 : ===
 : === SUCCESS

--- a/docker/ci/build
+++ b/docker/ci/build
@@ -7,19 +7,14 @@ BUNDLER_PATH=.bundle/gems
 function build_and_test_image() {
   container_name=$1
 
-  # Haven't yet figured out how to run a container with a mounted file in pipelines
-  # will probably end up adding an image with hadolint preloaded and update the
-  # lint commands to optionally use a local installation if I don't hear back that
-  # this is possible.
-  #: ===
-  #: === run linter on the docker files
-  #: ===
-  # bundle exec puppet-docker lint $container_name
+  : ===
+  : === run linter on the docker files
+  : ===
+   bundle exec puppet-docker local-lint $container_name
 
   : ===
   : === build and test $container_name
   : ===
-  bundle exec puppet-docker rev-labels $container_name
   bundle exec puppet-docker build $container_name --repository pcr-internal.puppet.net/release-engineering
   bundle exec puppet-docker spec $container_name
 }


### PR DESCRIPTION
The scripts allow us to set up a pipeline to build these containers on
pipelines.puppet.com.