### PR TITLE
(SERVER-2237) Use `python3` when `python` is not available

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -202,6 +202,13 @@ step 'SETUP: Configure the code-id script' do
   reload_server
 end
 
+step 'SETUP: Find Python executable'
+  if on(master, 'which python', :acceptable_exit_codes => [0, 1]).exit_code == 1
+    python_bin = 'python3'
+  else
+    python_bin = 'python'
+  end
+
 step 'Get the current code-id'
   current_code_id=on(master, '/opt/puppetlabs/server/apps/puppetserver/code-id-command_script.sh production').stdout.chomp
 
@@ -210,6 +217,6 @@ step 'Pull the catalog, validate that it contains the current code-id'
   key       ="/etc/puppetlabs/puppet/ssl/private_keys/#{fqdn}.pem"
   hostcert  ="/etc/puppetlabs/puppet/ssl/certs/#{fqdn}.pem"
   auth_str  ="--cacert #{cacert} --key #{key} --cert #{hostcert}"
-  result=on(master, "curl --silent #{auth_str} https://#{fqdn}:8140/puppet/v3/catalog/#{fqdn}?environment=production | python -m json.tool").stdout
+  result=on(master, "curl --silent #{auth_str} https://#{fqdn}:8140/puppet/v3/catalog/#{fqdn}?environment=production | #{python_bin} -m json.tool").stdout
   catalog=JSON.parse(result)
   assert_match(current_code_id, catalog['code_id'], "FAIL: Expected catalog to contain current_code_id #{current_code_id}.")


### PR DESCRIPTION
Ubuntu 18.04 does not ship with a `python` executable, instead
providing only `python3`. This commit updates our test that uses Python
to check for the `python` executable and use `python3` instead if it
cannot be found.

This is a cherry pick of https://github.com/puppetlabs/puppetserver/commit/b8cf75a12cc678ed90bd387974424c9a29eb66f1.