### PR TITLE
Add nightly alpine builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.bundle
+.meghanada
+target
+vendor
+ext/packaging
+junit
+log
+tmp
+Dockerfile

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,10 +4,16 @@ build_date := $(shell date -u +%FT%T)
 hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
 hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001
 hadolint_container := hadolint/hadolint:latest
+makefile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+makefile_dir := $(dir $(makefile_path))
+agent_ref = $(shell grep puppet_build_version $(makefile_dir)/../acceptance/config/beaker/options.rb | cut -d\" -f2)
+
+BUILD_TARGETS = build-ubuntu
 
 ifeq ($(IS_NIGHTLY),true)
 	dockerfile := Dockerfile.nightly
 	version := puppet6-nightly
+	BUILD_TARGETS += build-alpine
 else
 	version = $(shell echo $(git_describe) | sed 's/-.*//')
 	dockerfile := Dockerfile
@@ -21,21 +27,38 @@ endif
 
 lint:
 ifeq ($(hadolint_available),0)
-	@$(hadolint_command) puppetserver-standalone/$(dockerfile)
-	@$(hadolint_command) puppetserver/$(dockerfile)
+	$(hadolint_command) puppetserver-standalone/$(dockerfile)
+	$(hadolint_command) puppetserver/$(dockerfile)
 else
-	@docker pull $(hadolint_container)
-	@docker run --rm -v $(PWD)/puppetserver-standalone/$(dockerfile):/Dockerfile -i $(hadolint_container) $(hadolint_command) Dockerfile
-	@docker run --rm -v $(PWD)/puppetserver/$(dockerfile):/Dockerfile -i $(hadolint_container) $(hadolint_command) Dockerfile
+	docker pull $(hadolint_container)
+	docker run --rm -v $(PWD)/puppetserver-standalone/$(dockerfile):/Dockerfile -i $(hadolint_container) $(hadolint_command) Dockerfile
+	docker run --rm -v $(PWD)/puppetserver/$(dockerfile):/Dockerfile -i $(hadolint_container) $(hadolint_command) Dockerfile
+	docker run --rm -v $(PWD)/puppetserver-standalone-alpine/Dockerfile:/Dockerfile -i $(hadolint_container) $(hadolint_command) Dockerfile
 endif
 
-build: prep
+puppet-agent/.git/config:
+	@git clone https://github.com/puppetlabs/puppet-agent.git puppet-agent
+
+build-alpine-agent: prep puppet-agent/.git/config
+	@git -C puppet-agent fetch origin
+	@git -C puppet-agent checkout $(agent_ref)
+	@docker build -f puppet-agent/docker/puppet-agent-alpine/Dockerfile puppet-agent -t puppet-agent-alpine:$(agent_ref)
+
+build-alpine: prep build-alpine-agent
+	@docker build --build-arg vcs_ref=$(vcs_ref) --build-arg agent_ref=$(agent_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppetserver-standalone-alpine/Dockerfile --tag puppet/puppetserver-standalone-alpine:$(version) $(makefile_dir)/..
+ifeq ($(IS_LATEST),true)
+	@docker tag puppet/puppetserver-standalone-alpine:$(version) puppet/puppetserver-standalone-alpine:latest
+endif
+
+build-ubuntu: prep
 	@docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppetserver-standalone/$(dockerfile) --tag puppet/puppetserver-standalone:$(version) puppetserver-standalone
 	@docker build --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppetserver/$(dockerfile) --tag puppet/puppetserver:$(version) puppetserver
 ifeq ($(IS_LATEST),true)
 	@docker tag puppet/puppetserver-standalone:$(version) puppet/puppetserver-standalone:latest
 	@docker tag puppet/puppetserver:$(version) puppet/puppetserver:latest
 endif
+
+build: $(BUILD_TARGETS)
 
 test: prep
 	@bundle install --path .bundle/gems

--- a/docker/conf.d/auth.conf
+++ b/docker/conf.d/auth.conf
@@ -1,0 +1,193 @@
+authorization: {
+    version: 1
+    rules: [
+        {
+            # Allow nodes to retrieve their own catalog
+            match-request: {
+                path: "^/puppet/v3/catalog/([^/]+)$"
+                type: regex
+                method: [get, post]
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs catalog"
+        },
+        {
+            # Allow nodes to retrieve the certificate they requested earlier
+            match-request: {
+                path: "/puppet-ca/v1/certificate/"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs certificate"
+        },
+        {
+            # Allow all nodes to access the certificate revocation list
+            match-request: {
+                path: "/puppet-ca/v1/certificate_revocation_list/ca"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs crl"
+        },
+        {
+            # Allow nodes to request a new certificate
+            match-request: {
+                path: "/puppet-ca/v1/certificate_request"
+                type: path
+                method: [get, put]
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs csr"
+        },
+        {
+            # Allow unauthenticated access to the status service endpoint
+            match-request: {
+                path: "/status/v1/services"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/environments"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs environments"
+        },
+        {
+            # Allow nodes to access all file_bucket_files.  Note that access for
+            # the 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_bucket_file"
+                type: path
+                method: [get, head, post, put]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file bucket file"
+        },
+        {
+            # Allow nodes to access all file_content.  Note that access for the
+            # 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_content"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file content"
+        },
+        {
+            # Allow nodes to access all file_metadata.  Note that access for the
+            # 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_metadata"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file metadata"
+        },
+        {
+            # Allow nodes to retrieve only their own node definition
+            match-request: {
+                path: "^/puppet/v3/node/([^/]+)$"
+                type: regex
+                method: get
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs node"
+        },
+        {
+            # Allow nodes to store only their own reports
+            match-request: {
+                path: "^/puppet/v3/report/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs report"
+        },
+        {
+            # Allow nodes to update their own facts
+            match-request: {
+                path: "^/puppet/v3/facts/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs facts"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/status"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/static_file_content"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs static file content"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/tasks"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppet tasks information"
+        },
+        {
+            # Allow all users access to the experimental endpoint
+            # which currently only provides a dashboard web ui.
+            match-request: {
+                path: "/puppet/experimental"
+                type: path
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs experimental"
+        },
+        {
+            # Deny everything else. This ACL is not strictly
+            # necessary, but illustrates the default policy
+            match-request: {
+                path: "/"
+                type: path
+            }
+            deny: "*"
+            sort-order: 999
+            name: "puppetlabs deny all"
+        }
+    ]
+}

--- a/docker/conf.d/global.conf
+++ b/docker/conf.d/global.conf
@@ -1,0 +1,5 @@
+global: {
+    # Path to logback logging configuration file; for more
+    # info, see http://logback.qos.ch/manual/configuration.html
+    logging-config: /etc/puppetlabs/puppetserver/logback.xml
+}

--- a/docker/conf.d/metrics.conf
+++ b/docker/conf.d/metrics.conf
@@ -1,0 +1,53 @@
+# settings related to metrics
+metrics: {
+    # a server id that will be used as part of the namespace for metrics produced
+    # by this server
+    server-id: localhost
+    registries: {
+        puppetserver: {
+            # specify metrics to allow in addition to those in the default list
+            #metrics-allowed: ["compiler.compile.production"]
+
+            reporters: {
+                # enable or disable JMX metrics reporter
+                jmx: {
+                    enabled: true
+                }
+                # enable or disable Graphite metrics reporter
+                #graphite: {
+                #    enabled: true
+                #}
+            }
+
+        }
+    }
+
+    # this section is used to configure settings for reporters that will send
+    # the metrics to various destinations for external viewing
+    reporters: {
+        #graphite: {
+        #    # graphite host
+        #    host: "127.0.0.1"
+        #    # graphite metrics port
+        #    port: 2003
+        #    # how often to send metrics to graphite
+        #    update-interval-seconds: 5
+        #}
+    }
+    metrics-webservice: {
+        jolokia: {
+            # Enable or disable the Jolokia-based metrics/v2 endpoint.
+            # Default is true.
+            # enabled: false
+
+            # Configure any of the settings listed at:
+            #   https://jolokia.org/reference/html/agents.html#war-agent-installation
+            servlet-init-params: {
+                # Specify a custom security policy:
+                #  https://jolokia.org/reference/html/security.html
+                # policyLocation: "file:///etc/puppetlabs/puppetserver/jolokia-access.xml"
+            }
+        }
+    }
+
+}

--- a/docker/conf.d/puppetserver.conf
+++ b/docker/conf.d/puppetserver.conf
@@ -1,0 +1,76 @@
+# configuration for the JRuby interpreters
+jruby-puppet: {
+    # Where the puppet-agent dependency places puppet, facter, etc...
+    # Puppet server expects to load Puppet from this location
+    ruby-load-path: [ /usr/local/lib/site_ruby/2.5.0/, /usr/lib/ruby/vendor_ruby/ ]
+
+    # This setting determines where JRuby will install gems.  It is used for loading gems,
+    # and also by the `puppetserver gem` command line tool.
+    gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems
+
+    # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
+    # the gem-home directory as well as any other directories that gems can be loaded
+    # from (including the vendored gems directory for gems that ship with puppetserver)
+    gem-path: [${jruby-puppet.gem-home}, "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems", "/opt/puppetlabs/puppet/lib/ruby/vendor_gems"]
+
+    # PLEASE NOTE: Use caution when modifying the below settings. Modifying
+    # these settings will change the value of the corresponding Puppet settings
+    # for Puppet Server, but not for the Puppet CLI tools. This likely will not
+    # be a problem with master-var-dir, master-run-dir, or master-log-dir unless
+    # some critical setting in puppet.conf is interpolating the value of one
+    # of the corresponding settings, but it is important that any changes made to
+    # master-conf-dir and master-code-dir are also made to the corresponding Puppet
+    # settings when running the Puppet CLI tools. See
+    # https://docs.puppetlabs.com/puppetserver/latest/puppet_conf_setting_diffs.html#overriding-puppet-settings-in-puppet-server
+    # for more information.
+
+    # (optional) path to puppet conf dir; if not specified, will use
+    # /etc/puppetlabs/puppet
+    master-conf-dir: /etc/puppetlabs/puppet
+
+    # (optional) path to puppet code dir; if not specified, will use
+    # /etc/puppetlabs/code
+    master-code-dir: /etc/puppetlabs/code
+
+    # (optional) path to puppet var dir; if not specified, will use
+    # /opt/puppetlabs/server/data/puppetserver
+    master-var-dir: /opt/puppetlabs/server/data/puppetserver
+
+    # (optional) path to puppet run dir; if not specified, will use
+    # /var/run/puppetlabs/puppetserver
+    master-run-dir: /var/run/puppetlabs/puppetserver
+
+    # (optional) path to puppet log dir; if not specified, will use
+    # /var/log/puppetlabs/puppetserver
+    master-log-dir: /var/log/puppetlabs/puppetserver
+
+    # (optional) maximum number of JRuby instances to allow
+    #max-active-instances: 1
+
+    # (optional) Authorize access to Puppet master endpoints via rules
+    # specified in the legacy Puppet auth.conf file (if true) or via rules
+    # specified in the Puppet Server HOCON-formatted auth.conf (if false or not
+    # specified).
+    #use-legacy-auth-conf: true
+}
+
+# settings related to HTTPS client requests made by Puppet Server
+http-client: {
+    # A list of acceptable protocols for making HTTPS requests
+    #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]
+
+    # A list of acceptable cipher suites for making HTTPS requests
+    #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,
+    #                TLS_RSA_WITH_AES_256_CBC_SHA,
+    #                TLS_RSA_WITH_AES_128_CBC_SHA256,
+    #                TLS_RSA_WITH_AES_128_CBC_SHA]
+
+    # Whether to enable http-client metrics; defaults to 'true'.
+    #metrics-enabled: true
+}
+
+# settings related to profiling the puppet Ruby code
+profiler: {
+    # enable or disable profiling for the Ruby code; defaults to 'true'.
+    #enabled: true
+}

--- a/docker/conf.d/web-routes.conf
+++ b/docker/conf.d/web-routes.conf
@@ -1,0 +1,16 @@
+web-router-service: {
+    # These two should not be modified because the Puppet 4.x agent expects them to
+    # be mounted at these specific paths
+    "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": "/puppet-ca"
+    "puppetlabs.services.master.master-service/master-service": "/puppet"
+    "puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service": ""
+
+    # This controls the mount point for the puppet admin API.
+    "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
+
+    # This controls the mount point for the status API
+    "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
+
+    # This controls the mount point for the metrics API
+    "puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice": "/metrics"
+}

--- a/docker/conf.d/webserver.conf
+++ b/docker/conf.d/webserver.conf
@@ -1,0 +1,6 @@
+webserver: {
+    access-log-config: /etc/puppetlabs/puppetserver/request-logging.xml
+    client-auth: want
+    ssl-host: 0.0.0.0
+    ssl-port: 8140
+}

--- a/docker/puppetserver-standalone-alpine/Dockerfile
+++ b/docker/puppetserver-standalone-alpine/Dockerfile
@@ -61,7 +61,8 @@ RUN apk add --no-cache \
     boost-regex \
     boost-thread \
     java-jffi-native \
-    libc6-compat
+    libc6-compat \
+    tini
 
 COPY docker/conf.d /etc/puppetlabs/puppetserver/conf.d
 COPY ezbake/config/services.d /etc/puppetlabs/puppetserver/services.d
@@ -83,5 +84,7 @@ COPY --from=agent /usr/local/share /usr/local/share
 RUN ln -s /usr/local/lib/libfacter.so.* /usr/local/lib/libfacter.so
 
 EXPOSE 8140
+
+ENTRYPOINT ["/sbin/tini", "--"]
 
 CMD ["java", "-cp", "/puppet-server-release.jar", "clojure.main", "-m", "puppetlabs.trapperkeeper.main", "-b", "/etc/puppetlabs/puppetserver/bootstrap.cfg,/etc/puppetlabs/puppetserver/services.d", "-c", "/etc/puppetlabs/puppetserver/conf.d"]

--- a/docker/puppetserver-standalone-alpine/Dockerfile
+++ b/docker/puppetserver-standalone-alpine/Dockerfile
@@ -1,0 +1,87 @@
+ARG agent_ref
+
+FROM openjdk:8-jdk-alpine as lein
+
+ENV LEIN_ROOT true
+ENV PATH /usr/local/bin:$PATH
+
+RUN apk add --no-cache bash && \
+    mkdir -p /usr/local/bin && \
+    wget -O /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
+    chmod +x /usr/local/bin/lein && \
+    lein
+
+FROM lein as build
+WORKDIR /usr/src/app
+
+RUN apk add --no-cache make && \
+    apk add --no-cache java-jffi-native libc6-compat shadow
+
+COPY project.clj /usr/src/app/
+
+RUN lein deps
+
+COPY . /usr/src/app
+
+# hadolint ignore=SC2046
+RUN lein gem install --install-dir /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems \
+    --no-ri --no-rdoc $(sed 's/ /:/' resources/ext/build-scripts/jruby-gem-list.txt)
+
+RUN lein uberjar
+
+FROM puppet-agent-alpine:${agent_ref} as agent
+
+FROM openjdk:8-jre-alpine
+
+ARG vcs_ref
+ARG build_date
+ARG version="6.0.0"
+ENV PUPPETSERVER_JAVA_ARGS="-Xms512m -Xmx512m"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+  org.label-schema.vendor="Puppet" \
+  org.label-schema.url="https://github.com/puppetlabs/puppetserver" \
+  org.label-schema.name="Puppet Server (No PuppetDB)" \
+  org.label-schema.license="Apache-2.0" \
+  org.label-schema.version="$PUPPET_SERVER_VERSION" \
+  org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver" \
+  org.label-schema.vcs-ref="$vcs_ref" \
+  org.label-schema.build-date="$build_date" \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.dockerfile="/Dockerfile"
+
+RUN apk add --no-cache \
+    curl \
+    shadow \
+    yaml-cpp \
+    boost \
+    boost-program_options \
+    boost-system \
+    boost-filesystem \
+    boost-regex \
+    boost-thread \
+    java-jffi-native \
+    libc6-compat
+
+COPY docker/conf.d /etc/puppetlabs/puppetserver/conf.d
+COPY ezbake/config/services.d /etc/puppetlabs/puppetserver/services.d
+COPY ezbake/system-config/services.d/bootstrap.cfg /etc/puppetlabs/puppetserver/bootstrap.cfg
+COPY docker/puppetserver-standalone/logback.xml /etc/puppetlabs/puppetserver/
+COPY docker/puppetserver-standalone/request-logging.xml /etc/puppetlabs/puppetserver/
+
+RUN mkdir -p /var/run/puppetlabs/puppetserver /var/log/puppetlabs/puppetserver
+
+COPY --from=build /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems
+COPY --from=build /usr/src/app/target/puppet-server-release.jar /
+
+COPY --from=agent /usr/lib/ruby/vendor_ruby /usr/lib/ruby/vendor_ruby
+COPY --from=agent /etc/puppetlabs /etc/puppetlabs
+COPY --from=agent /usr/local/bin /usr/local/bin
+COPY --from=agent /usr/local/lib/site_ruby /usr/local/lib/site_ruby
+COPY --from=agent /usr/local/lib/libfacter.so.* /usr/local/lib/
+COPY --from=agent /usr/local/share /usr/local/share
+RUN ln -s /usr/local/lib/libfacter.so.* /usr/local/lib/libfacter.so
+
+EXPOSE 8140
+
+CMD ["java", "-cp", "/puppet-server-release.jar", "clojure.main", "-m", "puppetlabs.trapperkeeper.main", "-b", "/etc/puppetlabs/puppetserver/bootstrap.cfg,/etc/puppetlabs/puppetserver/services.d", "-c", "/etc/puppetlabs/puppetserver/conf.d"]


### PR DESCRIPTION
This uses the alpine Dockerfile from puppet-agent. For now it's only
nightlies as this isn't present in older puppet-agent versions.