### PR TITLE
(TK-472) Update clj-parent to 1.7.17

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.15"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.17"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This contains an update to Jetty which fixes a security vulnerability.