### PR TITLE
(docs)(DOC-3750) Remove broad ca.conf deprecation notes

### DIFF
--- a/documentation/config_file_ca.markdown
+++ b/documentation/config_file_ca.markdown
@@ -18,7 +18,7 @@ The `allow-subject-alt-names` setting in the `certificate-authority` section ena
 
 The `allow-authorization-extensions` setting in the `certificate-authority` section enables you to sign certs with authorization extensions. It is false by default for security reasons, but can be enabled if you know you need to sign certs this way. `puppet cert sign` used to allow this via a flag, but `puppetserver ca sign` requires it to be configued in the config file.
 
-## Status settings
+## Status settings (deprecated)
 
 The `certificate-status` setting in `ca.conf` provides [deprecated][] configuration options for access to the `certificate_status` and `certificate_statuses` HTTP endpoints. These endpoints allow certificates to be signed, revoked, and deleted through HTTP requests, which provides full control over Puppet's ability to securely authorize access. Therefore, you should **always** restrict access to `ca.conf`.
 

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -25,7 +25,7 @@ Puppet Server is the next-generation application for managing Puppet agents.
     * [logback.xml](./config_file_logbackxml.markdown)
         * [Advanced logging configuration](./config_logging_advanced.markdown)
     * [master.conf](./config_file_master.markdown) (deprecated)
-    * [ca.conf](./config_file_ca.markdown) (deprecated)
+    * [ca.conf](./config_file_ca.markdown)
     * [Differing behavior in puppet.conf](./puppet_conf_setting_diffs.markdown)
 * **Using and extending Puppet Server**
     * [Subcommands](./subcommands.markdown)

--- a/documentation/services_master_puppetserver.markdown
+++ b/documentation/services_master_puppetserver.markdown
@@ -65,7 +65,7 @@ Puppet Server includes a certificate authority (CA) service that accepts certifi
 See [CA V1 HTTP API](https://puppet.com/docs/puppet/latest/http_api/http_api_index.html#ca-v1-http-api)
 for more information on these APIs.
 
-Signing and revoking certificates over the network is disallowed by default; you can use the [`auth.conf`](./config_file_auth.html) file (or deprecated [`ca.conf`](./config_file_ca.markdown) file) to let specific certificate owners issue commands.
+Signing and revoking certificates over the network is disallowed by default; you can use the [`auth.conf`](./config_file_auth.html) file to let specific certificate owners issue commands.
 
 The CA service uses .pem files in the standard Puppet [`ssldir`](https://puppet.com/docs/puppet/latest/dirs_ssldir.html) to store credentials. You can use the standard `puppetserver ca` command to interact with these credentials, including listing, signing, and revoking certificates.
 
@@ -151,7 +151,7 @@ Puppet Server's `conf.d` directory contains:
 * `puppetserver.conf`: Settings for Puppet Server itself, including the JRuby interpreter and the administrative API.
 * `auth.conf`: Authentication rules for Puppet Server endpoints.
 * `master.conf` ([deprecated][]): Settings for the Puppet master functionality of Puppet Server.
-* `ca.conf` ([deprecated][]): Settings for the Certificate Authority service.
+* `ca.conf`: Settings for the Certificate Authority service.
 
 For detailed information about Puppet Server settings and the `conf.d` directory, refer to the [Configuration](./configuration.markdown) page.
 


### PR DESCRIPTION
The `ca.conf` file was initially deprecated in Server 2.2, but that deprecation's scope was later limited to only certificate status authorization settings being supplanted by settings in Server's `auth.conf` file.

Some, but not all, of the documented deprecation notices didn't fully reflect this narrowed scope. Furthermore, new settings added in Server 6.0 are intended for `ca.conf`, so notices that suggest the entire file is deprecated are confusingly conflicting.

Remove the overly broad deprecation notices, and modify the heading of the "Status settings" section (which describes only deprecated settings) in the `ca.conf` doc.