### PR TITLE
(maint) Install nss on RHEL 8

### DIFF
--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -21,7 +21,11 @@ step "Upgrade nss to version that is hopefully compatible with jdk version puppe
     nss_package_name="nss"
   end
   if nss_package_name
-    master.upgrade_package(nss_package_name)
+    if master['platform'] != 'el-8-x86_64'
+      master.upgrade_package(nss_package_name)
+    else
+      master.install_package(nss_package_name)
+    end
   else
     logger.warn("Don't know what nss package to use for #{variant} so not installing one")
   end


### PR DESCRIPTION
Our image of RHEL 8 does not appear to have nss installed by default
this will conditionally install or upgrade depending on platform.

---

I haven't checked whether or not nss is necessary. The pre-suite still fails locally for me after the currently failing check because libfacter isn't available for JRuby.

Will check if nss is necessary and if the libfacter problem is specifically a RHEL8 problem