### PR TITLE
(maint) Fix 'Text file busy' error in Dockerfile 

### DIFF
--- a/docker/puppetserver-standalone/docker-entrypoint.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.sh
@@ -2,9 +2,11 @@
 
 set -e
 
+chmod +x /docker-entrypoint.d/*.sh
+# sync prevents aufs from sometimes returning EBUSY if you exec right after a chmod
+sync
 for f in /docker-entrypoint.d/*.sh; do
     echo "Running $f"
-    chmod +x "$f"
     "$f"
 done
 


### PR DESCRIPTION
Supercedes #2007 

 - In rare situations running chmod and the script directly afterwards
   causes a 'Text file busy' error

 - See moby/moby#13594 for details

 - Similar change made to PDB at
   https://github.com/puppetlabs/puppetdb/pull/2887