### PR TITLE
(Docs) profiler-output-file setting incorrectly documented

### DIFF
--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -78,7 +78,7 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
     * `compile-mode`: Optional, experimental. Used to control JRuby's "CompileMode", which may improve performance. The default value is `off`, which is the most conservative value. A value of `jit` enables JRuby's "just-in-time" compilation of Ruby code. A value of `force` causes JRuby to attempt to pre-compile all Ruby code.
 
-    * `profiling-mode`: Optional. Used to enable JRuby's profiler for service startup and set it to one of the supported modes. The default value is `off`, but it can be set to one of `api`, `flat`, `graph`, `html`, `json`, `off`, and `service`. See [ruby-prof](https://github.com/ruby-prof/ruby-prof/blob/master/README.rdoc#reports) for details on what the various modes do.
+    * `profiler-mode`: Optional. Used to enable JRuby's profiler for service startup and set it to one of the supported modes. The default value is `off`, but it can be set to one of `api`, `flat`, `graph`, `html`, `json`, `off`, and `service`. See [ruby-prof](https://github.com/ruby-prof/ruby-prof/blob/master/README.rdoc#reports) for details on what the various modes do.
 
     * `profiling-output-file`: Optional. Used to set the output file to direct JRuby profiler output. Should be a fully qualified path writable by the service user. If not set will default to a random name inside the service working directory.
 


### PR DESCRIPTION
The documentation for the jruby profiling output file setting is incorrect. The current documentation shows profiling-output-file while the actual setting name is profiler-output-file. (https://github.com/puppetlabs/jruby-utils/blob/d8a8f9be9499f78356f5874d41b16cbeb65cc758/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj#L167)

This is also true for 5.3 onwards.