### PR TITLE
(SERVER-2213) Upgrade clj-parent to 2.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.0.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.1.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This clj-parent bump updates the version of jetty to 9.4.11.v20180605.