### PR TITLE
(SERVER-2215) Upgrade cljs workflows to use fighweel-sidecar

### DIFF
--- a/dev/dev_tools.clj
+++ b/dev/dev_tools.clj
@@ -29,7 +29,7 @@
             [puppetlabs.metrics.http :as http-metrics]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.puppet-profiler.puppet-profiler-core :as puppet-profiler-core]
-            [leiningen.core.main :as lein])
+            [figwheel-sidecar.repl-api :as ra])
   (:import (java.io File)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -98,9 +98,8 @@
 ;;; CLJS utility functions
 
 (defn start-figwheel []
-  (future
    (print "Starting figwheel.\n")
-   (lein/-main ["figwheel"])))
+   (ra/start-figwheel!))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utilities for interacting with running system

--- a/project.clj
+++ b/project.clj
@@ -89,7 +89,7 @@
                  [puppetlabs/i18n]
 
                  ;; dependencies for clojurescript dashboard
-                 [puppetlabs/cljs-dashboard-widgets]
+                 [puppetlabs/cljs-dashboard-widgets "0.1.1"]
                  [org.clojure/clojurescript ~clojurescript-version]
                  [cljs-http "0.1.36"]]
 
@@ -154,24 +154,12 @@
                                    [beckon]
                                    [com.cemerick/url "0.1.1"]
 
-                                   ;; Including this to avoid a logback version conflict when running
-                                   ;; 'lein figwheel'.
-                                   [ch.qos.logback/logback-classic]
-
                                    ;; dependencies for cljs development
-                                   [leiningen "2.7.1" :exclusions [org.codehaus.plexus/plexus-utils
-                                                                   ;; This exclusion doesn't seem to actually work (see
-                                                                   ;; comment where we explicitly define tools.nrepl's
-                                                                   ;; version above
-                                                                   ;; See SERVER-2216
-                                                                   org.clojure/tools.nrepl
-                                                                   org.clojure/tools.cli]]
-
-                                   [figwheel ~figwheel-version :exclusions [org.clojure/clojure]]]
+                                   [figwheel-sidecar "0.5.4-6" :exclusions [org.clojure/clojure]]]
                    ;; dev profile config for clojurescript dev
                    :plugins [[lein-cljsbuild ~cljsbuild-version
                               :exclusions [org.clojure/clojurescript]]
-                             [lein-figwheel ~figwheel-version
+                             [lein-figwheel "0.5.4-6"
                               :exclusions [org.clojure/clojure
                                            org.clojure/core.cache
                                            commons-io


### PR DESCRIPTION
Currently, we have a dependency on leiningen as a library so that we can run ``lein figwheel`` to access the cljs-dashboard-widgets. This commit uses figwheel-sidecar instead to start the figwheel server without calling the lein task. This allows us to remove dependencies on both leiningen and logback-classic.