### PR TITLE
Update health check script to use any hostname

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -51,12 +51,13 @@ ENTRYPOINT ["dumb-init", "/docker-entrypoint.sh"]
 CMD ["foreground"]
 
 HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD \
+  hostname=$(puppet config print certname) && \
   curl --fail -H 'Accept: pson' \
-  --resolve 'puppet:8140:127.0.0.1' \
+  --resolve '${hostname}:8140:127.0.0.1' \
   --cert   $(puppet config print hostcert) \
   --key    $(puppet config print hostprivkey) \
   --cacert $(puppet config print localcacert) \
-  https://puppet:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
+  https://${hostname}:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
   |  grep -q '"is_alive":true' \
   || exit 1
 


### PR DESCRIPTION
This allows HEALTHCHECK routine to work with any container hostname.