### PR TITLE
(maint) Update auth.conf for v4 catalog endpoints

### DIFF
--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -10,7 +10,18 @@ authorization: {
             }
             allow: "$1"
             sort-order: 500
-            name: "puppetlabs catalog"
+            name: "puppetlabs v3 catalog from agents"
+        },
+        {
+            # Allow services to retrieve catalogs on behalf of others
+            match-request: {
+                path: "^/puppet/v4/catalog/?$"
+                type: regex
+                method: post
+            }
+            deny: "*"
+            sort-order: 500
+            name: "puppetlabs v4 catalog for services"
         },
         {
             # Allow nodes to retrieve the certificate they requested earlier


### PR DESCRIPTION
Previously, the v4 endpoints were undeclared, so by default deny all.

However for documentation, testing, and later management purposes it is
valuable to have the two endpoint calling schemes spelled out in the
default auth.conf.