### PR TITLE
(SERVER-2308) Update CA bootstrap code to add CLI auth extension

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -722,7 +722,10 @@
                          #{:key-encipherment
                            :digital-signature} true)
                        (utils/subject-key-identifier
-                         master-public-key false)]]
+                         master-public-key false)
+                       {:oid cli-auth-oid
+                        :critical false
+                        :value "true"}]]
     (validate-dns-alt-names! alt-names-ext)
     (when csr-attr-exts
       (validate-extensions! csr-attr-exts))

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -685,6 +685,11 @@
                 "The Subject Alternative Names extension should contain the
                  master's actual hostname and the hostnames in $dns-alt-names")))
 
+        (testing "has CLI auth extension"
+          (let [cli-auth-ext (utils/get-extension-value hostcert cli-auth-oid)]
+            (is (= "true" cli-auth-ext)
+                "The master cert should have the auth extension for the CA CLI.")))
+
         (testing "is also saved in the CA's $signeddir"
           (let [signedpath (path-to-cert (:signeddir ca-settings) "master")]
             (is (fs/exists? signedpath))
@@ -1156,6 +1161,9 @@
                            {:oid      "2.5.29.14"
                             :critical false
                             :value    subject-pub}
+                           {:oid      "1.3.6.1.4.1.34380.1.3.39"
+                            :critical false
+                            :value    "true"}
                            {:oid      utils/subject-alt-name-oid
                             :critical false
                             :value    {:dns-name ["puppet" "subject"]}}]]
@@ -1191,6 +1199,9 @@
                                    {:oid      "2.5.29.14"
                                     :critical false
                                     :value    subject-pub}
+                                   {:oid      "1.3.6.1.4.1.34380.1.3.39"
+                                    :critical false
+                                    :value    "true"}
                                    {:oid      "2.5.29.17"
                                     :critical false
                                     :value    {:dns-name ["subject"


### PR DESCRIPTION
This commit updates the code that generates the master's host cert on
server start to add the auth extension needed by the CA CLI tool to talk
to the certificate_status endpoint.