### PR TITLE
Revert "(PDB-4232) Pin apt module to 6.2.1 when installing puppetDB"

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -14,13 +14,6 @@ step 'Install Puppet Release Repo' do
   install_puppetlabs_release_repo_on(master, 'puppet5')
 end
 
-step 'Install latest working version of apt module' do
-  # Version 6.3.0 of the apt module broke the puppetdb module.
-  # Until that is fix, pin the apt module to the previous version.
-  # See PDB-4232.
-  on(master, puppet('module install puppetlabs-apt --version 6.2.1'))
-end
-
 step 'Install PuppetDB module' do
   on(master, puppet('module install puppetlabs-puppetdb'))
 end


### PR DESCRIPTION
Reverts puppetlabs/puppetserver#1952

The modules causing the dependency cycle have been updated and the problem is fixed.