### PR TITLE
(MAINT) Replace deprecated --link usage

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,3 +1,4 @@
+NAMESPACE ?= puppet
 git_describe = $(shell git describe)
 vcs_ref := $(shell git rev-parse HEAD)
 build_date := $(shell date -u +%FT%T)
@@ -31,8 +32,10 @@ ifeq ($(hadolint_available),0)
 	@$(hadolint_command) puppetserver/$(dockerfile)
 else
 	@docker pull $(hadolint_container)
-	@docker run --rm -v $(PWD)/puppetserver-standalone/$(dockerfile):/Dockerfile -i $(hadolint_container) $(hadolint_command) Dockerfile
-	@docker run --rm -v $(PWD)/puppetserver/$(dockerfile):/Dockerfile -i $(hadolint_container) $(hadolint_command) Dockerfile
+	@docker run --rm -v $(PWD)/puppetserver-standalone/$(dockerfile):/Dockerfile \
+		-i $(hadolint_container) $(hadolint_command) Dockerfile
+	@docker run --rm -v $(PWD)/puppetserver/$(dockerfile):/Dockerfile \
+		-i $(hadolint_container) $(hadolint_command) Dockerfile
 endif
 
 build: prep
@@ -43,25 +46,30 @@ build: prep
 		--build-arg version=$(version) \
 		--build-arg pupperware_analytics_stream=$(PUPPERWARE_ANALYTICS_STREAM) \
 		--file puppetserver-standalone/$(dockerfile) \
-		--tag puppet/puppetserver-standalone:$(version) \
+		--tag $(NAMESPACE)/puppetserver-standalone:$(version) \
 		puppetserver-standalone
 	@docker build \
+		--build-arg namespace=$(NAMESPACE) \
 		--build-arg vcs_ref=$(vcs_ref) \
 		--build-arg build_date=$(build_date) \
 		--build-arg version=$(version) \
 		--build-arg pupperware_analytics_stream=$(PUPPERWARE_ANALYTICS_STREAM) \
 		--file puppetserver/$(dockerfile) \
-		--tag puppet/puppetserver:$(version) \
+		--tag $(NAMESPACE)/puppetserver:$(version) \
 		puppetserver
 ifeq ($(IS_LATEST),true)
-	@docker tag puppet/puppetserver-standalone:$(version) puppet/puppetserver-standalone:latest
-	@docker tag puppet/puppetserver:$(version) puppet/puppetserver:latest
+	@docker tag $(NAMESPACE)/puppetserver-standalone:$(version) \
+		$(NAMESPACE)/puppetserver-standalone:latest
+	@docker tag $(NAMESPACE)/puppetserver:$(version) \
+		$(NAMESPACE)/puppetserver:latest
 endif
 
 test: prep
 	@bundle install --path .bundle/gems
-	@PUPPET_TEST_DOCKER_IMAGE=puppet/puppetserver-standalone:$(version) bundle exec rspec --options puppetserver-standalone/.rspec spec
-	@PUPPET_TEST_DOCKER_IMAGE=puppet/puppetserver:$(version) bundle exec rspec --options puppetserver/.rspec spec
+	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/puppetserver-standalone:$(version) \
+		bundle exec rspec --options puppetserver-standalone/.rspec spec
+	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/puppetserver:$(version) \
+		bundle exec rspec --options puppetserver/.rspec spec
 
 publish: prep
 	@docker push puppet/puppetserver-standalone:$(version)


### PR DESCRIPTION
Explicitly create and destroy our own docker network when running
container spec tests.

Hopefully this results in fewer network transients in CI as we were
seeing problems with resolving `puppet:8140`.

----

Also in this PR ...

(MAINT) Configurable image name

Allow the Docker image namespace "puppet" (i.e. puppet/puppetserver) to
be configurable, which makes it easier for local development of the
image.

We don't want to push these images to DockerHub ever, so we don't honor
the namespace override in the `make publish` target.