### PR TITLE
(maint) Update 'latest' tag logic for Docker

### DIFF
--- a/docker/ci/build
+++ b/docker/ci/build
@@ -4,10 +4,15 @@ set -eux
 
 PATH=$PATH:/usr/local/bin
 BUNDLER_PATH=.bundle/gems
+IS_LATEST="${IS_LATEST:-false}"
 
 function build_and_test_image() {
   local container_name="$1"
   local container_version="$2"
+  local latest=''
+  if [[ "$IS_LATEST" == 'false' ]]; then
+    local latest='--no-latest'
+  fi
 
   : ===
   : === run linter on the docker files
@@ -17,17 +22,22 @@ function build_and_test_image() {
   : ===
   : === build and test $container_name
   : ===
-  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$container_version" --no-latest --build-arg namespace=puppet
+  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$container_version" --build-arg namespace=puppet $latest
   bundle exec puppet-docker spec "$container_name" --image "puppet/$container_name:$container_version"
 }
 
 function push_image() {
   local container_name="$1"
   local container_version="$2"
+  local latest=''
+  if [[ "$IS_LATEST" == 'false' ]]; then
+    local latest='--no-latest'
+  fi
+
   : ===
   : === push $container_name
   : ===
-  bundle exec puppet-docker push "$container_name" --repository puppet --version "$container_version" --no-latest
+  bundle exec puppet-docker push "$container_name" --repository puppet --version "$container_version" $latest
 }
 
 : ===

--- a/docker/ci/build
+++ b/docker/ci/build
@@ -6,7 +6,8 @@ PATH=$PATH:/usr/local/bin
 BUNDLER_PATH=.bundle/gems
 
 function build_and_test_image() {
-  container_name="$1"
+  local container_name="$1"
+  local container_version="$2"
 
   : ===
   : === run linter on the docker files
@@ -16,13 +17,13 @@ function build_and_test_image() {
   : ===
   : === build and test $container_name
   : ===
-  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$version" --no-latest --build-arg namespace=puppet
-  bundle exec puppet-docker spec "$container_name" --image "puppet/$container_name:$version"
+  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$container_version" --no-latest --build-arg namespace=puppet
+  bundle exec puppet-docker spec "$container_name" --image "puppet/$container_name:$container_version"
 }
 
 function push_image() {
-  container_name="$1"
-  container_version="$2"
+  local container_name="$1"
+  local container_version="$2"
   : ===
   : === push $container_name
   : ===
@@ -57,7 +58,7 @@ container_list=(puppetserver-standalone puppetserver)
 : === build and test all the images before we push anything
 : ===
 for container in "${container_list[@]}"; do
-  build_and_test_image "$container"
+  build_and_test_image "$container" "$version"
 done
 
 : ===


### PR DESCRIPTION
It's complicated trying to make sure `--no-latest` is set in the correct branches and nothing gets weird on mergeups. This adds the `IS_LATEST` environment variable that defaults to false and can be set to true for the one branch we need it set on in the build job.