### PR TITLE
(SERVER-2232) Fix unit test failure on OSX

### DIFF
--- a/dev-resources/puppetlabs/puppetserver/shell_utils_test/list_env_var_names
+++ b/dev-resources/puppetlabs/puppetserver/shell_utils_test/list_env_var_names
@@ -1,3 +1,7 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env sh
 
-puts ENV.keys
+# -s supresses lines that don't have an equals sign in them (this prevents bar in FOO=foo\nbar from being interpretted as a environment key)
+# -f selects which part of the split line to select
+# -d specifies the delimiter
+printenv | cut -s -f 1 -d "="
+

--- a/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
@@ -87,7 +87,7 @@
 
     (let [env-output (:stdout (sh-utils/execute-command
                                (script-path "list_env_var_names")
-                               {:env {"FOO" "foo"}}))
+                               {:env {"FOO" "foo\nbar"}}))
           env (parse-env-output env-output)
           ;; it seems that the JVM always includes a PWD env var, no
           ;; matter what, and in certain terminals it may also include a few


### PR DESCRIPTION
Prior to this commit, the script used ruby to get the environment keys
to work around a problem discovered during [SERVER-1494](https://github.com/puppetlabs/puppetserver/commit/7275b67cae0c514b31e49f9d6033c11bc5f755da). By switching to
ruby we make unintended calls to CoreFoundations on OSX which adds an
additional environment variables __CF_USER_TEXT_ENCODING causing the
tests to fail only on OSX.

To fix this, this commit reverts the test script to the shell
and uses the cut tool to select the keys.