### PR TITLE
(TEST)(maint) Change docker-entrypoint.sh to source from a directory

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -45,6 +45,7 @@ RUN puppet config set autosign true --section master && \
 
 COPY docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
 
 EXPOSE 8140
 

--- a/docker/puppetserver-standalone/docker-entrypoint.d/10-set-permissions.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/10-set-permissions.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+chown -R puppet:puppet /etc/puppetlabs/puppet/
+chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver/

--- a/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# During build, pristine config files get copied to this directory. If
+# they are not in the current container, use these templates as the
+# default
+TEMPLATES=/var/tmp/puppet
+
+cd /etc/puppetlabs/puppet
+for f in auth.conf hiera.yaml puppet.conf puppetdb.conf
+do
+    test -f "$TEMPLATES/$f" && cp -np "$TEMPLATES/$f" .
+done
+cd /

--- a/docker/puppetserver-standalone/docker-entrypoint.d/30-update-puppetdb-conf.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/30-update-puppetdb-conf.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if test -n "${PUPPETDB_SERVER_URLS}" ; then
+  sed -i "s@^server_urls.*@server_urls = ${PUPPETDB_SERVER_URLS}@" /etc/puppetlabs/puppet/puppetdb.conf
+fi

--- a/docker/puppetserver-standalone/docker-entrypoint.d/40-set-certname.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/40-set-certname.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if test -n "${PUPPETSERVER_HOSTNAME}"; then
+  /opt/puppetlabs/bin/puppet config set certname "$PUPPETSERVER_HOSTNAME"
+  /opt/puppetlabs/bin/puppet config set server "$PUPPETSERVER_HOSTNAME"
+fi

--- a/docker/puppetserver-standalone/docker-entrypoint.d/50-setup-autosign.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/50-setup-autosign.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Configure puppet to use a certificate autosign script (if it exists)
+# AUTOSIGN=true|false|path_to_autosign.conf
+if test -n "${AUTOSIGN}" ; then
+  puppet config set autosign "$AUTOSIGN" --section master
+fi

--- a/docker/puppetserver-standalone/docker-entrypoint.d/60-set-dns-alt-names.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/60-set-dns-alt-names.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Allow setting the dns_alt_names for the server's certificate. This
+# setting will only have an effect when the container is started without
+# an existing certificate on the /etc/puppetlabs/puppet volume
+if test -n "${DNS_ALT_NAMES}"; then
+    certname=$(puppet config print certname)
+    if test ! -f "/etc/puppetlabs/puppet/ssl/certs/$certname.pem" ; then
+        puppet config set dns_alt_names "${DNS_ALT_NAMES}" --section master
+    else
+        actual=$(puppet config print dns_alt_names --section master)
+        if test "${DNS_ALT_NAMES}" != "${actual}" ; then
+            echo "Warning: DNS_ALT_NAMES has been changed from the value in puppet.conf"
+            echo "         Remove/revoke the old certificate for this to become effective"
+        fi
+    fi
+fi

--- a/docker/puppetserver-standalone/docker-entrypoint.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.sh
@@ -1,51 +1,11 @@
 #!/bin/bash
 
-chown -R puppet:puppet /etc/puppetlabs/puppet/
-chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver/
+set -e
 
-# During build, pristine config files get copied to this directory. If
-# they are not in the current container, use these templates as the
-# default
-TEMPLATES=/var/tmp/puppet
-
-cd /etc/puppetlabs/puppet
-for f in auth.conf hiera.yaml puppet.conf puppetdb.conf
-do
-    if ! test -f $f ; then
-        cp -p $TEMPLATES/$f .
-    fi
+for f in /docker-entrypoint.d/*.sh; do
+    echo "Running $f"
+    chmod +x "$f"
+    "$f"
 done
-cd /
-
-if test -n "${PUPPETDB_SERVER_URLS}" ; then
-  sed -i "s@^server_urls.*@server_urls = ${PUPPETDB_SERVER_URLS}@" /etc/puppetlabs/puppet/puppetdb.conf
-fi
-
-if test -n "${PUPPETSERVER_HOSTNAME}"; then
-  /opt/puppetlabs/bin/puppet config set certname "$PUPPETSERVER_HOSTNAME"
-  /opt/puppetlabs/bin/puppet config set server "$PUPPETSERVER_HOSTNAME"
-fi
-
-# Configure puppet to use a certificate autosign script (if it exists)
-# AUTOSIGN=true|false|path_to_autosign.conf
-if test -n "${AUTOSIGN}" ; then
-  puppet config set autosign "$AUTOSIGN" --section master
-fi
-
-# Allow setting the dns_alt_names for the server's certificate. This
-# setting will only have an effect when the container is started without
-# an existing certificate on the /etc/puppetlabs/puppet volume
-if test -n "${DNS_ALT_NAMES}"; then
-    fqdn=$(facter fqdn)
-    if test ! -f "/etc/puppetlabs/puppet/ssl/certs/$fqdn.pem" ; then
-        puppet config set dns_alt_names "${DNS_ALT_NAMES}" --section master
-    else
-        actual=$(puppet config print dns_alt_names --section master)
-        if test "${DNS_ALT_NAMES}" != "${actual}" ; then
-            echo "Warning: DNS_ALT_NAMES has been changed from the value in puppet.conf"
-            echo "         Remove/revoke the old certificate for this to become effective"
-        fi
-    fi
-fi
 
 exec /opt/puppetlabs/bin/puppetserver "$@"


### PR DESCRIPTION
Redo of #1904 without the change to `.gitattributes` - just verifying that the newly added `set -e` never allows the `puppetserver-standalone` container to go to `healthy` status given the scripts will no longer end in LF when building in Azure.