### PR TITLE
(maint) Do not run code_commands test on Debian

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -1,6 +1,7 @@
 require 'json'
 
 skip_test 'SKIP: This test should only run in puppetserver FOSS.' if options[:type] == 'pe'
+skip_test 'SKIP: The required puppet module does not support Debian 8+' if master['platform'] =~ /debian/
 
 test_name 'SERVER-1118: Validate code-id-command feature in FOSS'
 


### PR DESCRIPTION
The Code command scripts test uses the puppetlabs/git module to set up a
FOSS code manager like environment. This module is deprecated and does
not support any of our currently supported versions of Debian. It does
however support RHEL variants that we will continue to support for the
long term.

Unfortunately, there is no clear cut replacement for the
functionality of the puppetlabs/git module and would require two
different modules to replace. At this point it is much more productive
to use the existing test setup on RedHat 7 for several more years before
surveying how we want to move off of puppetlabs/git.