### PR TITLE
Override Emacs CIDER nREPL dependency injection

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((clojure-mode . ((cider-inject-dependencies-at-jack-in . ()))))


### PR DESCRIPTION
CIDER, the interactive Clojure development environment, by default injects a
dependency on nREPL. Due to the dependency on nREPL 0.2.13 in project.clj and
`:pedantic :abort` this means that starting CIDER fails with a default config.

This tiny PR adds a `.dir-locals.el` which overrides the
`cider-inject-dependencies-at-jack-in` and sets it to `nil`.