### PR TITLE
(RE-12077) Bump to ezbake 1.9.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -177,7 +177,7 @@
                                                [puppetlabs/puppetserver ~ps-version :exclusions [puppetlabs/jruby-deps]]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.9.3"]]
+                      :plugins [[puppetlabs/lein-ezbake "1.9.7"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 nil]]}


### PR DESCRIPTION
This commit bumps the ezbake version to 1.9.7, which includes support for el 8.