### PR TITLE
(DOCS) Add Puppet Server 6.0.4 release notes

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -10,6 +10,15 @@ canonical: "/puppetserver/latest/release_notes.html"
 [puppetserver.conf]: ./config_file_puppetserver.markdown
 [product.conf]: ./config_file_product.markdown
 
+## Puppet Server 6.0.4
+
+Released 26 March 2019
+
+### Bug fixes
+
+- Updated bouncy-castle to 1.60 to fix security issues. [SERVER-2431](https://tickets.puppetlabs.com/browse/SERVER-2431)
+
+
 ## Puppet Server 6.0.2
 
 Released 23 October 2018


### PR DESCRIPTION
This commit adds the release notes for Puppet Server 6.0.4.