### PR TITLE
(SERVER-2239) Update clj-parent to 2.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.1.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.3.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -285,7 +285,9 @@
   :put!
   (fn [context]
     (let [desired-state (get-desired-state context)]
-      (ca/set-certificate-status! settings subject desired-state))))
+      (ca/set-certificate-status! settings subject desired-state)
+      (-> context
+        (assoc-in [:representation :media-type] "text/plain")))))
 
 (defresource certificate-statuses
   [settings]

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -568,7 +568,7 @@
                 (is (= 204 (:status response))
                     (ks/pprint-to-string response))
                 (is (= "text/plain" (get-in response [:headers "Content-Type"])))
-                (is (nil? (:body response)))
+                (is (= "" (:body response)))
                 (is (= (seq ca-subject-bytes)
                        (seq signed-cert-issuer-bytes))))
               (finally


### PR DESCRIPTION
This commit update clj-parent to 2.3.0, which contains an update to
liberator for java 9/10 compatability that required some code and test
changes.