### PR TITLE
(maint) Fix Dockerfile healthcheck for Windows

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -50,15 +50,8 @@ EXPOSE 8140
 ENTRYPOINT ["dumb-init", "/docker-entrypoint.sh"]
 CMD ["foreground"]
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD \
-  hostname=$(puppet config print certname) && \
-  curl --fail -H 'Accept: pson' \
-  --resolve '${hostname}:8140:127.0.0.1' \
-  --cert   $(puppet config print hostcert) \
-  --key    $(puppet config print hostprivkey) \
-  --cacert $(puppet config print localcacert) \
-  https://${hostname}:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
-  |  grep -q '"is_alive":true' \
-  || exit 1
+COPY healthcheck.sh /
+RUN chmod +x /healthcheck.sh
+HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD ["/healthcheck.sh"]
 
 COPY Dockerfile /

--- a/docker/puppetserver-standalone/healthcheck.sh
+++ b/docker/puppetserver-standalone/healthcheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+hostname=$(puppet config print certname)
+
+curl --fail -H 'Accept: pson' \
+--resolve '${hostname}:8140:127.0.0.1' \
+--cert   $(puppet config print hostcert) \
+--key    $(puppet config print hostprivkey) \
+--cacert $(puppet config print localcacert) \
+https://${hostname}:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
+|  grep -q '"is_alive":true' \
+|| exit 1


### PR DESCRIPTION
 - Windows LCOW, based on the following version, seems to have some
   difficulty with multiline healthchecks

              Server:
                Engine:
                  Version:          master-dockerproject-2018-09-03
                  API version:      1.39 (minimum version 1.24)
                  Go version:       go1.10.4
                  Git commit:       8af9176
                  Built:            Tue Sep  4 00:02:00 2018
                  OS/Arch:          windows/amd64
                  Experimental:     true

   It's unclear why this is the case (or if the problem was caused by
   something unrelated), but they do seem to work fine using the array
   syntax variant of CMD, when calling into a script hosted in the
   container like

     HEALTHCHECK CMD ["/healthcheck.sh"]

 - Similar behavior was observed when testing an Alpine Linux container
   independently.

   For instance, the following checks would yield `healthy`:

     HEALTHCHECK CMD ["echo", "hi"]
     HEALTHCHECK CMD ["cat", "/usr/src/app/index.js"]

   Yet the following would yield `unhealthy`

     HEALTHCHECK CMD echo "hi"
     HEALTHCHECK CMD /bin/true

To resolve conflicts I took the HEALTHCHECK from the 6.0.x Dockerfile
and updated the healthcheck.sh script to add the hostname logic.