### PR TITLE
(SERVER-2421) Update clj-parent to 2.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.5.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.6.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This downgrades dynapath to 0.2.5, fixing server reloads.