### PR TITLE
(RE-11577) Bump to ezbake 1.1.17

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -125,7 +125,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "1.1.15"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.1.17"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
This commit bumps to the latest ezbake version. This version adds a Gemfile to
the resulting package build and makes use of the packaging gem, rather than
cloning the packaging repo.