### PR TITLE
(SERVER-2475) Return logs from compilation with response

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -727,6 +727,7 @@
       (schema/optional-key "facts") {(schema/required-key "values") {schema/Any schema/Any}}
       (schema/optional-key "job_id") schema/Int
       (schema/optional-key "environment") schema/Str
+      (schema/optional-key "options") {(schema/optional-key "capture_logs") schema/Bool}
       (schema/optional-key "classes") [schema/Any]
       (schema/optional-key "parameters") {schema/Any schema/Any}}
      parameters)

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -1,4 +1,5 @@
 require 'puppet/server'
+require 'puppet/server/log_collector'
 
 module Puppet
   module Server
@@ -43,7 +44,7 @@ module Puppet
       def capture_logs(&block)
         logs = []
         result = nil
-        log_dest = Puppet::Test::LogCollector.new(logs)
+        log_dest = Puppet::Server::LogCollector.new(logs)
         Puppet::Util::Log.with_destination(log_dest) do
           result = yield
         end

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -19,11 +19,9 @@ module Puppet
         # Default to capturing errors and warnings from compiles
         options['capture_logs'] = true unless options['capture_logs']
 
-        processed_hash = convert_java_args_to_ruby(request_data)
-
         if options['capture_logs']
           catalog, logs = capture_logs do
-            compile_catalog(processed_hash)
+            compile_catalog(request_data)
           end
 
           { catalog: catalog, logs: logs }
@@ -84,20 +82,6 @@ module Puppet
         node.add_server_facts(@server_facts)
         node
       end
-
-      def convert_java_args_to_ruby(hash)
-        Hash[hash.collect do |key, value|
-          # Stolen and modified from params_to_ruby in handler.rb
-          if value.java_kind_of?(Java::ClojureLang::IPersistentMap)
-            [key, convert_java_args_to_ruby(value)]
-          elsif value.java_kind_of?(Java::JavaUtil::List)
-            [key, value.to_a]
-          else
-            [key, value]
-          end
-        end]
-      end
-
 
       # @return Puppet::Node::Facts facts, Hash trusted_facts
       def process_facts(request_data)

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -49,11 +49,11 @@ module Puppet
         end
 
         log_entries = logs.map do |log|
-          begin
-            log.to_data_hash
-          rescue
-            log
-          end
+          log.to_data_hash
+        end.select do |log|
+          # Filter out debug messages, which may be verbose and
+          # contain sensitive data
+          log['level'] == 'warning' || log['level'] == 'error'
         end
 
         return result, log_entries

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -26,16 +26,9 @@ module Puppet
       def capture_logs(&block)
         logs = []
         result = nil
-        Puppet::Util::Log.close_all
         log_dest = Puppet::Test::LogCollector.new(logs)
-        begin
-          Puppet::Util::Log.newdestination(log_dest)
-          Puppet::Util::Log.with_destination(log_dest) do
-            result = yield
-          end
-        ensure
-          Puppet::Util::Log.newdestination(:console)
-          Puppet::Util::Log.close(log_dest)
+        Puppet::Util::Log.with_destination(log_dest) do
+          result = yield
         end
 
         log_entries = logs.map do |log|

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -16,8 +16,6 @@ module Puppet
       #                if capturing logs was enabled
       def compile(request_data)
         options = request_data['options'] || {}
-        # Default to capturing errors and warnings from compiles
-        options['capture_logs'] = true unless options['capture_logs']
 
         if options['capture_logs']
           catalog, logs = capture_logs do

--- a/src/ruby/puppetserver-lib/puppet/server/log_collector.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/log_collector.rb
@@ -1,0 +1,26 @@
+module Puppet
+  module Server
+    # Log to an array, just for testing.
+    class LogCollector
+      def initialize(logs)
+        @logs = logs
+      end
+
+      def <<(value)
+        @logs << value
+      end
+    end
+
+    Puppet::Util::Log.newdesttype :collector do
+      match "Puppet::Server::LogCollector"
+
+      def initialize(messages)
+        @messages = messages
+      end
+
+      def handle(msg)
+        @messages << msg
+      end
+    end
+  end
+end

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -64,7 +64,7 @@ class Puppet::Server::Master
   end
 
   def compileCatalog(request_data)
-    @catalog_compiler.compile(request_data)
+    @catalog_compiler.compile(convert_java_args_to_ruby(request_data))
   end
 
   def getClassInfoForEnvironment(env)
@@ -129,6 +129,19 @@ class Puppet::Server::Master
   end
 
   private
+
+  def convert_java_args_to_ruby(hash)
+    Hash[hash.collect do |key, value|
+      # Stolen and modified from params_to_ruby in handler.rb
+      if value.java_kind_of?(Java::ClojureLang::IPersistentMap)
+        [key, convert_java_args_to_ruby(value)]
+      elsif value.java_kind_of?(Java::JavaUtil::List)
+        [key, value.to_a]
+      else
+        [key, value]
+      end
+    end]
+  end
 
   def self.getModules(env)
     env.modules.collect do |mod|


### PR DESCRIPTION
This commit adds code to wrap the catalog compilation that captures any
logging emitted during the compilation and returns it along with the
catalog. Normally, this logging would just go into the main puppetserver
log, and would be interleaved with any other compilations going on,
making it very hard to tell where the messages were coming from. This
way, the logs are tied to the catalog whose compilation produced them.

Note that this means that the logs will NOT also go to Puppet Server's
normal log destination.