### PR TITLE
(CPR-676) Move storeconfigs settings to the 'master' config section

### DIFF
--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -30,9 +30,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN puppet config set storeconfigs_backend puppetdb --section main && \
-    puppet config set storeconfigs true --section main && \
-    puppet config set reports puppetdb --section main && \
+RUN puppet config set storeconfigs_backend puppetdb --section master && \
+    puppet config set storeconfigs true --section master && \
+    puppet config set reports puppetdb --section master && \
     cp -p /etc/puppetlabs/puppet/puppet.conf /var/tmp/puppet
 
 COPY puppetdb.conf /var/tmp/puppet/


### PR DESCRIPTION
If storeconfigs are configured in the 'main' section in puppet.conf, the
run will always use cached facts. This commits move those to the
'master' section so agent runs do not used cached facts.