### PR TITLE
(DOCS) Add Puppet Server 6.2.0 release notes

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -10,6 +10,20 @@ canonical: "/puppetserver/latest/release_notes.html"
 [puppetserver.conf]: ./config_file_puppetserver.markdown
 [product.conf]: ./config_file_product.markdown
 
+## Puppet Server 6.2.0
+
+ Released 23 January 2019.
+
+ This release contains new features and resolved issues.
+
+ ### New features
+
+ - The EZBake configs now allow you to specify `JAVA_ARGS_CLI`, which is used when using `puppetserver` subcommands to configure Java differently from what is needed for the service. This was used by the CLI before, but as an environment variable only, not as an EZBake config option. [SERVER-2399](https://tickets.puppetlabs.com/browse/SERVER-2399)
+ 
+ ### Resolved issues
+
+-  A dependency issue caused puppetserver 6.1.0 to fail with OpenJDK 11. This has been fixed and Puppet Server packages can now start under Java 11. [SERVER-2404](https://tickets.puppetlabs.com/browse/SERVER-2404)
+ 
 ## Puppet Server 6.1.0
 
 Released 18 December 2018


### PR DESCRIPTION
This commit adds the release notes for Puppet Server 6.2.0.