### PR TITLE
(maint) Install python3 on RHEL 8

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -204,6 +204,9 @@ end
 
 step 'SETUP: Find Python executable'
   if on(master, 'which python', :acceptable_exit_codes => [0, 1]).exit_code == 1
+    if master['platform'] == 'el-8-x86_64'
+      master.install_package('python3')
+    end
     python_bin = 'python3'
   else
     python_bin = 'python'


### PR DESCRIPTION
RHEL 8 does not come with a python installation by default, so unlike on
other platforms, neither `python` nor `python3` is available as an
executable. This commit updates the test that uses python to install
python3 prior to attempting to use it.

The long term fix here is to remove Python from our test suite, see
SERVER-2501.