### PR TITLE
(SERVER-2327) Ship a default ca.conf

### DIFF
--- a/documentation/config_file_ca.markdown
+++ b/documentation/config_file_ca.markdown
@@ -18,6 +18,10 @@ The `allow-subject-alt-names` setting in the `certificate-authority` section ena
 
 The `allow-authorization-extensions` setting in the `certificate-authority` section enables you to sign certs with authorization extensions. It is false by default for security reasons, but can be enabled if you know you need to sign certs this way. `puppet cert sign` used to allow this via a flag, but `puppetserver ca sign` requires it to be configued in the config file.
 
+## Infrastructure CRL settings
+
+Puppet Server is able to create a separate CRL file containing only revocations of Puppet infrastructure nodes. This behavior is turned off by default. To enable it, set `certificate-authority.enable-infra-crl` to `true`.
+
 ## Status settings (deprecated)
 
 The `certificate-status` setting in `ca.conf` provides [deprecated][] configuration options for access to the `certificate_status` and `certificate_statuses` HTTP endpoints. These endpoints allow certificates to be signed, revoked, and deleted through HTTP requests, which provides full control over Puppet's ability to securely authorize access. Therefore, you should **always** restrict access to `ca.conf`.

--- a/ezbake/config/conf.d/ca.conf
+++ b/ezbake/config/conf.d/ca.conf
@@ -1,0 +1,10 @@
+certificate-authority: {
+    # allow CA to sign certificate requests that have subject alternative names.
+    # allow-subject-alt-names: false
+
+    # allow CA to sign certificate requests that have authorization extensions.
+    # allow-authorization-extensions: false
+
+    # enable the separate CRL for Puppet infrastructure nodes
+    # enable-infra-crl: false
+}

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -74,11 +74,3 @@ profiler: {
     # enable or disable profiling for the Ruby code; defaults to 'true'.
     #enabled: true
 }
-
-# settings related to the certificate authority
-certificate-authority: {
-    # allow CA to sign certificate requests that have subject alternative names.
-    # allow-subject-alt-names: false
-    # allow CA to sign certificate requests that have authorization extensions.
-    # allow-authorization-extensions: false
-}


### PR DESCRIPTION
This commit adds a ca.conf to the files ezbake installs alongside
puppetserver. It should be used for the new CA-related settings we added
in Server 6.