### PR TITLE
(maint) Upgrade cljs tools to re-enable building

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,8 @@
       default-heap-size)))
 
 (def figwheel-version "0.3.7")
-(def cljsbuild-version "1.1.5")
+(def cljsbuild-version "1.1.7")
+(def clojurescript-version "1.10.238")
 
 (defproject puppetlabs/puppetserver ps-version
   :description "Puppet Server"
@@ -89,7 +90,7 @@
 
                  ;; dependencies for clojurescript dashboard
                  [puppetlabs/cljs-dashboard-widgets]
-                 [org.clojure/clojurescript]
+                 [org.clojure/clojurescript ~clojurescript-version]
                  [cljs-http "0.1.36"]]
 
   :main puppetlabs.trapperkeeper.main
@@ -165,11 +166,11 @@
                                                                    ;; See SERVER-2216
                                                                    org.clojure/tools.nrepl
                                                                    org.clojure/tools.cli]]
-                                   [cljsbuild ~cljsbuild-version]
 
                                    [figwheel ~figwheel-version :exclusions [org.clojure/clojure]]]
                    ;; dev profile config for clojurescript dev
-                   :plugins [[lein-cljsbuild ~cljsbuild-version]
+                   :plugins [[lein-cljsbuild ~cljsbuild-version
+                              :exclusions [org.clojure/clojurescript]]
                              [lein-figwheel ~figwheel-version
                               :exclusions [org.clojure/clojure
                                            org.clojure/core.cache
@@ -213,10 +214,17 @@
                                                ;; brings in its own version, and older versions of
                                                ;; lein depend on clojure 1.6.
                                                [org.clojure/clojure nil]
+                                               ;; I honestly don't know why we should need this
+                                               ;; But building with ezbake is consistently failing and
+                                               ;; pulling in an old build of clojurescript without it.
+                                               [org.clojure/clojurescript ~clojurescript-version]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.8.1"]]
+                      :plugins [[lein-cljsbuild ~cljsbuild-version
+                                 :exclusions [org.clojure/clojurescript
+                                              org.apache.commons/commons-compress]]
+                                [puppetlabs/lein-ezbake "1.8.1"]]
                       :hooks [leiningen.cljsbuild]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]


### PR DESCRIPTION
Prior to this our cljs building broke because of an incompatibility
between clojurescript and newer versions of clojure.spec.

This upgrades cljsbuild and clojurescript, excludes cljsbuild from
bringing in its version of clojurescript and sets an explicit dependency
in our ezbake profile.