### PR TITLE
(maint) Require environment in v4 catalog endpoint

### DIFF
--- a/acceptance/suites/tests/catalog/v4_catalog.rb
+++ b/acceptance/suites/tests/catalog/v4_catalog.rb
@@ -65,6 +65,7 @@ PUPPETCONF
 
   base_request = {
     "certname" => compile_subject,
+    "environment" => "production",
     "persistence" => {
       "facts" => false,
       "catalog" => false

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -724,11 +724,11 @@
      {(schema/required-key "certname") schema/Str
       (schema/required-key "persistence") {(schema/required-key "facts") schema/Bool
                                            (schema/required-key "catalog") schema/Bool}
+      (schema/required-key "environment") schema/Str
       (schema/optional-key "trusted_facts") {(schema/required-key "values") {schema/Str schema/Any}}
       (schema/optional-key "facts") {(schema/required-key "values") {schema/Str schema/Any}}
       (schema/optional-key "job_id") schema/Str
       (schema/optional-key "transaction_uuid") schema/Str
-      (schema/optional-key "environment") schema/Str
       (schema/optional-key "options") {(schema/optional-key "capture_logs") schema/Bool
                                        (schema/optional-key "prefer_requested_environment") schema/Bool}
       (schema/optional-key "classes") [schema/Any]

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -35,7 +35,7 @@ module Puppet
       def create_node(request_data)
         facts, trusted_facts = process_facts(request_data)
         certname = request_data['certname']
-        requested_environment = request_data['environment'] || 'production'
+        requested_environment = request_data['environment']
         transaction_uuid = request_data['transaction_uuid']
         prefer_requested_environment =
           request_data.dig('options', 'prefer_requested_environment')

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -412,6 +412,7 @@
                                :uri "/v4/catalog"
                                :content-type "application/json"}
                               (ring-mock/body (json/encode {:certname "foo"
+                                                            :environment "production"
                                                             :persistence
                                                             {:catalog true
                                                              :facts true}}))))]


### PR DESCRIPTION
Previously we were not requiring the caller of the v4 catalog endpoint
to provide an environment, assuming that the caller would know when it
was needed and supply the environment in those cases.

This led to the need to create defaults, either a specific environment
like "production" or Puppet's ":current_environment" within its context.
Neither of these are good defaults as default environments could be set
by users to some value besides production and
Puppet.lookup(:current_environment) has undefined, non-thread safe
semantics.

The simplest and most backwards compatible behavior is to always require
and environment from the endpoint caller.

This may be loosened in the future if we can define more concrete
workflows that may break backwards compatibility.