### PR TITLE
(SERVER-1747) Update puppetserver-ca gem to 0.3.0

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list.txt
+++ b/resources/ext/build-scripts/mri-gem-list.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 0.2.0
+puppetserver-ca 0.3.0


### PR DESCRIPTION
This update of the gem contains the CLI tools for replacing `puppet
cert`.