### PR TITLE
(SERVER-2302) Allow access to all status endpoints

### DIFF
--- a/documentation/status-api/v1/services.markdown
+++ b/documentation/status-api/v1/services.markdown
@@ -123,15 +123,13 @@ Content-Type: application/json
 
 ### Authorization
 
-Requests to the `services` endpoint are not authorized by either the
-[Trapperkeeper-based authorization process][`auth.conf`] introduced in Puppet
-Server 2.3.0, or the deprecated Ruby-based authorization process. For more
-information about the supported and deprecated Puppet Server authorization
-processes and configuration settings, see the
+Requests to the `services` endpoint are authorized by the
+[Trapperkeeper-based authorization process][`auth.conf`] as of Puppet
+Server 5.3.0. For more information about the supported Puppet Server
+authorization processes and configuration settings, see the
 [`auth.conf` documentation][`auth.conf`].
 
-Unless the `client-auth` setting is set to `required` for the webserver, a
-client should be permitted to make a request to this endpoint via SSL with or
-without the use of a client certificate. See
+One may also restrict access to the status service by changing the
+`client-auth` setting to `required` for the webserver. See
 [Configuring the Webserver Service](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/jetty-config.md#client-auth)
 for more information on the `client-auth` setting.

--- a/documentation/status-api/v1/simple.markdown
+++ b/documentation/status-api/v1/simple.markdown
@@ -58,15 +58,13 @@ running
 
 ### Authorization
 
-Requests to the `simple` endpoint are not authorized by either the
-[Trapperkeeper-based authorization process][`auth.conf`] introduced in Puppet
-Server 2.3.0, or the deprecated Ruby-based authorization process. For more
-information about the supported and deprecated Puppet Server authorization
-processes and configuration settings, see the
+Requests to the `simple` endpoint are authorized by the
+[Trapperkeeper-based authorization process][`auth.conf`] as of Puppet
+Server 5.3.0. For more information about the supported Puppet Server
+authorization processes and configuration settings, see the
 [`auth.conf` documentation][`auth.conf`].
 
-Unless the `client-auth` setting is set to `required` for the webserver, a
-client should be permitted to make a request to this endpoint via SSL with or
-without the use of a client certificate. See
+One may also restrict access to the status service by changing the
+`client-auth` setting to `required` for the webserver. See
 [Configuring the Webserver Service](https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/jetty-config.md#client-auth)
 for more information on the `client-auth` setting.

--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -46,7 +46,6 @@ authorization: {
             name: "puppetlabs csr"
         },
         {
-            # Allow unauthenticated access to the status service endpoint
             match-request: {
                 path: "/status/v1/services"
                 type: path
@@ -54,7 +53,17 @@ authorization: {
             }
             allow-unauthenticated: true
             sort-order: 500
-            name: "puppetlabs status service"
+            name: "puppetlabs status service - full"
+        },
+        {
+            match-request: {
+                path: "/status/v1/simple"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service - simple"
         },
         {
             match-request: {


### PR DESCRIPTION
Previously, we added the ability for the status service to honor tk-auth
configs. To provide backwards compatability we opened up the default
tk-auth rules for the status service to be un-authenticated. However, in
that work we only opened up /status/v1/services, to allow calls to all
endpoints mounted under the status service this relaxes the path to only
be /status/v1.

During the previous work we also updated the tk-status service
documentation, however we missed documenting this change in our public
Puppet Server documentation. This includes that update as well.