### PR TITLE
(maint) Build Container in Azure Pipelines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docker/puppetserver/*               text  eol=lf
+docker/puppetserver-standalone/*    text  eol=lf

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,3 +41,8 @@ steps:
     Get-ChildItem Env: | % { Write-Host "$($_.Key): $($_.Value)"  }
   displayName: Diagnostic Host Information
   name: hostinfo
+- powershell: |
+    . ./docker/ci/build.ps1
+    Invoke-ContainerBuildSetup
+  displayName: Prepare Build Environment
+  name: build_prepare

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,43 @@
+pool:
+  # self-hosted agent on Windows 10 1709 environment
+  # includes newer Docker engine with LCOW enabled, new build of LCOW image
+  # includes Ruby 2.5, Go 1.10, Node.js 10.10, hadolint
+  name: Default
+
+steps:
+- powershell: |
+    $line = '=' * 80
+    Write-Host "$line`nWindows`n$line`n"
+    Get-ComputerInfo |
+      select WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer |
+      Out-String |
+      Write-Host
+    #
+    # Azure
+    #
+    Write-Host "`n`n$line`nAzure`n$line`n"
+    Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
+      ConvertTo-Json -Depth 10 |
+      Write-Host
+    #
+    # Docker
+    #
+    Write-Host "`n`n$line`nDocker`n$line`n"
+    docker version
+    docker images
+    docker info
+    sc.exe qc docker
+    #
+    # Ruby
+    #
+    Write-Host "`n`n$line`nRuby`n$line`n"
+    ruby --version
+    gem --version
+    bundle --version
+    #
+    # Environment
+    #
+    Write-Host "`n`n$line`nEnvironment`n$line`n"
+    Get-ChildItem Env: | % { Write-Host "$($_.Key): $($_.Value)"  }
+  displayName: Diagnostic Host Information
+  name: hostinfo

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,3 +59,13 @@ steps:
     Build-Container -Name puppetserver -Repository $ENV:BUILD_REPOSITORY
   displayName: Build Puppetserver
   name: build_puppetserver
+- powershell: |
+    . ./docker/ci/build.ps1
+    Invoke-ContainerTest -Name puppetserver-standalone -Repository $ENV:BUILD_REPOSITORY
+  displayName: Test Puppetserver Standalone
+  name: test_puppetserver_standalone
+- powershell: |
+    . ./docker/ci/build.ps1
+    Invoke-ContainerTest -Name puppetserver -Repository $ENV:BUILD_REPOSITORY
+  displayName: Test Puppetserver
+  name: test_puppetserver

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,11 +64,25 @@ steps:
     Invoke-ContainerTest -Name puppetserver-standalone -Repository $ENV:BUILD_REPOSITORY
   displayName: Test Puppetserver Standalone
   name: test_puppetserver_standalone
+- task: PublishTestResults@2
+  displayName: Publish Puppetserver Standalone test results
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: 'docker/**/TEST-*.xml'
+    #mergeTestResults: false # Optional
+    testRunTitle: Puppetserver Standalone Test Results
 - powershell: |
     . ./docker/ci/build.ps1
     Invoke-ContainerTest -Name puppetserver -Repository $ENV:BUILD_REPOSITORY
   displayName: Test Puppetserver
   name: test_puppetserver
+- task: PublishTestResults@2
+  displayName: Publish Puppetserver test results
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: 'docker/**/TEST-*.xml'
+    #mergeTestResults: false # Optional
+    testRunTitle: Puppetserver Test Results
 - powershell: |
     . ./docker/ci/build.ps1
     Clear-ContainerBuilds

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,3 +69,8 @@ steps:
     Invoke-ContainerTest -Name puppetserver -Repository $ENV:BUILD_REPOSITORY
   displayName: Test Puppetserver
   name: test_puppetserver
+- powershell: |
+    . ./docker/ci/build.ps1
+    Clear-ContainerBuilds
+  displayName: Container Cleanup
+  condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,9 @@ pool:
   # includes Ruby 2.5, Go 1.10, Node.js 10.10, hadolint
   name: Default
 
+variables:
+  BUILD_REPOSITORY: 127.0.0.1
+
 steps:
 - powershell: |
     $line = '=' * 80
@@ -46,3 +49,13 @@ steps:
     Invoke-ContainerBuildSetup
   displayName: Prepare Build Environment
   name: build_prepare
+- powershell: |
+    . ./docker/ci/build.ps1
+    Build-Container -Name puppetserver-standalone -Repository $ENV:BUILD_REPOSITORY
+  displayName: Build Puppetserver Standalone
+  name: build_puppetserver_standalone
+- powershell: |
+    . ./docker/ci/build.ps1
+    Build-Container -Name puppetserver -Repository $ENV:BUILD_REPOSITORY
+  displayName: Build Puppetserver
+  name: build_puppetserver

--- a/docker/.rspec
+++ b/docker/.rspec
@@ -1,0 +1,3 @@
+--format RspecJunitFormatter
+--out TEST-rspec.xml
+--format documentation

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -11,3 +11,4 @@ def location_for(place, fake_version = nil)
 end
 
 gem 'puppet_docker_tools', *location_for(ENV['PUPPET_DOCKER_LOCATION'] || '~> 0.2.0')
+gem 'rspec_junit_formatter'

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -10,4 +10,4 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'puppet_docker_tools', *location_for(ENV['PUPPET_DOCKER_LOCATION'] || '~> 0.1.5')
+gem 'puppet_docker_tools', *location_for(ENV['PUPPET_DOCKER_LOCATION'] || '~> 0.2.0')

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,8 +1,8 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-def location_for(place)
-  if place =~ /^((:?git|https?)[:@][^#]*)#(.*)/
-    [{ :git => $1, :branch => $2, :require => false }]
+def location_for(place, fake_version = nil)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
   elsif place =~ /^file:\/\/(.*)/
     ['>= 0', { :path => File.expand_path($1), :require => false }]
   else

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+
+function Get-CurrentDirectory
+{
+  $thisName = $MyInvocation.MyCommand.Name
+  [IO.Path]::GetDirectoryName((Get-Content function:$thisName).File)
+}
+
+# installs gems for build and test and grabs base images
+function Invoke-ContainerBuildSetup
+{
+  Push-Location (Get-CurrentDirectory)
+  bundle install --path '.bundle/gems'
+  bundle exec puppet-docker update-base-images ubuntu:16.04
+  Pop-Location
+}

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -22,3 +22,10 @@ function Build-Container($Name, $Repository = '127.0.0.1')
   bundle exec puppet-docker build $Name --no-cache --repository $Repository --build-arg namespace=$Repository
   Pop-Location
 }
+
+function Invoke-ContainerTest($Name, $Repository = '127.0.0.1')
+{
+  Push-Location (Join-Path (Get-CurrentDirectory) '..')
+  bundle exec puppet-docker spec $Name --image $Repository/$Name
+  Pop-Location
+}

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -14,3 +14,11 @@ function Invoke-ContainerBuildSetup
   bundle exec puppet-docker update-base-images ubuntu:16.04
   Pop-Location
 }
+
+function Build-Container($Name, $Repository = '127.0.0.1')
+{
+  Push-Location (Join-Path (Get-CurrentDirectory) '..')
+  bundle exec puppet-docker local-lint $Name
+  bundle exec puppet-docker build $Name --no-cache --repository $Repository --build-arg namespace=$Repository
+  Pop-Location
+}

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -29,3 +29,10 @@ function Invoke-ContainerTest($Name, $Repository = '127.0.0.1')
   bundle exec puppet-docker spec $Name --image $Repository/$Name
   Pop-Location
 }
+
+# removes any temporary containers / images used during builds
+function Clear-ContainerBuilds
+{
+  docker container prune --force
+  docker image prune --filter "dangling=true" --force
+}

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -44,6 +44,7 @@ RUN puppet config set autosign true --section master && \
     rm -rf /var/tmp/puppet/ssl
 
 COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
 
 EXPOSE 8140
 

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -51,14 +51,8 @@ EXPOSE 8140
 ENTRYPOINT ["dumb-init", "/docker-entrypoint.sh"]
 CMD ["foreground"]
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD \
-  curl --fail -H 'Accept: pson' \
-  --resolve 'puppet:8140:127.0.0.1' \
-  --cert   $(puppet config print hostcert) \
-  --key    $(puppet config print hostprivkey) \
-  --cacert $(puppet config print localcacert) \
-  https://puppet:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
-  |  grep -q '"is_alive":true' \
-  || exit 1
+COPY healthcheck.sh /
+RUN chmod +x /healthcheck.sh
+HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD ["/healthcheck.sh"]
 
 COPY Dockerfile /

--- a/docker/puppetserver-standalone/healthcheck.sh
+++ b/docker/puppetserver-standalone/healthcheck.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+curl --fail -H 'Accept: pson' \
+--resolve 'puppet:8140:127.0.0.1' \
+--cert   $(puppet config print hostcert) \
+--key    $(puppet config print hostprivkey) \
+--cacert $(puppet config print localcacert) \
+https://puppet:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
+|  grep -q '"is_alive":true' \
+|| exit 1


### PR DESCRIPTION
This enables building Docker images / containers in the Azure Devops Pipelines. Uses a custom agent in the `Default` agent pool that has Docker with LCOW supported installed / enabled, Ruby 2.5 and hadolint installed - all required for this build. It also has Go and Node.js installed, which are currently not required.

Currently requires https://github.com/puppetlabs/puppet_docker_tools/pull/26 (currently installing as a gem from that git ref) and has cherry-picked over test fixes in #1794 

Once those are merged, this can be rebased, edited to remove the cherry-picked commit and the git ref to the puppet_docker_tools PR, and merged.