### PR TITLE
Merge 5.3.x -> 6.0.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -180,7 +180,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.9.3"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.9.6"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 nil]]}


### PR DESCRIPTION
Merge conflicts were resolved by maintaining the state of the current branch.