### PR TITLE
(maint) Disable PDB on RHEL 8

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -64,7 +64,8 @@ module PuppetServerExtensions
     [
       /debian-7/,
       /debian-8/,
-      /el/, # includes cent6,7 and redhat6,7
+      /el-6/,
+      /el-7/,
       /ubuntu-12/,
       /ubuntu-14/,
       /ubuntu-1604/,


### PR DESCRIPTION
This commit updates the list of supported PDB platforms to explicitly
exclude RHEL 8, because the puppetdb module is not currently supported
on that platform. This should be undone once RHEL 8 support is added to
the module.