### PR TITLE
(SERVER-2237) Update ezbake and beaker-hostgenerator for bionic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'jira-ruby', :group => :development
 group :test do
   gem 'rspec'
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.27')
-  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
+  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 0.8")
   gem 'uuidtools'

--- a/project.clj
+++ b/project.clj
@@ -213,7 +213,7 @@
                                                [puppetlabs/puppetserver ~ps-version :exclusions [puppetlabs/jruby-deps]]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.8.1"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.8.5"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 nil]]}


### PR DESCRIPTION
This commit updates EZBake and beaker-hostgenerator in order to enable
building and testing Puppetserver on Ubuntu 18.04 Bionic.