### PR TITLE
(SERVER-2231) Disable using the infrastructure CRL by default

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -138,7 +138,7 @@
         defaults {:infra-nodes-path (str cadir "/infra_inventory.txt")
                   :infra-node-serials-path (str cadir "/infra_serials")
                   :infra-crl-path (str cadir "/infra_crl.pem")
-                  :enable-infra-crl true
+                  :enable-infra-crl false
                   :allow-subject-alt-names default-allow-subj-alt-names
                   :allow-authorization-extensions default-allow-auth-extensions}]
     (merge defaults ca-data)))


### PR DESCRIPTION
This commit updates puppetserver's configuration to not use a separate
infrastructure CRL by default.