### PR TITLE
(maint) Remove 'master' from the version string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "6.0.0-master-SNAPSHOT")
+(def ps-version "6.0.0-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This was added to help create a 'latest' stream for some perf testing
jobs. We have better ways of tracking 'latest' now, so this commit
removes the extra string, which was confusing version bump automation.