### PR TITLE
(maint) Updates to support disabling the CA and terminating SSL

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -11,6 +11,7 @@ ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/b
 ENV PUPPET_HEALTHCHECK_ENVIRONMENT="production"
 ENV PUPPETSERVER_MAX_ACTIVE_INSTANCES=1
 ENV PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE=0
+ENV TERMINATE_SSL=false
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -12,6 +12,7 @@ ENV PUPPET_HEALTHCHECK_ENVIRONMENT="production"
 ENV PUPPETSERVER_MAX_ACTIVE_INSTANCES=1
 ENV PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE=0
 ENV TERMINATE_SSL=false
+ENV ENABLE_CA=true
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -52,6 +52,7 @@ RUN puppet config set autosign true --section master && \
 COPY docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
 COPY docker-entrypoint.d /docker-entrypoint.d
+RUN mkdir /docker-entrypoint-additional.d
 
 EXPOSE 8140
 

--- a/docker/puppetserver-standalone/docker-entrypoint.d/70-terminate-ssl.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/70-terminate-ssl.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ "$TERMINATE_SSL" = "true" ]]; then
+  # Change puppetserver settings to allow HTTP traffic since we're terminating SSL.
+  # See https://puppet.com/docs/puppetserver/6.0/external_ssl_termination.html
+  hocon() {
+    /opt/puppetlabs/puppet/lib/ruby/vendor_gems/bin/hocon "$@"
+  }
+
+  cd /etc/puppetlabs/puppetserver/conf.d
+  # Switch webserver to plain http
+  hocon -f webserver.conf unset webserver.ssl-host
+  hocon -f webserver.conf unset webserver.ssl-port
+  hocon -f webserver.conf set webserver.host 0.0.0.0
+  hocon -f webserver.conf set webserver.port 8140
+  # Turn off legacy auth
+  hocon -f puppetserver.conf set jruby-puppet.use-legacy-auth-conf false
+  # Use HTTP headers for client auth
+  hocon -f auth.conf set authorization.allow-header-cert-info true
+fi

--- a/docker/puppetserver-standalone/docker-entrypoint.d/80-ca.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/80-ca.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+certname=$(puppet config print certname)
+
+if [[ "$ENABLE_CA" = "true" ]]; then
+  cd /etc/puppetlabs/puppet/ssl
+  # we are the master runnning the CA
+  if [[ ! -f ca/ca_key.pem ]]; then
+    echo "initializing the CA"
+    puppetserver ca setup --ca-name "Pupperware on $certname" \
+      --certname "$certname" --subject-alt-names "$DNS_ALT_NAMES"
+  fi
+  cd /
+else
+  # we are just an ordinary compiler
+  echo "turning off CA"
+  cat > /etc/puppetlabs/puppetserver/services.d/ca.cfg <<EOF
+puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service
+EOF
+fi

--- a/docker/puppetserver-standalone/docker-entrypoint.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.sh
@@ -3,9 +3,24 @@
 set -e
 
 for f in /docker-entrypoint.d/*.sh; do
-    echo "Running $f"
-    chmod +x "$f"
-    "$f"
+  echo "Running $f"
+  chmod +x "$f"
+  "$f"
 done
+
+if [[ -n "$(ls -A /docker-entrypoint-additional.d)" ]]; then
+  for f in /docker-entrypoint-additional.d/*; do
+    case "$f" in
+      *.sh)
+        echo "Running $f"
+        chmod +x "$f"
+        "$f"
+        ;;
+      *)
+        echo "ignoring $f, it's missing a .sh extension"
+        ;;
+    esac
+  done
+fi
 
 exec /opt/puppetlabs/bin/puppetserver "$@"

--- a/docker/puppetserver-standalone/healthcheck.sh
+++ b/docker/puppetserver-standalone/healthcheck.sh
@@ -5,11 +5,17 @@ set -e
 
 hostname=$(puppet config print certname)
 
+if [[ "$TERMINATE_SSL" = "true" ]]; then
+  url="http://${hostname}:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test"
+else
+  url="https://${hostname}:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test"
+fi
+
 curl --fail -H 'Accept: pson' \
 --resolve "${hostname}:8140:127.0.0.1" \
 --cert   $(puppet config print hostcert) \
 --key    $(puppet config print hostprivkey) \
 --cacert $(puppet config print localcacert) \
-https://${hostname}:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
+"${url}" \
 |  grep -q '"is_alive":true' \
 || exit 1


### PR DESCRIPTION
This is largely trying to get the work from https://github.com/puppetlabs/pupperware/pull/24 integrated into the base puppetserver container.