### PR TITLE
Merge 2.6.x -> 2.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -149,7 +149,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.1.13"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.1.15"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty9-version]]}


### PR DESCRIPTION
Conflicts were resolved by taking only the ezbake bump from 2.6.x and otherwise
maintaining the state of the current branch.