### PR TITLE
(maint) Bump CA CLI gem to 0.4.1

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list.txt
+++ b/resources/ext/build-scripts/mri-gem-list.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 0.4.0
+puppetserver-ca 0.4.1


### PR DESCRIPTION
This update adds the ability to specify a certname and a CA name as
flags to generate, both of which are used by the PE installer.