### PR TITLE
(maint) Use publicly available version of rbac-client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.21"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.23"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
We inadvertently made this version of puppetserver require a version of
rbac-client that was not publicly available.