### PR TITLE
(SERVER-2323) Backport CLI auth extension to 5.3.x

### DIFF
--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -46,6 +46,37 @@ authorization: {
             name: "puppetlabs csr"
         },
         {
+            # Allow the CA CLI to access the certificate_status endpoint
+            match-request: {
+                path: "/puppet-ca/v1/certificate_status"
+                type: path
+                method: [get, put, delete]
+            }
+            allow: {
+               extensions: {
+                   pp_cli_auth: "true"
+               }
+            }
+            sort-order: 500
+            name: "puppetlabs cert status"
+        },
+        {
+            # Allow the CA CLI to access the certificate_statuses endpoint
+            match-request: {
+                path: "/puppet-ca/v1/certificate_statuses"
+                type: path
+                method: get
+            }
+            allow: {
+               extensions: {
+                   pp_cli_auth: "true"
+               }
+            }
+            sort-order: 500
+            name: "puppetlabs cert statuses"
+        },
+        {
+            # Allow unauthenticated access to the status service endpoint
             match-request: {
                 path: "/status/v1/services"
                 type: path

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -644,7 +644,10 @@
                          #{:key-encipherment
                            :digital-signature} true)
                        (utils/subject-key-identifier
-                         master-public-key false)]]
+                         master-public-key false)
+                       {:oid cli-auth-oid
+                        :critical false
+                        :value "true"}]]
     (validate-dns-alt-names! alt-names-ext)
     (when csr-attr-exts
       (validate-extensions! csr-attr-exts))

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -140,6 +140,11 @@
   "The OID for the extension with shortname 'ppPrivCertExt'."
   "1.3.6.1.4.1.34380.1.3")
 
+;; Extension that is checked when allowing access to the certificate_status(es)
+;; endpoint. Should only be present on the puppet master cert.
+(def cli-auth-oid
+  "1.3.6.1.4.1.34380.1.3.39")
+
 (def puppet-short-names
   "A mapping of Puppet extension short names to their OIDs. These appear in
   csr_attributes.yaml."
@@ -169,7 +174,8 @@
    :pp_apptier          "1.3.6.1.4.1.34380.1.1.24"
    :pp_hostname         "1.3.6.1.4.1.34380.1.1.25"
    :pp_authorization    "1.3.6.1.4.1.34380.1.3.1"
-   :pp_auth_role        "1.3.6.1.4.1.34380.1.3.13"})
+   :pp_auth_role        "1.3.6.1.4.1.34380.1.3.13"
+   :pp_cli_auth         cli-auth-oid})
 
 (def netscape-comment-value
   "Standard value applied to the Netscape Comment extension for certificates"
@@ -567,6 +573,7 @@
   [extension :- Extension]
   (let [oid (:oid extension)]
     (or
+      (and (utils/subtree-of? ppAuthCertExt oid) (not (= cli-auth-oid oid)))
       (utils/subtree-of? ppRegCertExt oid)
       (utils/subtree-of? ppPrivCertExt oid))))
 

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -680,6 +680,11 @@
                 "The Subject Alternative Names extension should contain the
                  master's actual hostname and the hostnames in $dns-alt-names")))
 
+        (testing "has CLI auth extension"
+          (let [cli-auth-ext (utils/get-extension-value hostcert cli-auth-oid)]
+            (is (= "true" cli-auth-ext)
+                "The master cert should have the auth extension for the CA CLI.")))
+
         (testing "is also saved in the CA's $signeddir"
           (let [signedpath (path-to-cert (:signeddir ca-settings) "master")]
             (is (fs/exists? signedpath))
@@ -1149,6 +1154,9 @@
                            {:oid      "2.5.29.14"
                             :critical false
                             :value    subject-pub}
+                           {:oid      "1.3.6.1.4.1.34380.1.3.39"
+                            :critical false
+                            :value    "true"}
                            {:oid      utils/subject-alt-name-oid
                             :critical false
                             :value    {:dns-name ["puppet" "subject"]}}]]
@@ -1184,6 +1192,9 @@
                                    {:oid      "2.5.29.14"
                                     :critical false
                                     :value    subject-pub}
+                                   {:oid      "1.3.6.1.4.1.34380.1.3.39"
+                                    :critical false
+                                    :value    "true"}
                                    {:oid      "2.5.29.17"
                                     :critical false
                                     :value    {:dns-name ["subject"


### PR DESCRIPTION
This cherry-picks three commits from 6.0.x responsible for adding authentication for the CA CLI to the master cert out of the box:
1) Update to auth.conf to respect the extension
2) Addition of the extension OID to Puppetserver's list of recognized OIDs
3) Addition of the extension to the master cert during CA bootstrapping