### PR TITLE
(SERVER-2418) Update clj-parent to 2.5.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.4.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.5.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit updates clj-parent to 2.5.0, which brings in
jackson-databind 2.9.8, resolving some security issues.