### PR TITLE
(SERVER-2468) Use node indirection in v4/catalog

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
@@ -62,7 +62,6 @@ describe Puppet::Server::Compiler do
         let(:options) { { 'prefer_requested_environment' => true } }
 
         it 'uses the environment in the request' do
-          node = compiler.create_node(request_data)
           expect(node.environment.name).to eq(:fancy)
         end
       end

--- a/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
@@ -1,8 +1,71 @@
 require 'puppet/server/compiler'
 
 describe Puppet::Server::Compiler do
+  let(:compiler) { Puppet::Server::Compiler.new }
 
-  it 'can be instantiated' do
-    Puppet::Server::Compiler.new
+  context 'when creating a node' do
+    let(:certname) { 'mynode.best.website' }
+    let(:environment) { 'production' }
+    let(:persistence) { { 'facts' => false, 'catalog' => false } }
+    let(:facts) { { 'values' => { 'hello' => 'hi' } } }
+    let(:trusted_facts) { { 'values' => { 'secret' => 'm3ss4g3' } } }
+    let(:transaction_uuid) { '3542fd19-86df-424a-a2b1-31c6600a4ad9' }
+    let(:options) { {} }
+
+    let(:request_data) do
+      {
+        'certname' => certname,
+        'environment' => environment,
+        'persistence' => persistence,
+        'facts' => facts,
+        'trusted_facts' => trusted_facts,
+        'transaction_uuid' => transaction_uuid,
+        'options' => options
+      }
+    end
+
+    let(:node) { compiler.create_node(request_data) }
+
+    before(:each) do
+      Puppet::Node.indirection.terminus_class = :plain
+    end
+
+    it 'the node has facts set' do
+      expect(node.facts.values).to eq(facts['values'])
+    end
+
+    it 'the node has trusted data set' do
+      expect(node.trusted_data).to eq(trusted_facts['values'])
+    end
+
+    it 'the node has server facts set' do
+      expect(node.parameters).to include('serverversion' => Puppet.version.to_s)
+      expect(node.server_facts).to include('serverversion' => Puppet.version.to_s)
+    end
+
+    context 'the classified node has a different environment' do
+      let(:environment) { 'fancy' }
+
+      before(:each) do
+        FileUtils.mkdir_p(File.join(Puppet[:environmentpath], environment))
+
+        Puppet::Node.indirection.expects(:find).returns(
+          Puppet::Node.new(certname, environment: 'production')
+        )
+      end
+
+      it 'by default uses the classified environment' do
+        expect(node.environment.name).to eq(:production)
+      end
+
+      context 'and prefer_requested_environment is set' do
+        let(:options) { { 'prefer_requested_environment' => true } }
+
+        it 'uses the environment in the request' do
+          node = compiler.create_node(request_data)
+          expect(node.environment.name).to eq(:fancy)
+        end
+      end
+    end
   end
 end

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -729,7 +729,8 @@
       (schema/optional-key "job_id") schema/Int
       (schema/optional-key "transaction_uuid") schema/Str
       (schema/optional-key "environment") schema/Str
-      (schema/optional-key "options") {(schema/optional-key "capture_logs") schema/Bool}
+      (schema/optional-key "options") {(schema/optional-key "capture_logs") schema/Bool
+                                       (schema/optional-key "prefer_requested_environment") schema/Bool}
       (schema/optional-key "classes") [schema/Any]
       (schema/optional-key "parameters") {schema/Any schema/Any}}
      parameters)

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -40,10 +40,12 @@ module Puppet
         prefer_requested_environment =
           request_data.dig('options', 'prefer_requested_environment')
 
-        node = Puppet::Node.indirection.find(certname,
-                                             environment: environment,
-                                             facts: facts,
-                                             transaction_uuid: transaction_uuid)
+        node = Puppet.override(trusted_information: trusted_facts) do
+          Puppet::Node.indirection.find(certname,
+                                        environment: environment,
+                                        facts: facts,
+                                        transaction_uuid: transaction_uuid)
+        end
 
         if prefer_requested_environment
           node.environment = environment


### PR DESCRIPTION
In order to use the classifier (or other terminus such as an ENC) we need
to use the indirector to retrieve the node. Whether to use the requested
environment is controlled by a new parameter in the request:

```json
{"options": {"prefer_requested_environment": <boolean>}}
```