### PR TITLE
(SERVER-2261) Update puppetserver-ca gem to 0.2.0

### DIFF
--- a/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
+++ b/acceptance/suites/tests/certificate_authority/intermediate_ca.rb
@@ -3,7 +3,7 @@
 
 require 'puppet_x/acceptance/pki'
 
-test_name 'Intermediate CA setup' do
+test_name 'Intermediate CA import' do
 
   test_agent = (agents - [master]).first
   skip_test 'requires an agent not running on the CA' unless test_agent
@@ -90,7 +90,7 @@ test_name 'Intermediate CA setup' do
 
   step 'Import External CA infrastructure and restart Puppet Server' do
     ca_cli = '/opt/puppetlabs/bin/puppetserver'
-    on master, [ca_cli, 'ca', 'setup',
+    on master, [ca_cli, 'ca', 'import',
                 '--private-key', private_key_path,
                 '--cert-bundle', cert_bundle_path,
                 '--crl-chain', crl_chain_path].join(' ')

--- a/resources/ext/build-scripts/mri-gem-list.txt
+++ b/resources/ext/build-scripts/mri-gem-list.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 0.1.0
+puppetserver-ca 0.2.0


### PR DESCRIPTION
This version of the gem has changed the `setup` subcommand to `import`. So
this commit also updates the tests to use the new subcommand.