### PR TITLE
(maint) Setup CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,72 @@
+pool:
+  # vmImage: 'VS2017-Win2016'
+  vmImage: Vs2017-Server2016
+  # vmImage: 'win1803'
+
+# strategy:
+#   matrix:
+#     - ruby_version: 24-x64
+
+steps:
+- powershell: |
+    # basic diagnostic host info
+    Get-ComputerInfo | select WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer
+    Get-ChildItem Env: | % { Write-Host "$($_.Key): $($_.Value)"  }
+    docker version
+    docker images
+    docker info
+    sc.exe qc docker
+    # install Chocolatey - not necessary since image has it
+    # Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+    # install Ruby 2.5 and Go (for building LCOW)
+    choco install -y --no-progress ruby golang
+    #
+    # add to path
+    #
+    refreshenv
+    $Env:PATH += ';C:\tools\ruby25\bin'
+    #
+    # config the Go install
+    #
+    # Env:GOROOT already defaults to c:\tools\go
+    $Env:GOPATH = 'c:\go'
+    New-Item -Type Directory $Env:GOPATH
+    $Env:GOROOT = 'c:\tools\go'
+    $Env:PATH += ";${Env:GOPATH}\bin;${ENV:GOROOT}\bin;${Env:GOPATH}\go\bin"
+    #
+    # validate ENV vars
+    #
+    Get-ChildItem Env: | % { Write-Host "$($_.Key): $($_.Value)"  }
+    #
+    # validate Go environment
+    #
+    go version
+    go env
+    #
+    # validate the Ruby install
+    #
+    ruby --version
+    gem --version
+    gem install bundler --no-ri --no-rdoc
+    bundle --version
+    #
+    # build / config / install LCOW support
+    #
+    . ./docker/ci/docker-helpers.ps1
+    ./docker/ci/enable-lcow.ps1
+    #
+    # run Morgan fork that doesn't rely on docker-api for now
+    $Env:PUPPET_DOCKER_LOCATION='https://github.com/underscorgan/puppet_docker_tools#undo-docker-gem'
+    #
+    #
+    #
+    # $ENV:DOCKER_URL='tcp://127.0.0.1:2375'
+    # trigger basic build / run smoke tests
+    cd docker
+    # run a local container registry
+    # ./ci/setup-docker-registry.ps1
+    ./ci/build.ps1
+    # $exitCode = $LASTEXITCODE
+    # # Write-Output "Spec run exited with $exitCode"
+    # # $host.SetShouldExit($exitCode)
+    docker ps

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -1,0 +1,51 @@
+$ErrorActionPreference = 'Stop'
+
+$BUNDLER_PATH = '.bundle/gems'
+
+# $repository = 'pcr-internal.puppet.net/release-engineering'
+$repository = '127.0.0.1'
+
+function build_and_test_image($container_name)
+{
+  # ===
+  # === run linter on the docker files
+  # ===
+  bundle exec puppet-docker local-lint $container_name
+
+  # ===
+  # === build and test $container_name
+  # ===
+  bundle exec puppet-docker build $container_name --repository $repository
+  bundle exec puppet-docker spec $container_name
+}
+
+function push_image($container_name)
+{
+  bundle exec puppet-docker push $container_name --repository $repository
+}
+
+# ===
+# === bundle install to get ready
+# ===
+bundle install --path $BUNDLER_PATH
+
+# ===
+# === pull updated base images
+# ===
+bundle exec puppet-docker update-base-images ubuntu:16.04
+
+$container_list = @('puppetserver-standalone', 'puppetserver')
+
+# ===
+# === build and test all the images before we push anything
+# ===
+$container_list | % { build_and_test_image $_ }
+
+# ===
+# === push all the images
+# ===
+$container_list | % { push_image $_ }
+
+# ===
+# === SUCCESS
+# ===

--- a/docker/ci/docker-helpers.ps1
+++ b/docker/ci/docker-helpers.ps1
@@ -1,0 +1,40 @@
+function Get-DockerConfigFilePath
+{
+  $path = "${ENV:ALLUSERSPROFILE}\docker\config\daemon.json"
+
+  # retrieve the path to daemon.json from docker service config, if present
+  sc.exe qc docker |
+    ? { $_ -match 'BINARY_PATH_NAME\s*:\s*(.*)' } |
+    ? { $_ -match '--config-file\s*(.*daemon\.json)' }
+
+  # found BINARY_PATH_NAME which contains --config-file *AND* file exists
+  if (($Matches.Count -gt 0) -and ((Test-Path -Path $Matches[1]) -eq $True))
+  {
+    $path = $Matches[1]
+  }
+
+  Write-Host "Config file path: $path"
+  return $path
+}
+
+function Get-DockerConfig
+{
+  $json = '{}'
+  $configFilePath = Get-DockerConfigFilePath
+
+  if (Test-Path $configFilePath)
+  {
+    $json = Get-Content $configFilePath
+    Write-Host "Existing config:`n`n$json`n`n"
+  }
+  return ($json | ConvertFrom-Json)
+}
+
+function Set-DockerConfig($hash)
+{
+  $configFilePath = Get-DockerConfigFilePath
+  $utf8NoBom = New-Object System.Text.UTF8Encoding $False
+  # making sure to write a UTF-8 file with NO BOM
+  [System.IO.File]::WriteAllLines($configFilePath, ($hash | ConvertTo-Json), $utf8NoBom)
+  Write-Host "Updated config file:`n`n$(Get-Content $configFilePath)`n`n"
+}

--- a/docker/ci/enable-lcow.ps1
+++ b/docker/ci/enable-lcow.ps1
@@ -1,0 +1,60 @@
+function Enable-DockerExperimental
+{
+  $config = Get-DockerConfig
+  if (-not $config.PSObject.Properties.Match('experimental'))
+  {
+    $config.experimental = $True
+  }
+  else
+  {
+    $config | Add-Member -MemberType NoteProperty -Name 'experimental' -Value $True
+  }
+
+  Set-DockerConfig $config
+}
+
+Push-Location $Env:Temp
+
+# upgrade the docker engine with experimental LCOW support
+Invoke-WebRequest -OutFile docker-master.zip https://master.dockerproject.com/windows/x86_64/docker.zip
+# Appveyor has the engine installed to C:\Program Files\Docker\Docker\Resources\dockerd.exe
+Expand-Archive -Path docker-master.zip -DestinationPath . -Force
+
+$dockerHome = "$Env:ProgramFiles\Docker\"
+Stop-Service docker
+Copy-Item .\docker\* $dockerHome
+
+Enable-DockerExperimental
+
+Start-Service docker
+
+docker version
+docker info
+
+# run alpine to make sure Linux containers are working
+docker run alpine
+
+# acquire and build linuxkit from fork
+go get -v -u github.com/Iristyle/linuxkit/src/cmd/linuxkit
+
+# validate it was built and in path
+& linuxkit.exe version
+
+# clone the LCOW source and build the image with linuxkit
+git clone https://github.com/linuxkit/lcow
+Push-Location lcow
+& linuxkit.exe build lcow.yml
+
+# move the LCOW VM into the expected location
+$containerHome = "$Env:ProgramFiles\Linux Containers"
+New-Item $containerHome -Type Directory -Force
+Copy-Item .\lcow-initrd.img "$containerHome\initrd.img"
+Copy-Item .\lcow-kernel "$containerHome\kernel"
+Pop-Location
+
+# server doesn't require registration as experimental as its already setup that way
+# re-register the service
+# & $dockerHome\dockerd.exe --register-service --experimental
+
+Pop-Location
+Start-Service docker


### PR DESCRIPTION
This attempts to build puppetserver container using Azure and then consume / run it on a Windows hosts.

A few snags thus far:

* Can only build on Windows Server 2016 vmImage, which doesn't support LCOW, which prevents Linux container builds on Windows
* Server 1803 cannot build containers (because its hosted by 2016), but seems like it can run LCOW (with some work)