### PR TITLE
(CPR-650) Make puppetserver.conf more configurable

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -9,7 +9,7 @@ ENV UBUNTU_CODENAME="xenial"
 ENV PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m"
 ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 ENV PUPPET_HEALTHCHECK_ENVIRONMENT="production"
-ENV PUPPETSERVER_MAX_ACTIVE_INSTANCES=''
+ENV PUPPETSERVER_MAX_ACTIVE_INSTANCES=1
 ENV PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE=0
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -9,6 +9,8 @@ ENV UBUNTU_CODENAME="xenial"
 ENV PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m"
 ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 ENV PUPPET_HEALTHCHECK_ENVIRONMENT="production"
+ENV PUPPETSERVER_MAX_ACTIVE_INSTANCES=''
+ENV PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE=0
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
@@ -38,6 +40,8 @@ RUN apt-get update && \
 COPY puppetserver /etc/default/puppetserver
 COPY logback.xml /etc/puppetlabs/puppetserver/
 COPY request-logging.xml /etc/puppetlabs/puppetserver/
+COPY puppetserver.conf /etc/puppetlabs/puppetserver/conf.d/
+
 
 RUN puppet config set autosign true --section master && \
     cp -pr /etc/puppetlabs/puppet /var/tmp && \

--- a/docker/puppetserver-standalone/docker-entrypoint.d/35-update-puppetserver-conf.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/35-update-puppetserver-conf.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-if test -n "${PUPPETSERVER_MAX_ACTIVE_INSTANCES}"; then
-  sed -i "s/#max-active-instances/max-active-instances/" /etc/puppetlabs/puppetserver/conf.d/puppetserver.conf
-fi

--- a/docker/puppetserver-standalone/docker-entrypoint.d/35-update-puppetserver-conf.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/35-update-puppetserver-conf.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if test -n "${PUPPETSERVER_MAX_ACTIVE_INSTANCES}"; then
+  sed -i "s/#max-active-instances/max-active-instances/" /etc/puppetlabs/puppetserver/conf.d/puppetserver.conf
+fi

--- a/docker/puppetserver-standalone/puppetserver.conf
+++ b/docker/puppetserver-standalone/puppetserver.conf
@@ -1,0 +1,79 @@
+# configuration for the JRuby interpreters
+jruby-puppet: {
+    # Where the puppet-agent dependency places puppet, facter, etc...
+    # Puppet server expects to load Puppet from this location
+    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
+
+    # This setting determines where JRuby will install gems.  It is used for loading gems,
+    # and also by the `puppetserver gem` command line tool.
+    gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems
+
+    # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
+    # the gem-home directory as well as any other directories that gems can be loaded
+    # from (including the vendored gems directory for gems that ship with puppetserver)
+    gem-path: [${jruby-puppet.gem-home}, "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems", "/opt/puppetlabs/puppet/lib/ruby/vendor_gems"]
+
+    # PLEASE NOTE: Use caution when modifying the below settings. Modifying
+    # these settings will change the value of the corresponding Puppet settings
+    # for Puppet Server, but not for the Puppet CLI tools. This likely will not
+    # be a problem with master-var-dir, master-run-dir, or master-log-dir unless
+    # some critical setting in puppet.conf is interpolating the value of one
+    # of the corresponding settings, but it is important that any changes made to
+    # master-conf-dir and master-code-dir are also made to the corresponding Puppet
+    # settings when running the Puppet CLI tools. See
+    # https://docs.puppetlabs.com/puppetserver/latest/puppet_conf_setting_diffs.html#overriding-puppet-settings-in-puppet-server
+    # for more information.
+
+    # (optional) path to puppet conf dir; if not specified, will use
+    # /etc/puppetlabs/puppet
+    master-conf-dir: /etc/puppetlabs/puppet
+
+    # (optional) path to puppet code dir; if not specified, will use
+    # /etc/puppetlabs/code
+    master-code-dir: /etc/puppetlabs/code
+
+    # (optional) path to puppet var dir; if not specified, will use
+    # /opt/puppetlabs/server/data/puppetserver
+    master-var-dir: /opt/puppetlabs/server/data/puppetserver
+
+    # (optional) path to puppet run dir; if not specified, will use
+    # /var/run/puppetlabs/puppetserver
+    master-run-dir: /var/run/puppetlabs/puppetserver
+
+    # (optional) path to puppet log dir; if not specified, will use
+    # /var/log/puppetlabs/puppetserver
+    master-log-dir: /var/log/puppetlabs/puppetserver
+
+    # (optional) maximum number of JRuby instances to allow
+    #max-active-instances: ${PUPPETSERVER_MAX_ACTIVE_INSTANCES}
+    
+    # (optional) number of HTTP requests a given JRuby instance will handle in its lifetime
+    max-requests-per-instance: ${PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE}
+
+    # (optional) Authorize access to Puppet master endpoints via rules
+    # specified in the legacy Puppet auth.conf file (if true) or via rules
+    # specified in the Puppet Server HOCON-formatted auth.conf (if false or not
+    # specified).
+    #use-legacy-auth-conf: true
+}
+
+# settings related to HTTPS client requests made by Puppet Server
+http-client: {
+    # A list of acceptable protocols for making HTTPS requests
+    #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]
+
+    # A list of acceptable cipher suites for making HTTPS requests
+    #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,
+    #                TLS_RSA_WITH_AES_256_CBC_SHA,
+    #                TLS_RSA_WITH_AES_128_CBC_SHA256,
+    #                TLS_RSA_WITH_AES_128_CBC_SHA]
+
+    # Whether to enable http-client metrics; defaults to 'true'.
+    #metrics-enabled: true
+}
+
+# settings related to profiling the puppet Ruby code
+profiler: {
+    # enable or disable profiling for the Ruby code; defaults to 'true'.
+    #enabled: true
+}

--- a/docker/puppetserver-standalone/puppetserver.conf
+++ b/docker/puppetserver-standalone/puppetserver.conf
@@ -45,7 +45,7 @@ jruby-puppet: {
     master-log-dir: /var/log/puppetlabs/puppetserver
 
     # (optional) maximum number of JRuby instances to allow
-    #max-active-instances: ${PUPPETSERVER_MAX_ACTIVE_INSTANCES}
+    max-active-instances: ${PUPPETSERVER_MAX_ACTIVE_INSTANCES}
     
     # (optional) number of HTTP requests a given JRuby instance will handle in its lifetime
     max-requests-per-instance: ${PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE}


### PR DESCRIPTION
This adds env variables `PUPPETSERVER_MAX_ACTIVE_INSTANCES` and
`PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE` to allow `max-active-instances`
and `max-requests-per-instance` to be configured in
/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf.