### PR TITLE
(SERVER-2497) Save job_id along with catalog

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
@@ -10,6 +10,7 @@ describe Puppet::Server::Compiler do
     let(:facts) { { 'values' => { 'hello' => 'hi' } } }
     let(:trusted_facts) { { 'values' => { 'secret' => 'm3ss4g3' } } }
     let(:transaction_uuid) { '3542fd19-86df-424a-a2b1-31c6600a4ad9' }
+    let(:job_id) { '1234' }
     let(:options) { {} }
 
     let(:request_data) do
@@ -20,6 +21,7 @@ describe Puppet::Server::Compiler do
         'facts' => facts,
         'trusted_facts' => trusted_facts,
         'transaction_uuid' => transaction_uuid,
+        'job_id' => job_id,
         'options' => options
       }
     end

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -726,6 +726,7 @@
                                            (schema/required-key "catalog") schema/Bool}
       (schema/optional-key "trusted_facts") {(schema/required-key "values") {schema/Str schema/Any}}
       (schema/optional-key "facts") {(schema/required-key "values") {schema/Str schema/Any}}
+      (schema/optional-key "job_id") schema/Str
       (schema/optional-key "transaction_uuid") schema/Str
       (schema/optional-key "environment") schema/Str
       (schema/optional-key "options") {(schema/optional-key "capture_logs") schema/Bool

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -86,7 +86,10 @@ module Puppet
 
       def compile_catalog(request_data)
         persist = request_data['persistence']
-        save_options = request_data.slice('environment', 'transaction_id', 'certname')
+        save_options = request_data.slice('environment',
+                                          'transaction_id',
+                                          'certname',
+                                          'job_id')
 
         node = create_node(request_data)
 
@@ -155,6 +158,7 @@ module Puppet
       # @option options [String] environment    Required
       # @option options [String] certname       Required
       # @option options [String] transaction_id Optional
+      # @option options [String] job_id         Optional
       def save_catalog(catalog, options)
         if Puppet::Resource::Catalog.indirection.cache?
           terminus = Puppet::Resource::Catalog.indirection.cache


### PR DESCRIPTION
This commit passes the `job_id` from the v4 catalog request along to
PuppetDB to be saved alongside the catalog.