### PR TITLE
(SERVER-2479) Plumb code_id through to the v4 catalog endpoint

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -736,7 +736,8 @@
 
 (schema/defn ^:always-validate
   v4-catalog-fn :- IFn
-  [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)]
+  [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
+   current-code-id-fn :- IFn]
   (fn [request]
     (let [request-options (decode-catalog-post-body (slurp (:body request)))]
       {:status 200
@@ -744,12 +745,15 @@
        :body (json/encode
               (jruby-protocol/compile-catalog jruby-service
                                               (:jruby-instance request)
-                                              request-options))})))
+                                              (assoc request-options
+                                                     "code_id"
+                                                     (current-code-id-fn (jruby-request/get-environment-from-request request)))))})))
 
 (schema/defn ^:always-validate
   v4-catalog-handler :- IFn
-  [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)]
-  (-> (v4-catalog-fn jruby-service)
+  [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
+   current-code-id-fn :- IFn]
+  (-> (v4-catalog-fn jruby-service current-code-id-fn)
       (jruby-request/wrap-with-jruby-instance jruby-service)
       jruby-request/wrap-with-error-handling))
 
@@ -840,14 +844,15 @@
 (schema/defn ^:always-validate
   v4-routes :- bidi-schema/RoutePair
   [clojure-request-wrapper :- IFn
-   jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)]
-  (let [v4-catalog-handler (v4-catalog-handler jruby-service)]
+   jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
+   current-code-id-fn :- IFn]
+  (let [v4-catalog-handler (v4-catalog-handler jruby-service current-code-id-fn)]
     (comidi/context
           "/v4"
           (comidi/wrap-routes
            (comidi/routes
             (comidi/POST "/catalog" request
-                         (v4-catalog-handler request) ))
+                         (v4-catalog-handler request)))
            clojure-request-wrapper))))
 
 (schema/defn ^:always-validate
@@ -976,7 +981,8 @@
               current-code-id-fn
               environment-class-cache-enabled)
    (v4-routes clojure-request-wrapper
-              jruby-service)))
+              jruby-service
+              current-code-id-fn)))
 
 (schema/defn ^:always-validate
   wrap-middleware :- IFn

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -726,7 +726,6 @@
                                            (schema/required-key "catalog") schema/Bool}
       (schema/optional-key "trusted_facts") {(schema/required-key "values") {schema/Str schema/Any}}
       (schema/optional-key "facts") {(schema/required-key "values") {schema/Str schema/Any}}
-      (schema/optional-key "job_id") schema/Int
       (schema/optional-key "transaction_uuid") schema/Str
       (schema/optional-key "environment") schema/Str
       (schema/optional-key "options") {(schema/optional-key "capture_logs") schema/Bool}

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -44,7 +44,7 @@ module Puppet
         # Note: if we change this to use the indirection we may no longer
         # need to call `save_catalog` below. See its documentation for
         # further info.
-        catalog = Puppet::Parser::Compiler.compile(node, request_data['job_id'])
+        catalog = Puppet::Parser::Compiler.compile(node, request_data['code_id'])
 
         if persist['catalog']
           save_catalog(catalog, save_options)


### PR DESCRIPTION
Before this PR, the schema had a `job_id` that was propagated through to be used at compile time. However, all the code indicates that the proper name should be `code_id`,  and is furthermore determined by the `current-code-id-fn`.

This PR removes that `job_id` from the schema and plumbs the code_id function through to the v4 catalog endpoint.