### PR TITLE
(SERVER-2266) Note universe is required on 18.04.

### DIFF
--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -43,7 +43,10 @@ update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 ### Ubuntu
 
+-   Ubuntu 18.04 (Bionic)
 -   Ubuntu 16.04 (Xenial)
+
+On Ubuntu 18.04, enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu), which contains packages necessary for Puppet Server.
 
 ### SUSE Linux Enterprise Server
 


### PR DESCRIPTION
Ubuntu 18.04 needs the universe repository enabled to install `openjdk-8-jre-headless`, which is required by Server. Document this.