### PR TITLE
(maint) Docker: change how we deal with puppetserver configuration

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -39,7 +39,9 @@ COPY puppetserver /etc/default/puppetserver
 COPY logback.xml /etc/puppetlabs/puppetserver/
 COPY request-logging.xml /etc/puppetlabs/puppetserver/
 
-RUN puppet config set autosign true --section master
+RUN puppet config set autosign true --section master && \
+    cp -pr /etc/puppetlabs/puppet /var/tmp && \
+    rm -rf /var/tmp/puppet/ssl
 
 COPY docker-entrypoint.sh /
 

--- a/docker/puppetserver-standalone/docker-entrypoint.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 
-chown -R puppet:puppet /etc/puppetlabs/puppet/ssl
+chown -R puppet:puppet /etc/puppetlabs/puppet/
 chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver/
+
+# During build, pristine config files get copied to this directory. If
+# they are not in the current container, use these templates as the
+# default
+TEMPLATES=/var/tmp/puppet
+
+cd /etc/puppetlabs/puppet
+for f in auth.conf hiera.yaml puppet.conf puppetdb.conf
+do
+    if ! test -f $f ; then
+        cp -p $TEMPLATES/$f .
+    fi
+done
+cd /
 
 if test -n "${PUPPETDB_SERVER_URLS}" ; then
   sed -i "s@^server_urls.*@server_urls = ${PUPPETDB_SERVER_URLS}@" /etc/puppetlabs/puppet/puppetdb.conf
@@ -16,6 +30,22 @@ fi
 # AUTOSIGN=true|false|path_to_autosign.conf
 if test -n "${AUTOSIGN}" ; then
   puppet config set autosign "$AUTOSIGN" --section master
+fi
+
+# Allow setting the dns_alt_names for the server's certificate. This
+# setting will only have an effect when the container is started without
+# an existing certificate on the /etc/puppetlabs/puppet volume
+if test -n "${DNS_ALT_NAMES}"; then
+    fqdn=$(facter fqdn)
+    if test ! -f "/etc/puppetlabs/puppet/ssl/certs/$fqdn.pem" ; then
+        puppet config set dns_alt_names "${DNS_ALT_NAMES}" --section master
+    else
+        actual=$(puppet config print dns_alt_names --section master)
+        if test "${DNS_ALT_NAMES}" != "${actual}" ; then
+            echo "Warning: DNS_ALT_NAMES has been changed from the value in puppet.conf"
+            echo "         Remove/revoke the old certificate for this to become effective"
+        fi
+    fi
 fi
 
 exec /opt/puppetlabs/bin/puppetserver "$@"

--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -24,8 +24,9 @@ RUN apt-get update && \
 
 RUN puppet config set storeconfigs_backend puppetdb --section main && \
     puppet config set storeconfigs true --section main && \
-    puppet config set reports puppetdb --section main
+    puppet config set reports puppetdb --section main && \
+    cp -p /etc/puppetlabs/puppet/puppet.conf /var/tmp/puppet
 
-COPY puppetdb.conf /etc/puppetlabs/puppet/
+COPY puppetdb.conf /var/tmp/puppet/
 
 COPY Dockerfile /


### PR DESCRIPTION
We now expect all of /etc/puppetlabs/puppet to live on a volume, rather
than just expecting ssl/ to live there.

That way, users can modify puppetserver configuration by editing files on
the volume from outside the container, and have those changes persist
across restarts/recreation of the container.

Since users should be able to start puppetserver with an empty volume, and
have the container populate it with sensible defaults, we also stash the
relevant configuration files in /var/tmp/puppet from where we retrieve them
if the container is started with those files on the volume. The files in
question are auth.conf, hiera.yaml, puppet.conf, and puppetdb.conf.

The only settings that we need to know when starting on an empty volume are
the certname and dns_alt_names for the server's certificate as they are a
pain to change later. The certname gets taken from the container's
hostname, and the dns_alt_names can be passed in with the DNS_ALT_NAMES
environment variable.