### PR TITLE
(maint) Update the version of puppet 4 we test against

### DIFF
--- a/acceptance/suites/pre_suite/puppet4_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet4_compat/70_install_puppet.rb
@@ -15,7 +15,7 @@ nonmaster_agents.each { |agent|
 
 step "Install Legacy Puppet Agents."
 
-default_puppet_version = '1.10.1'
+default_puppet_version = '1.10.15'
 puppet_version = ENV['PUPPET_LEGACY_VERSION']
 if not puppet_version
   logger.info "PUPPET_LEGACY_VERSION is not set!"


### PR DESCRIPTION
A recent change to beaker-puppet requires metadata that puppet-agent 1.10.1
packages did not have. This commit updates our compat tests to the most
recent puppet-agent 1.10, containing Puppet 4. This version has the
metadata, and is probably more representative of the compatability we
want to support.