### PR TITLE
Merge 5.3.x -> 6.0.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.3.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.4.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This also contains an update to clj-parent for TK-473.