### PR TITLE
(SERVER-2156) add support for multi-platform tasks

### DIFF
--- a/documentation/puppet-api/v3/task_detail.json
+++ b/documentation/puppet-api/v3/task_detail.json
@@ -52,11 +52,11 @@
               }
             },
             "required": ["path", "params"],
-            "additionalProperties": false
+            "additionalProperties": true
           }
         },
         "required": ["metadata", "files", "code_id"],
-        "additionalProperties": false
+        "additionalProperties": true
       }
     }
   }

--- a/documentation/puppet-api/v3/task_detail.markdown
+++ b/documentation/puppet-api/v3/task_detail.markdown
@@ -34,10 +34,11 @@ the Ruby-based Puppet master's authorization methods and configuration. See the
 A task file name has the same restriction as puppet type names and must match
 the regular expression `\A[a-z][a-z0-9_]*\z` (excluding extensions).
 
-### Returns entries for tasks with no executable files
+### Will error if the tasks implementations are invalid
 
-A task will be listed if only metadata for it exists. How many files are
-associated with a task can be found by querying that task's details.
+Since the returning file information requires parsing metadata and finding
+implementation files this endpoint will error if the metadata cannot be parsed
+or the implementation content is invalid.
 
 ### Does read files
 
@@ -104,6 +105,24 @@ Content-Type: application/json
       }
     }
   ]
+}
+```
+
+#### GET request for invalid module
+
+If you request details for a task which cannot be computed because the metadata
+is unreadable or it's implementations are not usable Bolt will return an error
+response with a status code of 500 containing `kind`, `msg`, and `details` keys.
+
+```
+GET /puppet/v3/tasks/modulename/taskname?environment=env
+HTTP/1.1 500 Server Error
+Content-Type: application/json
+
+{
+    "details": {},
+    "kind": "puppet.tasks/unparseable-metadata",
+    "msg": "unexpected token at '{ \"name\": \"init.sh\" , }\n  ]\n}\n'"
 }
 ```
 

--- a/documentation/puppet-api/v3/tasks.json
+++ b/documentation/puppet-api/v3/tasks.json
@@ -28,11 +28,11 @@
             }
           },
           "required": ["name"],
-          "additionalProperties": false
+          "additionalProperties": true
         }
       }
     },
     "required": ["name", "environment"],
-    "additionalProperties": false
+    "additionalProperties": true
   }
 }

--- a/test/integration/puppetlabs/services/master/tasks_int_test.clj
+++ b/test/integration/puppetlabs/services/master/tasks_int_test.clj
@@ -150,7 +150,7 @@
                                  "production" "shell::..."))
 
             (testing "returns 500 when the metadata file is unparseable"
-              (assert-task-error 500 #"invalid-task-metadata"
+              (assert-task-error 500 #"puppet\.tasks/unparseable-metadata"
                                  "production" "mysql::test")))))))
 
   (testing "full stack task metadata smoke test with code management:"


### PR DESCRIPTION
This adds support for multi-platform tasks by including all
"implementations in the "files" response for TaskDetails. In order to
prevent duplicating logic in both puppet-server and ruby this moves
metadata reading and validation out of clj in puppet-server and into
puppet itself.

fix tests