### PR TITLE
(maint) Remove leftover lein dependency

### DIFF
--- a/dev/dev_tools.clj
+++ b/dev/dev_tools.clj
@@ -28,8 +28,7 @@
             [puppetlabs.metrics :as metrics]
             [puppetlabs.metrics.http :as http-metrics]
             [puppetlabs.trapperkeeper.services :as tk-services]
-            [puppetlabs.services.puppet-profiler.puppet-profiler-core :as puppet-profiler-core]
-            [leiningen.core.main :as lein])
+            [puppetlabs.services.puppet-profiler.puppet-profiler-core :as puppet-profiler-core])
   (:import (java.io File)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
As part of removing the developer dashboard, we removed the need to
depend on lein as a dev dependency. It was removed from project.clj at
that time, but not from dev_tools.clj, meaning that the repl can no
longer be started on the 5.3.x series. In the 6.x series, this dep was
removed as part of the move to figwheel-sidecar. This commit removes it
from dev_tools.clj in the older branch.