### PR TITLE
(PE-24670) Add default authorization rule for status service endpoint

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -89,7 +89,7 @@ discussion in this document assumes the content of
 To use one of the pre-defined config files, specify the path to it
 using `beaker`'s `--config` option. For example:
 
-    bundle exec beaker --config acceptance/beaker/jenkins/redhat7-64m-64a.cfg ...
+    bundle exec beaker --config acceptance/config/beaker/jenkins/redhat7-64m-64a.cfg ...
 
 ### Using beaker-hostgenerator
 

--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -135,6 +135,11 @@ with_puppet_running_on(master, {}) do
     assert_allowed
   end
 
+  step 'status service endpoint' do
+    curl_unauthenticated('/status/v1/services')
+    assert_allowed
+  end
+
   step 'static file content endpoint' do
     # We'd actually need to perform a commit and use its code-id in order to
     # get back a 200, but we know that a 400 means we got past authorization

--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -46,6 +46,17 @@ authorization: {
             name: "puppetlabs csr"
         },
         {
+            # Allow unauthenticated access to the status service endpoint
+            match-request: {
+                path: "/status/v1/services"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service"
+        },
+        {
             match-request: {
                 path: "/puppet/v3/environments"
                 type: path

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.6"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.8"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
The status service endpoint previously did not check the puppetserver
auth.conf file.  Now that it does, we will give it a default rule to
allow unauthenticated requests (default behavior).