### PR TITLE
(SERVER-2478) Do not require `infra_serials` file on startup

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list.txt
+++ b/resources/ext/build-scripts/mri-gem-list.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.2.1
+puppetserver-ca 1.3.1

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -224,7 +224,7 @@
   "The set of SSL related files that are required on the CA."
   [enable-infra-crl]
   (union #{:cacert :cacrl :cakey :cert-inventory :serial}
-     (if enable-infra-crl #{:infra-node-serials-path :infra-nodes-path :infra-crl-path} #{})))
+     (if enable-infra-crl #{:infra-nodes-path :infra-crl-path} #{})))
 
 (def max-ca-ttl
   "The longest valid duration for CA certs, in seconds. 50 standard years."


### PR DESCRIPTION
This commit updates the list of required CA files to no longer include
the infra_serials file. This file is always updated (or created) when
puppetserver starts and the infra CRL feature is enabled, so it is
unnecessary to require it to be present beforehand. This requirement was
unnecessarily causing issues with upgrade workflows.