### PR TITLE
(maint) Use rspec expectations instead of mocha

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,9 +9,9 @@ ACCEPTANCE_ROOT = ENV['ACCEPTANCE_ROOT'] ||
 BEAKER_OPTIONS_FILE = File.join(ACCEPTANCE_ROOT, 'config', 'beaker', 'options.rb')
 PUPPET_SRC = File.join(PROJECT_ROOT, 'ruby', 'puppet')
 PUPPET_LIB = File.join(PROJECT_ROOT, 'ruby', 'puppet', 'lib')
-PUPPET_SPEC = File.join(PROJECT_ROOT, 'ruby', 'puppet', 'spec')
 FACTER_LIB = File.join(PROJECT_ROOT, 'ruby', 'facter', 'lib')
 PUPPET_SERVER_RUBY_SRC = File.join(PROJECT_ROOT, 'src', 'ruby', 'puppetserver-lib')
+PUPPET_SERVER_RUBY_SPEC = File.join(PROJECT_ROOT, 'spec')
 PUPPET_SUBMODULE_PATH = File.join('ruby','puppet')
 # Branch of puppetserver for which to update submodule pins
 PUPPETSERVER_BRANCH = ENV['PUPPETSERVER_BRANCH'] || 'master'
@@ -193,7 +193,7 @@ task :spec => ["spec:init"] do
     BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
     GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
     lein run -m org.jruby.Main \
-      -I'#{PUPPET_LIB}' -I'#{PUPPET_SPEC}' -I'#{FACTER_LIB}' -I'#{PUPPET_SERVER_RUBY_SRC}' \
+      -I'#{PUPPET_SERVER_RUBY_SPEC}' -I'#{PUPPET_LIB}' -I'#{FACTER_LIB}' -I'#{PUPPET_SERVER_RUBY_SRC}' \
       ./spec/run_specs.rb
   CMD
   sh run_rspec_with_jruby

--- a/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
@@ -53,7 +53,7 @@ describe Puppet::Server::Compiler do
       end
 
       it 'by default uses the classified environment' do
-        Puppet::Node.indirection.expects(:find).returns(
+        expect(Puppet::Node.indirection).to receive(:find).and_return(
           Puppet::Node.new(certname, environment: 'production')
         )
 
@@ -64,17 +64,16 @@ describe Puppet::Server::Compiler do
         let(:facts) { nil }
 
         it 'requests facts from pdb after classifying and attempts to classify again' do
-          pdb_environments = sequence('pdb environments')
-          Puppet::Node::Facts.indirection.terminus.stubs(:name).returns(:puppetdb)
-          compiler.expects(:get_facts_from_pdb)
+          allow(Puppet::Node::Facts.indirection.terminus).to receive(:name).and_return(:puppetdb)
+          expect(compiler).to receive(:get_facts_from_pdb)
                   .with(certname, 'fancy')
-                  .in_sequence(pdb_environments)
-                  .returns(Puppet::Node::Facts.new(certname))
-          compiler.expects(:get_facts_from_pdb)
+                  .ordered
+                  .and_return(Puppet::Node::Facts.new(certname))
+          expect(compiler).to receive(:get_facts_from_pdb)
                   .with(certname, 'production')
-                  .in_sequence(pdb_environments)
-                  .returns(Puppet::Node::Facts.new(certname))
-          Puppet::Node.indirection.expects(:find).returns(
+                  .ordered
+                  .and_return(Puppet::Node::Facts.new(certname))
+          expect(Puppet::Node.indirection).to receive(:find).and_return(
             Puppet::Node.new(certname, environment: 'production')
           ).twice
 
@@ -85,25 +84,25 @@ describe Puppet::Server::Compiler do
           %w[foo bar baz qux].each do |env|
             FileUtils.mkdir_p(File.join(Puppet[:environmentpath], env))
           end
-          environments = sequence('environments')
-          Puppet::Node::Facts.indirection.terminus.stubs(:name).returns(:puppetdb)
-          compiler.stubs(:get_facts_from_pdb).returns(Puppet::Node::Facts.new(certname))
 
-          Puppet::Node.indirection.expects(:find).returns(
+          allow(Puppet::Node::Facts.indirection.terminus).to receive(:name).and_return(:puppetdb)
+          allow(compiler).to receive(:get_facts_from_pdb).and_return(Puppet::Node::Facts.new(certname))
+
+          expect(Puppet::Node.indirection).to receive(:find).and_return(
             Puppet::Node.new(certname, environment: 'production')
-          ).in_sequence(environments)
-          Puppet::Node.indirection.expects(:find).returns(
+          ).ordered
+          expect(Puppet::Node.indirection).to receive(:find).and_return(
             Puppet::Node.new(certname, environment: 'foo')
-          ).in_sequence(environments)
-          Puppet::Node.indirection.expects(:find).returns(
+          ).ordered
+          expect(Puppet::Node.indirection).to receive(:find).and_return(
             Puppet::Node.new(certname, environment: 'bar')
-          ).in_sequence(environments)
-          Puppet::Node.indirection.expects(:find).returns(
+          ).ordered
+          expect(Puppet::Node.indirection).to receive(:find).and_return(
             Puppet::Node.new(certname, environment: 'baz')
-          ).in_sequence(environments)
-          Puppet::Node.indirection.expects(:find).returns(
+          ).ordered
+          expect(Puppet::Node.indirection).to receive(:find).and_return(
             Puppet::Node.new(certname, environment: 'qux')
-          ).in_sequence(environments)
+          ).ordered
 
           expect { compiler.create_node(request_data) }
             .to raise_error(Puppet::Error, /environment didn't stabilize/)
@@ -114,7 +113,7 @@ describe Puppet::Server::Compiler do
         let(:options) { { 'prefer_requested_environment' => true } }
 
         it 'uses the environment in the request' do
-          Puppet::Node.indirection.expects(:find).returns(
+          expect(Puppet::Node.indirection).to receive(:find).and_return(
             Puppet::Node.new(certname, environment: 'production')
           )
 

--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -4,11 +4,11 @@ describe 'Puppet::Server::PuppetConfig' do
   context "initializing Puppet Server" do
     context "setting the Puppet log level from logback" do
       let(:logger) do
-        stub("Logger", isDebugEnabled: false, isInfoEnabled: true, isWarnEnabled: false, isErrorEnabled: false)
+        double("Logger", isDebugEnabled: false, isInfoEnabled: true, isWarnEnabled: false, isErrorEnabled: false)
       end
 
       before :each do
-        Puppet::Server::Logger.expects(:get_logger).returns(logger)
+        expect(Puppet::Server::Logger).to receive(:get_logger).and_return(logger)
         Puppet::Server::PuppetConfig.initialize_puppet({})
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+require 'puppet'
+require 'puppet/test/test_helper'
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+
+  Puppet::Test::TestHelper.initialize
+
+  config.before(:all) do
+    Puppet::Test::TestHelper.before_all_tests
+  end
+
+  config.after(:all) do
+    Puppet::Test::TestHelper.after_all_tests
+  end
+
+  config.before(:each) do
+    Puppet::Test::TestHelper.before_each_test
+  end
+
+  config.after(:each) do
+    Puppet::Test::TestHelper.after_each_test
+  end
+end


### PR DESCRIPTION
This adds our own spec_helper file and moves us to using rspec
expectations instead of mocha.