### PR TITLE
(SERVER-2431) Update clj-parent to 1.7.21

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.19"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.21"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This brings in a new BouncyCastle, fixing a security vulnerability.