### PR TITLE
(maint) Specify `server` setting puppet.conf

### DIFF
--- a/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
@@ -4,8 +4,9 @@ step "Configure puppet.conf" do
   dir = master.tmpdir(File.basename('/tmp'))
 
   lay_down_new_puppet_conf( master,
-                           {"main" => { "dns_alt_names" => "puppet,#{hostname},#{fqdn}",
-                                       "verbose" => true }}, dir)
+                           {"main" => {"dns_alt_names" => "puppet,#{hostname},#{fqdn}",
+                                       "verbose" => true,
+                                       "server" => fqdn}}, dir)
 
   config = { 'certificate-authority' => { 'allow-subject-alt-names' => true }}
   path = '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'


### PR DESCRIPTION
Previously, we did not specify the server setting in the puppet.conf but
used `--server <server>` in any invocation that required it. The
`puppetserver ca` cli does not have a `--server` flag like puppet does
(it expects you to have your agent configured to actually talk to your
master correctly). Consequently we need to have the server value set in
our puppet.conf (the default of "puppet" is used by our internal Ops
infra). Previously, the puppetserver ca tool used a default server value
of `certname` rather than `puppet` so it didn't require this.