### PR TITLE
(maint) Update to Docker builds for Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,10 +20,17 @@ steps:
     #
     # Azure
     #
-    Write-Host "`n`n$line`nAzure`n$line`n"
-    Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
-      ConvertTo-Json -Depth 10 |
-      Write-Host
+    $assetTag = Get-WmiObject -class Win32_SystemEnclosure -namespace root\CIMV2 |
+      Select -ExpandProperty SMBIOSAssetTag
+
+    # only Azure VMs have this hard-coded DMI value
+    if ($assetTag -eq '7783-7084-3265-9085-8269-3286-77')
+    {
+      Write-Host "`n`n$line`nAzure`n$line`n"
+      Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
+        ConvertTo-Json -Depth 10 |
+        Write-Host
+    }
     #
     # Docker
     #

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,7 @@ steps:
     Write-Host "`n`n$line`nRuby`n$line`n"
     ruby --version
     gem --version
+    gem env
     bundle --version
     #
     # Environment

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -61,6 +61,8 @@ function Invoke-ContainerTest(
 
   bundle install --path .bundle/gems
   $ENV:PUPPET_TEST_DOCKER_IMAGE = "$Namespace/${Name}:$Version"
+  Write-Host "Testing against image: ${ENV:PUPPET_TEST_DOCKER_IMAGE}"
+  bundle exec rspec --version
   bundle exec rspec --options $Name/.rspec spec
 
   Pop-Location

--- a/docker/puppetserver-standalone/.rspec
+++ b/docker/puppetserver-standalone/.rspec
@@ -1,3 +1,4 @@
+--require spec_helper
 --format RspecJunitFormatter
 --out puppetserver-standalone/TEST-rspec.xml
 --format documentation

--- a/docker/puppetserver/.rspec
+++ b/docker/puppetserver/.rspec
@@ -1,3 +1,4 @@
+--require spec_helper
 --format RspecJunitFormatter
 --out puppetserver/TEST-rspec.xml
 --format documentation

--- a/docker/spec/puppetserver_spec.rb
+++ b/docker/spec/puppetserver_spec.rb
@@ -26,6 +26,7 @@ describe 'puppetserver container' do
     network_opt = File::ALT_SEPARATOR.nil? ? '' : '--driver=nat'
 
     @network = %x(docker network create #{network_opt} puppetserver_test_network).chomp
+    fail 'Failed to create network' unless $?.exitstatus == 0
 
     @container = %x(docker run --rm --detach \
                --env DNS_ALT_NAMES=puppet \
@@ -34,6 +35,8 @@ describe 'puppetserver container' do
                --network #{@network} \
                --hostname puppet.test \
                #{@image}).chomp
+    fail 'Failed to create puppet.test' unless $?.exitstatus == 0
+
     @compiler = %x(docker run --rm --detach \
                --env DNS_ALT_NAMES=puppet \
                --env PUPPERWARE_DISABLE_ANALYTICS=true \
@@ -43,6 +46,7 @@ describe 'puppetserver container' do
                --name puppet-compiler.test \
                --hostname puppet-compiler.test \
                #{@image}).chomp
+    fail 'Failed to create compiler' unless $?.exitstatus == 0
   end
 
   after(:all) do

--- a/docker/spec/puppetserver_spec.rb
+++ b/docker/spec/puppetserver_spec.rb
@@ -4,23 +4,7 @@ require 'rspec/core'
 require 'open3'
 
 describe 'puppetserver container' do
-
-  def run_command(command)
-    stdout_string = ''
-    status = nil
-    Open3.popen3(command) do |stdin, stdout, stderr, wait_thread|
-      Thread.new do
-        stdout.each { |l| stdout_string << l; STDOUT.puts l }
-      end
-      Thread.new do
-        stderr.each { |l| STDOUT.puts l }
-      end
-      stdin.close
-      status = wait_thread.value
-    end
-
-    { status: status, stdout: stdout_string }
-  end
+  include Helpers
 
   def puppetserver_health_check(container)
     result = run_command("docker inspect \"#{container}\" --format '{{.State.Health.Status}}'")

--- a/docker/spec/spec_helper.rb
+++ b/docker/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+require 'open3'
+
+module Helpers
+  def run_command(command)
+    stdout_string = ''
+    status = nil
+
+    Open3.popen3(command) do |stdin, stdout, stderr, wait_thread|
+      Thread.new do
+        stdout.each { |l| stdout_string << l; STDOUT.puts l }
+      end
+      Thread.new do
+        stderr.each { |l| STDOUT.puts l }
+      end
+
+      stdin.close
+      status = wait_thread.value
+    end
+
+    { status: status, stdout: stdout_string }
+  end
+end


### PR DESCRIPTION
- Emit more debug output in Azure / Docker builds
- Add some extra code to fail fast if network or containers can't be created for tests
- Change %x to a new helper command based on popen that emits stderr / captures stdout / returns error code
- Only read Azure metadata uri when in Azure VM