### PR TITLE
(maint) Use rspec expectations instead of mocha

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,9 +9,9 @@ ACCEPTANCE_ROOT = ENV['ACCEPTANCE_ROOT'] ||
 BEAKER_OPTIONS_FILE = File.join(ACCEPTANCE_ROOT, 'config', 'beaker', 'options.rb')
 PUPPET_SRC = File.join(PROJECT_ROOT, 'ruby', 'puppet')
 PUPPET_LIB = File.join(PROJECT_ROOT, 'ruby', 'puppet', 'lib')
-PUPPET_SPEC = File.join(PROJECT_ROOT, 'ruby', 'puppet', 'spec')
 FACTER_LIB = File.join(PROJECT_ROOT, 'ruby', 'facter', 'lib')
 PUPPET_SERVER_RUBY_SRC = File.join(PROJECT_ROOT, 'src', 'ruby', 'puppetserver-lib')
+PUPPET_SERVER_RUBY_SPEC = File.join(PROJECT_ROOT, 'spec')
 PUPPET_SUBMODULE_PATH = File.join('ruby','puppet')
 # Branch of puppetserver for which to update submodule pins
 PUPPETSERVER_BRANCH = ENV['PUPPETSERVER_BRANCH'] || '5.1.x'
@@ -197,7 +197,7 @@ task :spec => ["spec:init"] do
     BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
     GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
     lein #{profile} run -m org.jruby.Main \
-      -I'#{PUPPET_LIB}' -I'#{PUPPET_SPEC}' -I'#{FACTER_LIB}' -I'#{PUPPET_SERVER_RUBY_SRC}' \
+      -I'#{PUPPET_SERVER_RUBY_SPEC}' -I'#{PUPPET_LIB}' -I'#{FACTER_LIB}' -I'#{PUPPET_SERVER_RUBY_SRC}' \
       ./spec/run_specs.rb
   CMD
   sh run_rspec_with_jruby

--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -65,7 +65,7 @@ describe Puppet::Server::Execution do
       end
 
       it "should support environment variables" do
-        result = test_execute(%(FOO=bar python -c "import os; print os.environ['FOO']"))
+        result = test_execute(%(FOO=bar sh -c 'echo $FOO'))
         expect(result).to be_a Puppet::Util::Execution::ProcessOutput
         expect(result).to eq "bar\n"
         expect(result.exitstatus).to eq 0

--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -4,11 +4,11 @@ describe 'Puppet::Server::PuppetConfig' do
   context "initializing Puppet Server" do
     context "setting the Puppet log level from logback" do
       let(:logger) do
-        stub("Logger", isDebugEnabled: false, isInfoEnabled: true, isWarnEnabled: false, isErrorEnabled: false)
+        double("Logger", isDebugEnabled: false, isInfoEnabled: true, isWarnEnabled: false, isErrorEnabled: false)
       end
 
       before :each do
-        Puppet::Server::Logger.expects(:get_logger).returns(logger)
+        expect(Puppet::Server::Logger).to receive(:get_logger).and_return(logger)
         Puppet::Server::PuppetConfig.initialize_puppet({})
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+require 'puppet'
+require 'puppet/test/test_helper'
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+
+  Puppet::Test::TestHelper.initialize
+
+  config.before(:all) do
+    Puppet::Test::TestHelper.before_all_tests
+  end
+
+  config.after(:all) do
+    Puppet::Test::TestHelper.after_all_tests
+  end
+
+  config.before(:each) do
+    Puppet::Test::TestHelper.before_each_test
+  end
+
+  config.after(:each) do
+    Puppet::Test::TestHelper.after_each_test
+  end
+end


### PR DESCRIPTION
(maint) Use rspec expectations instead of mocha

This adds our own spec_helper file and moves us to using rspec expectations instead of mocha.

I also backported a test fix from master.