### PR TITLE
(SERVER-2172) Pull in updated puppetserver-ca cmd

### DIFF
--- a/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
+++ b/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
@@ -80,10 +80,10 @@ test_name 'Intermediate CA setup' do
 
   step 'Import External CA infrastructure and restart Puppet Server' do
     ca_cli = '/opt/puppetlabs/bin/puppetserver'
-    on master, [ca_cli, 'ca', 'import',
-                private_key_path,
-                cert_bundle_path,
-                crl_chain_path].join(' ')
+    on master, [ca_cli, 'ca', 'setup',
+                '--private-key', private_key_path,
+                '--cert-bundle', cert_bundle_path,
+                '--crl-chain', crl_chain_path].join(' ')
 
     on master, "service #{master['puppetservice']} start"
   end

--- a/resources/ext/build-scripts/mri-gem-list.txt
+++ b/resources/ext/build-scripts/mri-gem-list.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 0.0.1-dev1
+puppetserver-ca 0.1.0

--- a/resources/ext/cli/ca.erb
+++ b/resources/ext/cli/ca.erb
@@ -1,30 +1,5 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
-require 'fileutils'
-require 'puppetserver/ca/stub'
+require 'puppetserver/ca/cli'
 
-command = ARGV[0]
-
-unless command == "import"
-  STDERR.puts "  'import' is the only valid subcommand, try:"
-  STDERR.puts "    `puppetserver ca import <key> <bundle> <crl>"
-  exit 1
-end
-
-private_key = ARGV[1]
-cert_bundle = ARGV[2]
-crl_chain   = ARGV[3]
-
-unless private_key && cert_bundle && crl_chain
-  STDERR.puts "The import subcommand requires three arguments: private-key, cert-bundle, crl, in that order."
-  exit 1
-end
-
-ca_dir = '/etc/puppetlabs/puppet/ssl/ca'
-FileUtils.mkdir_p ca_dir
-Puppetserver::Ca::Stub.import(private_key, cert_bundle, crl_chain)
-FileUtils.touch(ca_dir + '/inventory.txt')
-File.open(ca_dir + '/serial', 'w+') {|f| f.puts '003' }
-FileUtils.chown_R 'puppet', 'puppet', ca_dir
-
-STDOUT.puts "Import complete"
+exit Puppetserver::Ca::Cli.run(ARGV)


### PR DESCRIPTION
This pulls in the remaining work for SERVER-2172, [_to be_] released in
puppetserver-ca 0.1.0 and updates the intermediate_ca acceptance test
accordingly.