### PR TITLE
(PDB-4232) Pin apt module to 6.2.1 when installing puppetDB

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -14,6 +14,13 @@ step 'Install Puppet Release Repo' do
   install_puppetlabs_release_repo_on(master, 'puppet5')
 end
 
+step 'Install latest working version of apt module' do
+  # Version 6.3.0 of the apt module broke the puppetdb module.
+  # Until that is fix, pin the apt module to the previous version.
+  # See PDB-4232.
+  on(master, puppet('module install puppetlabs-apt --version 6.2.1'))
+end
+
 step 'Install PuppetDB module' do
   on(master, puppet('module install puppetlabs-puppetdb'))
 end


### PR DESCRIPTION
The 6.3.0 release of the puppetlabs-apt module broke the PDB module's
ability to install PDB on Debian. Until a solution can be found to
resolve this, this commit pins the version of the apt module in our
tests to allow PDB to install on Debian.