### PR TITLE
Provide ability to disable CA service

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -23,7 +23,7 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.dockerfile="/Dockerfile"
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget=1.17.1-1ubuntu1 ca-certificates && \
+    apt-get install -y --no-install-recommends wget=1.17.1-1ubuntu1 ca-certificates netcat && \
     wget https://apt.puppetlabs.com/puppet5-release-"$UBUNTU_CODENAME".deb && \
     wget https://github.com/Yelp/dumb-init/releases/download/v"$DUMB_INIT_VERSION"/dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
     dpkg -i puppet5-release-"$UBUNTU_CODENAME".deb && \

--- a/docker/puppetserver-standalone/docker-entrypoint.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.sh
@@ -26,12 +26,6 @@ if test -n "${PUPPETSERVER_HOSTNAME}"; then
   /opt/puppetlabs/bin/puppet config set server "$PUPPETSERVER_HOSTNAME"
 fi
 
-# Configure puppet to use a certificate autosign script (if it exists)
-# AUTOSIGN=true|false|path_to_autosign.conf
-if test -n "${AUTOSIGN}" ; then
-  puppet config set autosign "$AUTOSIGN" --section master
-fi
-
 # Allow setting the dns_alt_names for the server's certificate. This
 # setting will only have an effect when the container is started without
 # an existing certificate on the /etc/puppetlabs/puppet volume
@@ -46,6 +40,45 @@ if test -n "${DNS_ALT_NAMES}"; then
             echo "         Remove/revoke the old certificate for this to become effective"
         fi
     fi
+fi
+
+# Disable local CA if using external CA or multi-master configuration
+# CA service enabled by default.
+if test "${CA_DISABLE}" = "true"; then
+  sed -i -e 's@^\(puppetlabs.services.ca.certificate-authority-service/certificate-authority-service\)@# \1@' -e 's@.*\(puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service\)@\1@' /etc/puppetlabs/puppetserver/services.d/ca.cfg
+
+# MUST provide CA_SERVER hostname
+# Use fqdn hostname to specify CA servers.
+  if test -n "${CA_SERVER}" ; then
+    # Generate SSL certificates if missing.
+    # May need manual signing on the CA server
+    # But first wait for CA server to be ready
+    fqdn=$(facter fqdn)
+    if [ ! -f "/etc/puppetlabs/puppet/ssl/certs/$fqdn.pem" ]; then
+      while ! nc -z "$CA_SERVER" 8140; do
+        sleep 1
+      done
+      
+      puppet agent --noop --server=$CA_SERVER
+    fi
+    # Workaround fix on non-ca Puppetmasters. Default ssl-crl-path=/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem
+    if [ ! -d "/etc/puppetlabs/puppet/ssl/ca" ]; then
+      mkdir /etc/puppetlabs/puppet/ssl/ca
+      ln -s /etc/puppetlabs/puppet/ssl/crl.pem /etc/puppetlabs/puppet/ssl/ca/ca_crl.pem
+    fi
+  else
+    echo "Warning: NO CA_SERVER is provided"
+    echo "         Please provide CA_SERVER hostname"
+    echo "         Otherwise any Certificate Signing Request from this container will fail"
+  fi
+
+else
+  # Configure CA server. This is the default behavior
+  # Configure puppet to use a certificate autosign script (if it exists)
+  # AUTOSIGN=true|false|path_to_autosign.conf
+  if test -n "${AUTOSIGN}" ; then
+    puppet config set autosign "$AUTOSIGN" --section master
+  fi
 fi
 
 exec /opt/puppetlabs/bin/puppetserver "$@"


### PR DESCRIPTION
This maybe necessary when using external CA or in Multi-master
Puppet configuration setup

Not sure if this is the right approach. We are trying to use Puppetserver docker images to create a stack of Puppet servers and need a way to disable PuppetCA on Compile masters and only allow CA service on some docker containers designated as PuppetCAs.
This was just a quick hack. Please let me know in case there's a better way?

