### PR TITLE
(maint) Improve intermediate ca acceptance test

### DIFF
--- a/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
+++ b/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
@@ -15,8 +15,8 @@ test_name 'Intermediate CA setup' do
         __FILE__))
   end
 
-  ssl_directory    = master.puppet['ssldir']
-  ca_directory     = master.puppet['cadir']
+  ssl_directory    = puppet_config(master, 'ssldir', section: 'master')
+  ca_directory     = puppet_config(master, 'cadir', section: 'master')
   auth_conf        = "/etc/puppetlabs/puppetserver/conf.d/auth.conf"
   test_directory   = master.tmpdir('intermediate_ca_files')
   backup_directory = master.tmpdir('intermediate_ca_backup')
@@ -93,11 +93,13 @@ test_name 'Intermediate CA setup' do
 
 
   # Remove the old CA infrastructure from an agent
-  on test_agent, "rm -rf #{test_agent.puppet['ssldir']}"
+  ssldir = puppet_config(test_agent, 'ssldir', section: 'agent')
+  cert = puppet_config(master, 'hostcert', section: 'master')
+  cacert = puppet_config(master, 'localcacert', section: 'master')
+  key = puppet_config(master, 'hostprivkey', section: 'master')
 
-  ssl_options = "--cert #{master.puppet['hostcert']} " +
-                "--cacert #{master.puppet['localcacert']} " +
-                "--key #{master.puppet['hostprivkey']}"
+  on test_agent, "rm -rf #{ssldir}"
+  ssl_options = "--cert #{cert} --cacert #{cacert} --key #{key}"
 
   # Create a dummy agent
   on test_agent,

--- a/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
+++ b/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
@@ -15,6 +15,8 @@ test_name 'Intermediate CA setup' do
         __FILE__))
   end
 
+  # We set these variables outside of a step block so that we can use it
+  # in multiple steps and the teardown below
   ssl_directory    = puppet_config(master, 'ssldir', section: 'master')
   ca_directory     = puppet_config(master, 'cadir', section: 'master')
   auth_conf        = "/etc/puppetlabs/puppetserver/conf.d/auth.conf"
@@ -26,23 +28,28 @@ test_name 'Intermediate CA setup' do
   crl_chain_path   = test_directory + '/' + 'crl_chain.pem'
 
 
-  step 'Backup current CA infrastructure' do
-    on master, "mkdir -p #{backup_directory}/{ca,ssl}"
+  step 'Stop and backup the CA' do
     on master, "service #{master['puppetservice']} stop"
+
+    on master, "mkdir -p #{backup_directory}/{ca,ssl}"
     on master, "cp -pR #{ca_directory}/* #{backup_directory}/ca"
     on master, "rm -rf #{ca_directory}/*"
     on master, "cp -pR #{ssl_directory}/* #{backup_directory}/ssl"
     on master, "rm -rf #{ssl_directory}/*"
 
-    # Disable communication to services already configured to use older PKI
+    on master, "mv #{auth_conf} #{backup_directory}/"
+  end
+
+  step 'Disable communication to services already configured to use older PKI' do
     on master, puppet('config set --section master route_file /tmp/nonexistent.yaml')
     if master.is_pe?
       on master, puppet('config set --section master report false')
       on master, puppet('config set --section master storeconfigs false')
       on master, puppet('config set --section master node_terminus plain')
     end
-    on master, "mv #{auth_conf} #{backup_directory}/"
+  end
 
+  step 'Put test specific files in place' do
     create_remote_file master, auth_conf, <<-AUTHCONF
     authorization: {
       version: 1
@@ -92,38 +99,45 @@ test_name 'Intermediate CA setup' do
   end
 
 
-  # Remove the old CA infrastructure from an agent
-  ssldir = puppet_config(test_agent, 'ssldir', section: 'agent')
+  step 'Remove the old CA infrastructure from an agent' do
+    ssldir = puppet_config(test_agent, 'ssldir', section: 'agent')
+    on test_agent, "rm -rf #{ssldir}"
+  end
+
+  # We use the master's PKI with curl since it won't change again until after
+  # the test, though all curl calls below need to happen on the master.
   cert = puppet_config(master, 'hostcert', section: 'master')
   cacert = puppet_config(master, 'localcacert', section: 'master')
   key = puppet_config(master, 'hostprivkey', section: 'master')
-
-  on test_agent, "rm -rf #{ssldir}"
   ssl_options = "--cert #{cert} --cacert #{cacert} --key #{key}"
 
-  # Create a dummy agent
-  on test_agent,
-    puppet("agent -t --certname fake_agent_name --server #{master}"),
-    :acceptable_exit_codes => [1]
+  step 'Download the intermediate PKI and submit a test CSR' do
+    on test_agent,
+      puppet("agent -t --certname fake_agent_name --server #{master}"),
+      :acceptable_exit_codes => [1]
+  end
 
-  # Sign the cert
-  on master, "curl -XPUT #{ssl_options} " +
-             %q<-H 'Content-Type: application/json' -d '{"desired_state":"signed"}' > +
-             "--url https://#{master}:8140/puppet-ca/v1/certificate_status/fake_agent_name?environment=production"
-  on test_agent,
-     puppet("agent -t --certname fake_agent_name --server #{master} --noop")
+  step 'Sign the cert and verify the agent runs correctly with its new PKI' do
+    on master, "curl -XPUT #{ssl_options} " +
+               %q<-H 'Content-Type: application/json' -d '{"desired_state":"signed"}' > +
+               "--url https://#{master}:8140/puppet-ca/v1/certificate_status/fake_agent_name?environment=production"
+
+    on test_agent,
+       puppet("agent -t --certname fake_agent_name --server #{master} --noop")
+  end
 
 
-  # Revoke the cert -- We need to be using the master for this!
-  on master, "curl -XPUT #{ssl_options} " +
-             %q<-H 'Content-Type: application/json' -d '{"desired_state":"revoked"}' > +
-             "--url https://#{master}:8140/puppet-ca/v1/certificate_status/fake_agent_name?environment=production"
+  step 'Verify revocation works as expected' do
+    on master, "curl -XPUT #{ssl_options} " +
+               %q<-H 'Content-Type: application/json' -d '{"desired_state":"revoked"}' > +
+               "--url https://#{master}:8140/puppet-ca/v1/certificate_status/fake_agent_name?environment=production"
 
-  on master, "curl -XDELETE -H 'Content-Type: application/json' #{ssl_options} " +
-             "--url https://#{master}:8140/puppet-ca/v1/certificate_status/fake_agent_name?environment=production"
+    on master, "curl -XDELETE -H 'Content-Type: application/json' #{ssl_options} " +
+               "--url https://#{master}:8140/puppet-ca/v1/certificate_status/fake_agent_name?environment=production"
 
-  on test_agent,
-     puppet("agent -t --certname fake_agent_name --server #{master}"),
-     :acceptable_exit_codes => [1]
+    on test_agent,
+       puppet("agent -t --certname fake_agent_name --server #{master}"),
+       :acceptable_exit_codes => [1]
+  end
 
 end

--- a/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
+++ b/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
@@ -5,6 +5,9 @@ require 'puppet_x/acceptance/pki'
 
 test_name 'Intermediate CA setup' do
 
+  test_agent = (agents - [master]).first
+  skip_test 'requires an agent not running on the CA' unless test_agent
+
   def fixture(filename)
     File.read(
       File.expand_path(
@@ -88,7 +91,6 @@ test_name 'Intermediate CA setup' do
     on master, "service #{master['puppetservice']} start"
   end
 
-  test_agent = (agents - [master]).first
 
   # Remove the old CA infrastructure from an agent
   on test_agent, "rm -rf #{test_agent.puppet['ssldir']}"


### PR DESCRIPTION
This skips the test if there's no non-CA agent (we need at least those to hosts to properly test downloading all of the ssl files) and should resolve issues we're seeing in CI where we are running this test with only a single master & agent host.

While investigating `host.puppet['setting']` I remembered that `puppet_config` was added and should be used going forward (works with config sections rather than applications). See https://github.com/puppetlabs/beaker-puppet/commit/f5dcaa031bd7c6a15dc3914328960260238473ed#diff-1ad39dbbbad154ea718af70e36bca745 for details.

Will test locally with a mono install and w/o and report back.