### PR TITLE
Revert "(RE-12077) Bump to ezbake 1.9.6"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -177,7 +177,7 @@
                                                [puppetlabs/puppetserver ~ps-version :exclusions [puppetlabs/jruby-deps]]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.9.6"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.9.3"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 nil]]}


### PR DESCRIPTION
This reverts commit 38fa24729e6006e33690c6e1feea00aa610567a1.
Tests started to fail after this bump, so reverting until we sort it out.