### PR TITLE
(WIP) Run AppVeyor Docker Tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test do
   gem 'master_manipulator'
 
   # docker-api 1.32.0 requires ruby 2.0.0
-  gem 'docker-api', '1.31.0'
+  # gem 'docker-api', '1.31.0'
 end
 
 if File.exists? "#{__FILE__}.local"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+# based off of the code at
+# https://github.com/appveyor-tests/docker-ce/blob/master/appveyor.yml
+build: off
+image: Visual Studio 2017 Preview
+# Preview has Docker binaries in different location, doesn't have Switch-DockerLinux??
+# image: Visual Studio 2017 Preview
+matrix:
+  fast_finish: true
+
+environment:
+  matrix:
+    - ruby_version: 24-x64
+
+init:
+  - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  # run Morgan fork that doesn't rely on docker-api for now
+  - set PUPPET_DOCKER_LOCATION=https://github.com/underscorgan/puppet_docker_tools#undo-docker-gem
+
+install:
+  - ps: |
+      # basic diagnostic host info
+      Get-ComputerInfo | select WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer
+      ruby --version
+      gem --version
+      bundle --version
+      Get-ChildItem Env: | % { Write-Output "$($_.Key): $($_.Value)"  }
+      docker version
+      docker images
+      docker info
+      sc.exe qc docker
+      docker pull alpine
+
+test_script:
+  - ps: |
+      # $ENV:DOCKER_URL='tcp://127.0.0.1:2375'
+      # Switch-DockerLinux
+      # docker-switch-linux
+      # trigger basic build / run smoke tests
+      cd docker
+      # run a local container registry
+      # ./ci/setup-docker-registry.ps1
+      ./ci/build.ps1
+      $exitCode = $LASTEXITCODE
+      Write-Output "Spec run exited with $exitCode"
+      $host.SetShouldExit($exitCode)
+      docker ps
+
+notifications:
+  - provider: Email
+    to:
+    - nobody@nowhere.com
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -1,0 +1,51 @@
+$ErrorActionPreference = 'Stop'
+
+$BUNDLER_PATH = '.bundle/gems'
+
+# $repository = 'pcr-internal.puppet.net/release-engineering'
+$repository = '127.0.0.1'
+
+function build_and_test_image($container_name)
+{
+  # ===
+  # === run linter on the docker files
+  # ===
+  bundle exec puppet-docker local-lint $container_name
+
+  # ===
+  # === build and test $container_name
+  # ===
+  bundle exec puppet-docker build $container_name --repository $repository
+  bundle exec puppet-docker spec $container_name
+}
+
+function push_image($container_name)
+{
+  bundle exec puppet-docker push $container_name --repository $repository
+}
+
+# ===
+# === bundle install to get ready
+# ===
+bundle install --path $BUNDLER_PATH
+
+# ===
+# === pull updated base images
+# ===
+bundle exec puppet-docker update-base-images ubuntu:16.04
+
+$container_list = @('puppetserver-standalone', 'puppetserver')
+
+# ===
+# === build and test all the images before we push anything
+# ===
+$container_list | % { build_and_test_image $_ }
+
+# ===
+# === push all the images
+# ===
+$container_list | % { push_image $_ }
+
+# ===
+# === SUCCESS
+# ===

--- a/docker/ci/setup-docker-registry.ps1
+++ b/docker/ci/setup-docker-registry.ps1
@@ -1,0 +1,80 @@
+# runs a registry on
+function Start-DockerRegistry
+{
+  docker pull registry:2
+  docker run -d -p 5000:5000 --restart=always --name registry registry:2
+}
+
+# runs a registry on top of Windows Nano Server
+# requires LCOW on to test puppetserver and run this Windows container
+function Start-DockerRegistryWindows
+{
+  # Run the registry container
+  # https://hub.docker.com/r/stefanscherer/registry-windows/
+  New-Item -Type Directory c:\registry
+  docker pull stefanscherer/registry-windows:2.6.2
+  docker run -d -p 5000:5000 --restart=always --name registry -v C:\registry:C:\registry stefanscherer/registry-windows:2.6.2
+}
+
+function Get-DockerConfigFilePath
+{
+  $path = "${ENV:ALLUSERSPROFILE}\docker\config\daemon.json"
+
+  # retrieve the path to daemon.json from docker service config, if present
+  sc.exe qc docker |
+    ? { $_ -match 'BINARY_PATH_NAME\s*:\s*(.*)' } |
+    ? { $_ -match '--config-file\s*(.*daemon\.json)' }
+
+  # found BINARY_PATH_NAME which contains --config-file *AND* file exists
+  if (($Matches.Count -gt 0) -and ((Test-Path -Path $Matches[1]) -eq $True))
+  {
+    $path = $Matches[1]
+  }
+
+  Write-Host "Config file path: $path"
+  return $path
+}
+
+function Get-DockerConfig
+{
+  $json = '{}'
+  $configFilePath = Get-DockerConfigFilePath
+
+  if (Test-Path $configFilePath)
+  {
+    $json = Get-Content $configFilePath
+    Write-Host "Existing config:`n`n$json`n`n"
+  }
+  return ($json | ConvertFrom-Json)
+}
+
+function Set-DockerConfig($hash)
+{
+  $configFilePath = Get-DockerConfigFilePath
+  $utf8NoBom = New-Object System.Text.UTF8Encoding $False
+  # making sure to write a UTF-8 file with NO BOM
+  [System.IO.File]::WriteAllLines($configFilePath, ($hash | ConvertTo-Json), $utf8NoBom)
+  Write-Host "Updated config file:`n`n$(Get-Content $configFilePath)`n`n"
+}
+
+function Add-UntrustedDockerRegistry($Address)
+{
+  $config = Get-DockerConfig
+  # Reconfigure the docker daemon to use the registry untrusted
+  # add the tcp listener on loopback for docker-api gem
+  # $config.hosts += 'tcp://127.0.0.1:2375'
+  if (-not $config.ContainsKey('insecure-registries'))
+  {
+    $config.'insecure-registries' = @()
+  }
+  $config.'insecure-registries' += @("127.0.0.1:5000")
+
+  Set-DockerConfig $config
+}
+
+
+Start-DockerRegistry
+Add-UntrustedDockerRegistry -Address '127.0.0.1:5000'
+
+# Restart service for configuration to take effect
+Restart-Service docker


### PR DESCRIPTION
Take 2

* Uses Windows docker registry container
* Uses WIP https://github.com/puppetlabs/puppet_docker_tools/pull/25 that replaces docker-api gem with `docker` CLI
