### PR TITLE
fixing text file busy error at entrypoint when using nfs

### DIFF
--- a/docker/puppetserver-standalone/docker-entrypoint.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 for f in /docker-entrypoint.d/*.sh; do
     echo "Running $f"
     chmod +x "$f"
+    sync
     "$f"
 done
 


### PR DESCRIPTION
When using docker/kubernetes cluster depending on the underlying storage layer you could stumble upon the following which prevents puppet from starting:
```
Running /docker-entrypoint.d/10-analytics.sh
/docker-entrypoint.sh: /docker-entrypoint.d/10-analytics.sh: /bin/sh: bad interpreter: Text file busy`
```
Adding sync in the entrypoint fixes the issue.