### PR TITLE
(maint) Add Docker build version support

### DIFF
--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -6,6 +6,19 @@ function Get-CurrentDirectory
   [IO.Path]::GetDirectoryName((Get-Content function:$thisName).File)
 }
 
+function Get-ContainerVersion
+{
+  # shallow repositories need to pull remaining code to `git describe` correctly
+  if (Test-Path "$(git rev-parse --git-dir)/shallow")
+  {
+    git pull --unshallow
+  }
+
+  # tags required for versioning
+  git fetch origin 'refs/tags/*:refs/tags/*'
+  (git describe) -replace '-.*', ''
+}
+
 # installs gems for build and test and grabs base images
 function Invoke-ContainerBuildSetup
 {
@@ -15,18 +28,18 @@ function Invoke-ContainerBuildSetup
   Pop-Location
 }
 
-function Build-Container($Name, $Repository = '127.0.0.1')
+function Build-Container($Name, $Repository = '127.0.0.1', $Version = (Get-ContainerVersion))
 {
   Push-Location (Join-Path (Get-CurrentDirectory) '..')
   bundle exec puppet-docker local-lint $Name
-  bundle exec puppet-docker build $Name --no-cache --repository $Repository --build-arg namespace=$Repository
+  bundle exec puppet-docker build $Name --no-cache --repository $Repository --version $Version --no-latest --build-arg namespace=$Repository
   Pop-Location
 }
 
-function Invoke-ContainerTest($Name, $Repository = '127.0.0.1')
+function Invoke-ContainerTest($Name, $Repository = '127.0.0.1', $Version = (Get-ContainerVersion))
 {
   Push-Location (Join-Path (Get-CurrentDirectory) '..')
-  bundle exec puppet-docker spec $Name --image $Repository/$Name
+  bundle exec puppet-docker spec $Name --image "$Repository/${Name}:$Version"
   Pop-Location
 }
 


### PR DESCRIPTION
 - Use the git describe as we're doing in Bash scripts to pull a version
   from the repository when building / testing Docker containers