### PR TITLE
(DOCS) clarify usage of once, since in docs

### DIFF
--- a/documentation/compatibility_with_puppet_agent.markdown
+++ b/documentation/compatibility_with_puppet_agent.markdown
@@ -11,7 +11,7 @@ canonical: "/puppetserver/latest/compatibility_with_puppet_agent.html"
 [deprecated]: https://docs.puppet.com/puppetserver/2.2/deprecated_features.html
 [Puppet Server `auth.conf` documentation]: ./config_file_auth.markdown
 
-Since version 2.1, Puppet Server can serve configurations to both Puppet 4 and Puppet 3 agents. Once your Puppet 3 nodes work with a newer Puppet Server, start upgrading them to Puppet 4.
+In version 2.1 and later, Puppet Server can serve configurations to both Puppet 4 and Puppet 3 agents. After your Puppet 3 nodes work with a newer Puppet Server, start upgrading them to Puppet 4.
 
 ## Preparing Puppet 3 Nodes for Puppet Server 2
 

--- a/documentation/config_file_auth_migration.markdown
+++ b/documentation/config_file_auth_migration.markdown
@@ -101,7 +101,7 @@ Next, let's convert each component of the deprecated rule to the new HOCON forma
     ...
     ```
 
-2.  Next, add its type to the section's [`type`](./config_file_auth.markdown#match-request) setting. Since this is a literal string path, the type is `path`.
+2.  Next, add its type to the section's [`type`](./config_file_auth.markdown#match-request) setting. Because this is a literal string path, the type is `path`.
 
     ``` hocon
     ...

--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -18,7 +18,7 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
 ## Settings
 
-> **Note:** Under most conditions, you won't change the default settings for `master-conf-dir` or `master-code-dir`. However, if you do, also change the equivalent Puppet settings (`confdir` or `codedir`) to ensure that commands like `puppetserver ca` and `puppet module` use the same directories as Puppet Server. You must also specify the non-default `confdir` when running commands, since that setting must be set before Puppet tries to find its config file.
+> **Note:** Under most conditions, you won't change the default settings for `master-conf-dir` or `master-code-dir`. However, if you do, also change the equivalent Puppet settings (`confdir` or `codedir`) to ensure that commands like `puppetserver ca` and `puppet module` use the same directories as Puppet Server. You must also specify the non-default `confdir` when running commands, because that setting must be set before Puppet tries to find its config file.
 
 * The `jruby-puppet` settings configure the interpreter.
 
@@ -54,7 +54,7 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
 
         JRuby flushing can be useful for working around buggy module code that would otherwise cause memory leaks, but it slightly reduces performance whenever a new JRuby instance reloads all of the Puppet Ruby code. If memory leaks from module code are not an issue in your deployment, the default value of 0 performs best.
 
-    * `max-queued-requests`: Optional. The maximum number of requests that may be queued waiting to borrow a JRuby from the pool. Once this limit is exceeded, a 503 "Service Unavailable" response will be returned for all new requests until the queue drops below the limit. If `max-retry-delay` is set to a positive value, then the 503 responses will include a `Retry-After` header indicating a random sleep time after which the client may retry the request. The default is 0, which disables the queue limit.
+    * `max-queued-requests`: Optional. The maximum number of requests that may be queued waiting to borrow a JRuby from the pool. When this limit is exceeded, a 503 "Service Unavailable" response will be returned for all new requests until the queue drops below the limit. If `max-retry-delay` is set to a positive value, then the 503 responses will include a `Retry-After` header indicating a random sleep time after which the client may retry the request. The default is 0, which disables the queue limit.
       > **Note:** Don't use this solution if your managed infrastructure includes a significant number of agents older than Puppet 5.3. Older agents treat a 503 response as a failure, which ends their runs, causing groups of older agents to schedule their next runs at the same time, creating a thundering herd problem.
 
     * `max-retry-delay`: Optional. Sets the upper limit for the random sleep set as a `Retry-After` header on 503 responses returned when `max-queued-requests` is enabled. A value of 0 will cause the `Retry-After` header to be omitted. Default is 1800 seconds which corresponds to the default run interval of the Puppet daemon.

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -127,4 +127,4 @@ To enable SSLv3 at the JRE layer, first create a properties file (for example, `
 jdk.tls.disabledAlgorithms=
 ~~~
 
-Once this property file exists, update `JAVA_ARGS`, typically defined in `/etc/sysconfig/puppetserver`, and add the option `-Djava.security.properties=/etc/sysconfig/puppetserver-properties/java.security`. This will configure the JVM to override the `jdk.tls.disabledAlgorithms` property defined in `$JAVA_HOME/jre/lib/security/java.security`. Restart the `puppetserver` service for this setting to take effect.
+After this property file exists, update `JAVA_ARGS`, typically defined in `/etc/sysconfig/puppetserver`, and add the option `-Djava.security.properties=/etc/sysconfig/puppetserver-properties/java.security`. This will configure the JVM to override the `jdk.tls.disabledAlgorithms` property defined in `$JAVA_HOME/jre/lib/security/java.security`. Restart the `puppetserver` service for this setting to take effect.

--- a/documentation/dev_debugging.markdown
+++ b/documentation/dev_debugging.markdown
@@ -50,7 +50,7 @@ source with `lein run` rather than `lein repl`:
     $ lein run --config ~/.puppetserver/puppetserver.conf
 
 The `lein run` command will start the server in the foreground as normal.
-`pry` or `ruby-debug` will display an input prompt once the relevant statement
+`pry` or `ruby-debug` will display an input prompt when the relevant statement
 is reached.  Expect to see the normal `lein run` output and then the Ruby REPL
 will present itself as compared to `lein repl` which presents a prompt early in
 the process lifecycle.  In this way the "ruby repl" is more of a breakpoint

--- a/documentation/dev_running_from_source.markdown
+++ b/documentation/dev_running_from_source.markdown
@@ -214,7 +214,7 @@ Use a command like the one below to run an agent against your running puppetserv
 
 Note that a system installed Puppet Agent is ok for use with
 source-based PuppetDB and Puppet Server. The `--confdir` above
-specifies the same confdir that Puppet Server is using. Since the
+specifies the same confdir that Puppet Server is using. Because the
 Puppet Agent and Puppet Server instances are both using the same
 confdir, they're both using the same certificates as well. This
 alleviates the need to sign certificates as a separate step.
@@ -363,7 +363,7 @@ PuppetDB conf.d directory. The update would look like:
     ssl-key = <home dir>/.puppetlabs/etc/puppet/ssl/private_keys/<MASTERHOST>.pem
     ssl-ca-cert = <home dir>/.puppetlabs/etc/puppet/ssl/certs/ca.pem
 
-Once the SSL config is in place, start (or restart) PuppetDB:
+After the SSL config is in place, start (or restart) PuppetDB:
 
     lein run services -c <path to PDB config>/conf.d
 

--- a/documentation/http_api_index.markdown
+++ b/documentation/http_api_index.markdown
@@ -121,7 +121,7 @@ Puppet provides a [JSON schema for error objects](https://puppet.com/docs/puppet
 
 The certificate authority (CA) API contains all of the endpoints supporting Puppet's public key infrastructure (PKI) system.
 
-The CA V1 endpoints share the same basic format as the Puppet V3 API, since they are based on the interface of Puppet's indirector-based CA. However, Puppet Server's CA is implemented in Clojure. Both have a different prefix and version than the V3 API.
+The CA V1 endpoints share the same basic format as the Puppet V3 API, because they are based on the interface of Puppet's indirector-based CA. However, Puppet Server's CA is implemented in Clojure. Both have a different prefix and version than the V3 API.
 
 These endpoints follow the form `/puppet-ca/v1/:indirection/:key?environment=:environment`, where:
 

--- a/documentation/http_certificate_revocation_list.md
+++ b/documentation/http_certificate_revocation_list.md
@@ -44,7 +44,7 @@ None
 
 ### Examples
 
-Since the returned CRL always looks similar to the human eye, the successful examples are each followed by an openssl
+Because the returned CRL always looks similar to the human eye, the successful examples are each followed by an openssl
 decoding of the CRL PEM file.
 
 #### Empty revocation list

--- a/documentation/puppet-api/v3/task_detail.json
+++ b/documentation/puppet-api/v3/task_detail.json
@@ -31,7 +31,7 @@
             "type": "number"
           },
           "uri": {
-            "description": "Information on how to request the file contents from a Puppet master node. This will only provide a relative path, since clients may want to request from a compile master instead of the primary master.",
+            "description": "Information on how to request the file contents from a Puppet master node. This will only provide a relative path, because clients may want to request from a compile master instead of the primary master.",
             "type": "object",
             "properties": {
               "path": {

--- a/documentation/puppet-api/v3/task_detail.markdown
+++ b/documentation/puppet-api/v3/task_detail.markdown
@@ -36,7 +36,7 @@ the regular expression `\A[a-z][a-z0-9_]*\z` (excluding extensions).
 
 ### Will error if the tasks implementations are invalid
 
-Since the returning file information requires parsing metadata and finding
+Because the returning file information requires parsing metadata and finding
 implementation files this endpoint will error if the metadata cannot be parsed
 or the implementation content is invalid.
 

--- a/documentation/puppet_conf_setting_diffs.markdown
+++ b/documentation/puppet_conf_setting_diffs.markdown
@@ -234,7 +234,7 @@ While it is not as critical to keep `master-var-dir`, `master-run-dir`, and `mas
 Puppet settings, please note that this applies to these settings as well.
 
 Also, please note that these configuration differences also apply to the interpolation of the `confdir`, `codedir`, `vardir`, `rundir`, and `logdir`
-settings in your `puppet.conf` file. So, take the above example, wherein you set `master-code-dir` to `/etc/my-puppet-code-dir`. Since the
+settings in your `puppet.conf` file. So, take the above example, wherein you set `master-code-dir` to `/etc/my-puppet-code-dir`. Because the
 `basemodulepath` setting is by default `$codedir/modules:/opt/puppetlabs/puppet/modules`, then Puppet Server would use
 `/etc/my-puppet-code-dir/modules:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting, whereas the `puppet module` tool would use
 `/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting.

--- a/documentation/puppet_server_metrics.markdown
+++ b/documentation/puppet_server_metrics.markdown
@@ -131,7 +131,7 @@ The [sample Grafana dashboard][] provides what we think is an interesting starti
 
 -   **Request durations:** This graph breaks down the average response times for different types of requests made by Puppet agents. This indicates how expensive catalog and report requests are compared to the other types of requests. It also provides a way to see changes in catalog compilation times when you modify your Puppet code. A sharp curve upward for all of the types of requests indicates an overloaded server, and they should trend downward after reducing the load on the server.
 
--   **Request ratios:** This graph shows how many requests of each type that Puppet Server has handled. Under normal circumstances, you should see about the same number of catalog, node, or report requests, because these all happen once per agent run. The number of file and file metadata requests correlate to how many remote file resources are in the agents' catalogs.
+-   **Request ratios:** This graph shows how many requests of each type that Puppet Server has handled. Under normal circumstances, you should see about the same number of catalog, node, or report requests, because these all happen one time per agent run. The number of file and file metadata requests correlate to how many remote file resources are in the agents' catalogs.
 
 -   **Communications with PuppetDB:** This graph tracks the amount of time it takes Puppet Server to send data and requests for common operations to, and receive responses from, PuppetDB.
 

--- a/documentation/puppet_server_metrics_performance.markdown
+++ b/documentation/puppet_server_metrics_performance.markdown
@@ -41,11 +41,11 @@ There are two indicators in Puppet Server's metrics that can help you identify a
 -   **Average JRuby Wait Time:** This refers to the amount of time Puppet Server has to wait for an available JRuby to become available, and increases when each JRuby is held for a longer period of time, which reduces the overall number of free JRubies and forces new requests to wait longer for available resources.
 -   **Average JRuby Borrow Time:** This refers to the amount of time that Puppet Server "holds" a JRuby as a resource for a request, and increases because of other factors on the server.
 
-If wait time increases but borrow time stays the same, your Server infrastructure might be serving too many agents. This indicates that Server can easily handle requests but is receiving too many at once to keep up.
+If wait time increases but borrow time stays the same, your Server infrastructure might be serving too many agents. This indicates that Server can easily handle requests but is receiving too many at one time to keep up.
 
 If both wait and borrow times are increasing, something else on your server is causing requests to take longer to process. The longer borrow times suggest that Puppet Server is struggling more than before to process requests, which has a cascading effect on wait times. Correlate borrow time increases with other events whenever possible to isolate what activities might cause them, such as a Puppet code change.
 
-If you are setting up Puppet Server for the first time, start by increasing your Server infrastructure's capacity through additional JRubies (if your server has spare CPU and memory resources) or compile masters until you have more than 0 free JRubies, and your average number of free JRubies are at least 1. Once your system can handle its request volume, you can start looking into more specific performance improvements.
+If you are setting up Puppet Server for the first time, start by increasing your Server infrastructure's capacity through additional JRubies (if your server has spare CPU and memory resources) or compile masters until you have more than 0 free JRubies, and your average number of free JRubies are at least 1. After your system can handle its request volume, you can start looking into more specific performance improvements.
 
 #### Adding more JRubies
 
@@ -69,12 +69,12 @@ If you don't have the additional capacity on your master to add more JRubies, yo
 
 If JRuby metrics appear to be stable, performance issues might originate from lag in server requests, which also have a cascading effect on other metrics. HTTP metrics in the [status API][], and the requests graph in the [Grafana dashboard](./puppet_server_metrics.markdown), can help you determine when and where request times have increased.
 
-HTTP metrics include the total time for the server to handle the request, including waiting for a JRuby instance to become available. Once JRuby borrow time increases, wait time also increases, so once borrow time for *one* type of request increases, wait times for *all* requests increases.
+HTTP metrics include the total time for the server to handle the request, including waiting for a JRuby instance to become available. When JRuby borrow time increases, wait time also increases, so when borrow time for *one* type of request increases, wait times for *all* requests increases.
 
 Catalog compilation, which is graphed on the [sample Grafana dashboard][], most commonly increases request times, because there are many points of potential failure or delay in a catalog compilation. Several things could cause catalog compilation lengthen JRuby borrow times.
 
 -   A Puppet code change, such as a faulty or complex new function. The Grafana dashboard should show if functions start taking significantly longer, and the experimental dashboard and [status API][] endpoint also list the lengthiest function calls (showing the top 10 and top 40, respectively) based on aggregate execution times.
--   Adding many file resources at once.
+-   Adding many file resources at one time.
 
 In cases like these, there might be more efficient ways to author your Puppet code, you might be extending Puppet to the point where you need to add JRubies or compile masters even if you aren't adding more agents.
 

--- a/documentation/services_master_puppetserver.markdown
+++ b/documentation/services_master_puppetserver.markdown
@@ -74,7 +74,7 @@ Right now, the main administrative task is forcing expiration of all environment
 
 Most of Puppet Server's work — compiling catalogs, receiving reports, etc. — is still done by Ruby code. But instead of using the operating system's MRI Ruby runtime, Puppet Server runs Puppet in JRuby, an implementation of the Ruby interpreter that runs on the JVM.
 
-Since we don't use the system Ruby, you can't use the system `gem` command to install Ruby Gems for use by the Puppet master. Instead, Puppet Server includes a separate `puppetserver gem` command for installing any libraries that your Puppet extensions might require. See [the "Using Ruby Gems" page](./gems.markdown) for details.
+Because we don't use the system Ruby, you can't use the system `gem` command to install Ruby Gems for use by the Puppet master. Instead, Puppet Server includes a separate `puppetserver gem` command for installing any libraries that your Puppet extensions might require. See [the "Using Ruby Gems" page](./gems.markdown) for details.
 
 Additionally, if you need to test or debug code that will be used by Puppet Server, we include `puppetserver ruby` and `puppetserver irb` commands that will execute Ruby code in a JRuby environment.
 

--- a/documentation/ssl_server_certificate_change_and_virtual_ips.markdown
+++ b/documentation/ssl_server_certificate_change_and_virtual_ips.markdown
@@ -33,7 +33,7 @@ javax.net.ssl.SSLHandshakeException: server certificate change is restricted dur
 
 If you need Puppet Server to act as a client to a load-balanced HTTPS service (e.g., multiple PuppetDB servers), your best option right now is to have all of the servers behind the load balancer present the same certificate.
 
-There appear to be ways to fulfill the renegotiation check with certificates that only partially match ([see here for more info](http://hg.openjdk.java.net/bsd-port/bsd-port/jdk/rev/eabde5c42157#l1.186)), but these might not be foolproof, especially since future JDK implementations might disallow these partial matches. The most reliable way is to simply use the same certificates.
+There appear to be ways to fulfill the renegotiation check with certificates that only partially match ([see here for more info](http://hg.openjdk.java.net/bsd-port/bsd-port/jdk/rev/eabde5c42157#l1.186)), but these might not be foolproof, especially because future JDK implementations might disallow these partial matches. The most reliable way is to simply use the same certificates.
 
 The Puppet Enterprise documentation has [instructions for configuring multiple PuppetDB][pe_db_instructions] servers to use a single certificate, but note that this configuration isn't necessarily supported.
 

--- a/documentation/subcommands.markdown
+++ b/documentation/subcommands.markdown
@@ -48,7 +48,7 @@ The available actions:
 
 Because these commands utilize Puppet Server’s API, all except `setup` and `import` need the server to be running in order to work.
 
-Since these commands are shipped as a gem alongside Puppet Server, it can be updated out-of-band to pick up improvements and bug fixes. To upgrade it, run this command: `/opt/puppetlabs/puppet/bin/gem install -i /opt/puppetlabs/puppet/lib/ruby/vendor_gems puppetserver-ca`
+Because these commands are shipped as a gem alongside Puppet Server, it can be updated out-of-band to pick up improvements and bug fixes. To upgrade it, run this command: `/opt/puppetlabs/puppet/bin/gem install -i /opt/puppetlabs/puppet/lib/ruby/vendor_gems puppetserver-ca`
 
 **Note:** These commands are available in Puppet 5, but in order to use them, you must update Puppet Server’s `auth.conf` to include a rule allowing the master’s certname to access the `certificate_status` and `certificate_statuses` endpoints. The same applies to upgrading in open source Puppet: if you're upgrading from Puppet 5 to Puppet 6 and are not regenerating your CA, you must whitelist the master’s certname. See [Puppet Server Configuration Files: auth.conf](/puppetserver/latest/config_file_auth.html) for details on how to use `auth.conf`.
 
@@ -68,7 +68,7 @@ Example:
 ```
 
 ### Signing certs with SANs or auth extensions
-With the removal of `puppet cert sign`, it's possible for Puppet Server’s CA API to sign certificates with subject alternative names or auth extensions, which was previously completely disallowed. This is disabled by default for security reasons, but you can turn it on by setting `allow-subject-alt-names` or `allow-authorization-extensions` to true in the `certificate-authority` section of Puppet Server’s config (usually located in `ca.conf`). Once these have been configured, you can use `puppetserver ca sign --certname <name>` to sign certificates with these additions.
+With the removal of `puppet cert sign`, it's possible for Puppet Server’s CA API to sign certificates with subject alternative names or auth extensions, which was previously completely disallowed. This is disabled by default for security reasons, but you can turn it on by setting `allow-subject-alt-names` or `allow-authorization-extensions` to true in the `certificate-authority` section of Puppet Server’s config (usually located in `ca.conf`). After these have been configured, you can use `puppetserver ca sign --certname <name>` to sign certificates with these additions.
 
 ## gem
 

--- a/documentation/tuning_guide.markdown
+++ b/documentation/tuning_guide.markdown
@@ -23,7 +23,7 @@ several Ruby processes to hand off work to.
 
 Puppet Server isolates these JRuby instances so that they will only be allowed
 to handle one request at a time. This ensures that we don't encounter any
-concurrency issues, since the Ruby code is not thread-safe. When an HTTP request
+concurrency issues, because the Ruby code is not thread-safe. When an HTTP request
 comes in to Puppet Server, and it determines that some Ruby code will need to be
 executed in order to handle the request, Puppet Server "borrows" a JRuby instance
 from the pool, uses it to do the work, and then "returns" it to the pool.  If


### PR DESCRIPTION
Happy May, Server team! I bring you good tidings of docs pothole repair. 
This PR fixes instances of "once" and "since" in the puppetserver/documentation directory. Both of these words have several different meanings, which can make them ambiguous for non-native English speakers. I've changed many of these instances to more specific words like "because," "after," or "when." Where "since" indicates a given period of time passing ("since 1966"), I've left it alone.