### PR TITLE
(TK-473) Update clj-parent to 1.7.18

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.17"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.18"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This contains an update to Jetty to stop reporting the server version in
headers.