### PR TITLE
(TK-466) Update clj-parent to 1.7.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.6"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
The most relevant change in this update is that a HUP will now be logged
at INFO level rather than DEBUG.