### PR TITLE
(SERVER-2283) Update task-details to include required task files

### DIFF
--- a/documentation/puppet-api/v3/static_file_content.markdown
+++ b/documentation/puppet-api/v3/static_file_content.markdown
@@ -29,9 +29,9 @@ request to this endpoint with the required parameters.
 
 The `<FILE-PATH>` segment of the endpoint is required. The path corresponds to the
 requested file's path on the Server relative to the given environment's root directory,
-and must point to a file in the `*/*/files/**` or `*/*/tasks/**` glob. For example, Puppet Server will
-inline metadata into static catalogs for file resources sourcing module files located by
-default in
+and must point to a file in the `*/*/files/**`, `*/*/lib/**`, or `*/*/tasks/**` glob. For
+example, Puppet Server will inline metadata into static catalogs for file resources
+sourcing module files located by default in
 `/etc/puppetlabs/code/environments/<ENVIRONMENT>/modules/<MODULE NAME>/files/**`.
 
 ### Query parameters

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -214,6 +214,11 @@
           (is (= 200 (:status response)))
           (is (= "application/octet-stream" (get-in response [:headers "content-type"])))
           (is (= "test foobar modules/foo/tasks/bar.txt\n" (:body response)))))
+      (testing "the /static_file_content endpoint successfully streams lib content"
+        (let [response (testutils/get-static-file-content "plugins/foo/lib/bar.txt?code_id=foobar&environment=test")]
+          (is (= 200 (:status response)))
+          (is (= "application/octet-stream" (get-in response [:headers "content-type"])))
+          (is (= "test foobar plugins/foo/lib/bar.txt\n" (:body response)))))
       (testing (str "the /static_file_content endpoint successfully streams file content "
                     "from directories other than /modules")
         (let [response (testutils/get-static-file-content "site/foo/files/bar.txt?code_id=foobar&environment=test")]
@@ -272,7 +277,7 @@
                              "environment=test&code_id=foobar"))]
           (is (= 403 (:status response)))
           (is (= (str "Request Denied: A /static_file_content request must be "
-                      "a file within the files or tasks directory of a module.")
+                      "a file within the files, lib, or tasks directory of a module.")
                  (:body response)))))
       (testing "the /static_file_content endpoint returns an error (400) for attempted traversals"
         (let [response (testutils/get-static-file-content "modules/foo/files/bar/../../../..?environment=test&code_id=foobar")]


### PR DESCRIPTION
This verifies that the 'files' key includes all files including the task file, implementation files if provided, and helper files if provided in the metadata.