### PR TITLE
(DOC-3180) Add CentOS as a supported platform

### DIFF
--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -21,6 +21,11 @@ Puppet provides official packages that install Puppet Server 6.0 and all of its 
 -   Enterprise Linux 6
 -   Enterprise Linux 7
 
+### CentOS
+
+-   CentOS 6
+-   CentOS 7
+
 ### Debian
 
 -   Debian 8 (Jessie)


### PR DESCRIPTION
This commit adds CentOS as a supported platform, based on DOC-3180. 