### PR TITLE
(maint) If consul is enabled, run the http healthcheck every second

### DIFF
--- a/docker/puppetserver-standalone/docker-entrypoint.d/90-consul.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/90-consul.sh
@@ -15,7 +15,7 @@ if [ "$CONSUL_ENABLED" = "true" ]; then
     {
       "http": "https://${HOSTNAME}:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test",
       "tls_skip_verify": true,
-      "interval": "30s",
+      "interval": "1s",
       "deregister_critical_service_after": "5m"
     }
   ]


### PR DESCRIPTION
This check is super lightweight, so we should run it every second to
avoid unnecessary latency with consul knowing what services/hosts are
available