### PR TITLE
(SERVER-2350) Register the CA service with the status service

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -19,6 +19,7 @@
             [liberator.representation :as representation]
             [ring.util.request :as request]
             [ring.util.response :as rr]
+            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
             [puppetlabs.i18n.core :as i18n]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -333,3 +334,11 @@
           (get-in ca-settings [:access-control :certificate-status]))
         i18n/locale-negotiator
         (wrap-middleware puppet-version))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(schema/defn ^:always-validate v1-status :- status-core/StatusCallbackResponse
+  [level :- status-core/ServiceStatusDetailLevel]
+  {:state :running
+   :status {}})

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -8,14 +8,16 @@
             [puppetlabs.services.ca.certificate-authority-core :as core]
             [puppetlabs.services.protocols.ca :refer [CaService]]
             [puppetlabs.comidi :as comidi]
-            [puppetlabs.i18n.core :as i18n]))
+            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]))
 
 (tk/defservice certificate-authority-service
   CaService
   [[:PuppetServerConfigService get-config get-in-config]
    [:WebroutingService add-ring-handler get-route]
    [:AuthorizationService wrap-with-authorization-check]
-   [:FilesystemWatchService create-watcher]]
+   [:FilesystemWatchService create-watcher]
+   [:StatusService register-status]]
   (init
     [this context]
     (let [path (get-route this)
@@ -54,6 +56,11 @@
                                 ca-crl-file))
                        events)
              (ca/retrieve-ca-crl! ca-crl-file host-crl-file)))))
+      (register-status
+        "ca"
+        (status-core/get-artifact-version "puppetlabs" "puppetserver")
+        1
+        (partial core/v1-status))
       (assoc context :auth-handler auth-handler
                      :watcher watcher)))
 

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -120,7 +120,7 @@
      (is (= 200 (:status resp)))
      (let [status (json/parse-string (:body resp) true)]
 
-       (is (= #{:jruby-metrics :master :puppet-profiler :status-service}
+       (is (= #{:ca :jruby-metrics :master :puppet-profiler :status-service}
               (set (keys status))))
 
        (is (= 1 (get-in status [:jruby-metrics :service_status_version])))

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -144,7 +144,7 @@
      (let [resp (http-get "/status/v1/services?level=debug")]
        (is (= 200 (:status resp)))
        (let [status (json/parse-string (:body resp) true)]
-         (is (= #{:jruby-metrics :master :puppet-profiler :status-service}
+         (is (= #{:ca :jruby-metrics :master :puppet-profiler :status-service}
                 (set (keys status))))
 
          (is (= 1 (get-in status [:jruby-metrics :service_status_version])))


### PR DESCRIPTION
This commit registers the CA service with the StatusService. It does not
register the DisabledCAService, so if that is enabled instead of the
regular CA service, no CA info will be available from the status
endpoint.