### PR TITLE
Mergeup and clj-parent bump

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -157,7 +157,7 @@ namespace :spec do
       gem_install_bundler = <<-CMD
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
       lein run -m org.jruby.Main \
-      -e 'load "META-INF/jruby.home/bin/gem"' install -i '#{TEST_GEMS_DIR}' --no-rdoc --no-ri bundler --source '#{GEM_SOURCE}'
+      -e 'load "META-INF/jruby.home/bin/gem"' install -i '#{TEST_GEMS_DIR}' bundler -v '< 2' --no-document --source '#{GEM_SOURCE}'
       CMD
       sh gem_install_bundler
 

--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -46,10 +46,12 @@ To use a different temporary directory, you can set the following JVM property:
 -Djava.io.tmpdir=/some/other/temporary/directory
 ```
 
-When Puppet Server is installed from packages, this property should be added
-to the `JAVA_ARGS` variable defined in either `/etc/sysconfig/puppetserver`
-or `/etc/default/puppetserver`, depending on upon your distribution. Note that
-the service will need to be restarted in order for this change to take effect.
+When Puppet Server is installed from packages, add this property
+to the `JAVA_ARGS` and `JAVA_ARGS_CLI` variables defined in either
+`/etc/sysconfig/puppetserver` or `/etc/default/puppetserver`, depending on
+your distribution. Invocations of the `gem`, `ruby`, and `irb` subcommands
+use the updated `JAVA_ARGS_CLI` on their next invocation. The service will
+need to be restarted in order to re-read the `JAVA_ARGS` variable.
 
 ## Puppet Server Master Fails to Connect to Load-Balanced Servers with Different SSL Certificates
 

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.4.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.5.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This updates clj-parent to 2.5.0 for the jackson-databind CVE update.