### PR TITLE
(SERVER-2532) Enable caching for transports

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "ruby/hiera"]
 	path = ruby/hiera
 	url = https://github.com/puppetlabs/hiera.git
+[submodule "ruby/resource_api"]
+	path = ruby/resource_api
+	url = https://github.com/puppetlabs/puppet-resource_api.git

--- a/dev-resources/puppetlabs/services/master/environment_transports_int_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/environment_transports_int_test/puppet.conf
@@ -1,0 +1,5 @@
+[main]
+
+certname = localhost
+environmentpath = $confdir/environments
+environment_timeout = 0

--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -45,7 +45,7 @@ web-router-service: {
 jruby-puppet: {
     # Where the puppet-agent dependency places puppet, facter, etc...
     # Puppet server expects to load Puppet from this location
-    ruby-load-path: [./ruby/puppet/lib, ./ruby/facter/lib, ./ruby/hiera/lib]
+    ruby-load-path: [./ruby/puppet/lib, ./ruby/facter/lib, ./ruby/hiera/lib, ./ruby/resource_api/lib]
 
     # This setting determines where JRuby will install gems.  It is used for loading gems,
     # and also by the `puppetserver gem` command line tool.

--- a/documentation/puppet-api/v3/environment_transports.json
+++ b/documentation/puppet-api/v3/environment_transports.json
@@ -1,0 +1,52 @@
+{
+  "$schema":     "http://json-schema.org/draft-04/schema#",
+  "title":       "Environment Transports",
+  "description": "Information about the Resource API Transports in a Puppet code environment",
+  "type":        "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "description": "The name of the environment queried",
+      "type": "string"
+    },
+    "transports": {
+      "description": "A list of available transports for this environment",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additonalProperties": false,
+        "properties": {
+          "name": {
+            "description": "The machine readable name of the transport",
+            "type": "string"
+          },
+          "desc": {
+            "description": "The human readable description of the transport this schema specifies",
+            "type": "string"
+          },
+          "connection_info": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["type", "desc"],
+              "properties": {
+                "type": {
+                  "description": "The PCore type of the connection info property",
+                  "type": "string"
+                },
+                "desc": {
+                  "description": "The description of the connection info property",
+                  "type": "string"
+                },
+                "sensitive": {
+                  "description": "Whether or not the connection info property should be considered sensitive",
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/documentation/puppet-api/v3/environment_transports.markdown
+++ b/documentation/puppet-api/v3/environment_transports.markdown
@@ -1,0 +1,38 @@
+---
+layout: default
+title: "Puppet Server: Puppet API: Environment Transports"
+canonical: "/puppetserver/latest/puppet-api/v3/environment_transports.html"
+---
+
+[Resource API Transports]: https://puppet.com/docs/puppet/latest/about_the_resource_api.html#resource-api-transports
+[environment cache API]: ../../admin-api/v1/environment-cache.markdown
+[environment classes API]: ./environment_classes.markdown
+[transports schema]: ./environment_transports.json
+[`auth.conf` documentation]: ../../config_file_auth.markdown
+
+The environment transports API returns a JSON object representing the
+requested environment and schemas for all available [Resource API Transports][].
+The endpoint follows all conventions set by the [environment classes API][]
+including request format, etag validation with expiration managed by the
+[environment cache API][], and errors.
+
+## `GET /puppet/v3/environment_transports?environment=<environment>`
+
+(Introduced in Puppet Server 6.4.0)
+
+
+### Query Parameters
+
+#### `environment` (required)
+The name of the environment to query for available device transport schemas.
+
+### Schema
+
+The transports endpoint response body conforms to the [transports schema][].
+
+### Authorization
+
+All requests made to the environment transports API are authorized using the
+Trapperkeeper-based `auth.conf`.  For more information about the Puppet Server
+authorization process and configuration settings, see the
+[`auth.conf` documentation][].

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -314,27 +314,16 @@
     (update original-environment-info-entry :cache-generation-id inc)
     (environment-info-entry)))
 
-(schema/defn ^:always-validate update-environment-info-entry
-  :- EnvironmentInfoCacheEntry
-  "Return the supplied 'original-environment-info-entry', only updated
-  with the supplied tag and a cache-generation-id value that has been
-  incremented."
-  [original-environment-info-entry :-
-   (schema/maybe EnvironmentInfoCacheEntry)
-   tag :- (schema/maybe schema/Str)]
-  (-> original-environment-info-entry
-      inc-cache-generation-id-for-info-entry
-      (assoc-in [:info :classes] tag)))
-
 (schema/defn ^:always-valid invalidate-environment-info-entry
   :- EnvironmentInfoCacheEntry
   "Return the supplied 'original-environment-info-entry', only updated
   with nil tags and a cache-generation-id value that has been incremented."
   [original-environment-info-entry :-
    (schema/maybe EnvironmentInfoCacheEntry)]
-  (update-environment-info-entry
-   original-environment-info-entry
-   nil))
+  (-> original-environment-info-entry
+    inc-cache-generation-id-for-info-entry
+    (assoc-in [:info :classes] nil)
+    (assoc-in [:info :transports] nil)))
 
 (schema/defn ^:always-validate
   environment-info-cache-with-invalidated-entry
@@ -370,9 +359,9 @@
   (let [cache-entry (get environment-info-cache env-name)]
     (if (= (:cache-generation-id cache-entry)
            cache-generation-id-before-tag-computed)
-      (assoc environment-info-cache
-        env-name
-        (update-environment-info-entry cache-entry tag))
+      (-> environment-info-cache
+        (assoc-in [env-name :info :classes] tag)
+        (update-in [env-name :cache-generation-id] inc))
       environment-info-cache)))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -376,6 +376,30 @@
       environment-info-cache)))
 
 (schema/defn ^:always-validate
+  environment-info-cache-updated-with-tag :- EnvironmentInfoCache
+  "Return the supplied environment class info cache argument, updated per
+  supplied arguments.  cache-generation-id-before-tag-computed should represent
+  what the client received for a
+  'get-environment-class-info-cache-generation-id!' call for the environment,
+  made before the client started doing the work to parse environment info
+  / compute the new tag.  If cache-generation-id-before-tag-computed equals the
+  'cache-generation-id' value stored in the cache for the environment, the new
+  'tag' will be stored for the environment and the corresponding
+  'cache-generation-id' value will be incremented.  If
+  cache-generation-id-before-tag-computed is different than the
+  'cache-generation-id' value stored in the cache for the environment, the cache
+  will remain unchanged as a result of this call."
+  [environment-info-cache :- EnvironmentInfoCache
+   env-name :- schema/Str
+   svc-id :- schema/Keyword
+   tag :- (schema/maybe schema/Str)
+   prior-cache-id :- schema/Int]
+  (let [cache-entry (get environment-info-cache env-name)]
+    (if (= (:cache-generation-id cache-entry) prior-cache-id)
+      (assoc-in environment-info-cache [env-name :info svc-id] tag)
+      environment-info-cache)))
+
+(schema/defn ^:always-validate
   add-environment-info-cache-entry-if-not-present!
   :- EnvironmentInfoCache
   "Update the 'environment-info-cache' atom with a new cache entry for

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -97,7 +97,7 @@
    [this env-name]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
-     (get-in @environment-class-info [env-name :tag])))
+     (get-in @environment-class-info [env-name :info :classes])))
 
   (get-environment-class-info-cache-generation-id!
    [this env-name]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -99,6 +99,12 @@
                                  (tk-services/service-context this))]
      (get-in @environment-class-info [env-name :info :classes])))
 
+  (get-environment-info-tag
+   [this env-name info-svc]
+   (let [environment-class-info (:environment-class-info-tags
+                                 (tk-services/service-context this))]
+     (get-in @environment-class-info [env-name :info info-svc])))
+
   (get-environment-class-info-cache-generation-id!
    [this env-name]
    (let [environment-class-info (:environment-class-info-tags

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -123,6 +123,17 @@
             tag
             cache-generation-id-before-tag-computed)))
 
+  (set-environment-info-tag!
+   [this env-name info-id tag initial-cache-id]
+   (let [environment-class-info (:environment-class-info-tags
+                                 (tk-services/service-context this))]
+     (swap! environment-class-info
+            core/environment-info-cache-updated-with-tag
+            env-name
+            info-id
+            tag
+            initial-cache-id)))
+
   (get-task-data
    [this jruby-instance env-name module-name task-name]
    (.getTaskData jruby-instance env-name module-name task-name))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -99,11 +99,11 @@
                                  (tk-services/service-context this))]
      (get-in @environment-class-info [env-name :classes :tag])))
 
-  (get-environment-info-tag
-   [this env-name info-svc]
+  (get-cached-info-tag
+   [this env-name info-service]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
-     (get-in @environment-class-info [env-name info-svc :tag])))
+     (get-in @environment-class-info [env-name info-service :tag])))
 
   (get-environment-class-info-cache-generation-id!
    [this env-name]
@@ -113,14 +113,14 @@
       environment-class-info
       env-name)))
 
-  (get-environment-cache-version!
-   [this env-name info-svc]
+  (get-cached-content-version
+   [this env-name info-service]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
-     (core/get-environment-cache-version!
+     (core/get-cached-content-version
       environment-class-info
       env-name
-      info-svc)))
+      info-service)))
 
   (set-environment-class-info-tag!
    [this env-name tag cache-generation-id-before-tag-computed]
@@ -132,16 +132,16 @@
             tag
             cache-generation-id-before-tag-computed)))
 
-  (set-environment-info-tag!
-   [this env-name info-id tag initial-cache-id]
+  (set-cache-info-tag!
+   [this env-name info-service-id tag initial-content-version]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
      (swap! environment-class-info
-            core/environment-info-cache-updated-with-tag
+            core/maybe-update-environment-info-service-cache
             env-name
-            info-id
+            info-service-id
             tag
-            initial-cache-id)))
+            initial-content-version)))
 
   (get-task-data
    [this jruby-instance env-name module-name task-name]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -5,8 +5,8 @@
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby]
-            [puppetlabs.i18n.core :as i18n])
-  (:import (org.jruby.runtime Constants)))
+            [puppetlabs.i18n.core :as i18n]))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -97,13 +97,13 @@
    [this env-name]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
-     (get-in @environment-class-info [env-name :info :classes])))
+     (get-in @environment-class-info [env-name :classes :tag])))
 
   (get-environment-info-tag
    [this env-name info-svc]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
-     (get-in @environment-class-info [env-name :info info-svc])))
+     (get-in @environment-class-info [env-name info-svc :tag])))
 
   (get-environment-class-info-cache-generation-id!
    [this env-name]
@@ -112,6 +112,15 @@
      (core/get-environment-class-info-cache-generation-id!
       environment-class-info
       env-name)))
+
+  (get-environment-cache-version!
+   [this env-name info-svc]
+   (let [environment-class-info (:environment-class-info-tags
+                                 (tk-services/service-context this))]
+     (core/get-environment-cache-version!
+      environment-class-info
+      env-name
+      info-svc)))
 
   (set-environment-class-info-tag!
    [this env-name tag cache-generation-id-before-tag-computed]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -77,6 +77,10 @@
     [this jruby-instance env-name]
     (.getClassInfoForEnvironment jruby-instance env-name))
 
+  (get-environment-transport-info
+    [this jruby-instance env-name]
+    (.getTransportInfoForEnvironment jruby-instance env-name))
+
   (compile-catalog
    [this jruby-instance request-options]
    (.compileCatalog jruby-instance request-options))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -594,7 +594,7 @@
    request-tag :- (schema/maybe String)
    cache-version :- (schema/maybe schema/Int)]
   (let [body (cheshire/encode info)
-        tag (ks/utf8-string->sha1 body)]
+        tag (ks/utf8-string->sha256 body)]
     (if (= tag request-tag)
       (not-modified-response tag)
       (do

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -302,49 +302,6 @@
       (rr/status 304)))
 
 (schema/defn ^:always-validate
-  environment-class-response! :- ringutils/RingResponse
-  "Process the environment class info, returning a Ring response to be
-  propagated back up to the caller of the environment_classes endpoint.
-
-  If the specified `environment-class-cache-enabled` is 'true', a SHA-1 hash
-  of the class info will be generated.  If the hash is equal to the supplied
-  `request-tag`, the response will have an HTTP 304 (Not Modified) status code
-  and the response body will be empty.  If the hash is not equal to the supplied
-  `request-tag`, the response will have an HTTP 200 (OK) status code and
-  the class info, serialized to JSON, will appear in the response body.  The
-  newly generated hash code, along with the specified `cache-generation-id`,
-  will be passed to the `jruby-service`, to be stored in its environment class
-  cache, and will also be returned in the response as the value for an HTTP
-  Etag header.
-
-  If the specified `environment-class-cache-enabled` is 'false', no hash
-  will be generated for the class info.  The response will always have an
-  HTTP 200 (OK) status code and the class info, serialized to JSON, as the
-  response body.  An HTTP Etag header will not appear in the response."
-  [info-from-jruby :- Map
-   environment :- schema/Str
-   jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
-   request-tag :- (schema/maybe String)
-   cache-generation-id :- (schema/maybe schema/Int)
-   environment-class-cache-enabled :- schema/Bool]
-  (let [info-for-json (class-info-from-jruby->class-info-for-json
-                       info-from-jruby
-                       environment)]
-    (if environment-class-cache-enabled
-      (let [info-as-json (cheshire/generate-string info-for-json)
-            parsed-tag (ks/utf8-string->sha1 info-as-json)]
-        (jruby-protocol/set-environment-class-info-tag!
-         jruby-service
-         environment
-         parsed-tag
-         cache-generation-id)
-        (if (= parsed-tag request-tag)
-          (not-modified-response parsed-tag)
-          (-> (response-with-etag info-as-json parsed-tag)
-              (rr/content-type "application/json"))))
-      (middleware-utils/json-response 200 info-for-json))))
-
-(schema/defn ^:always-validate
   all-tasks-response! :- ringutils/RingResponse
   "Process the info, returning a Ring response to be propagated back up to the
   caller of the endpoint.
@@ -429,31 +386,6 @@
   "Ring handler to provide a standard error when a task is not found."
   [task :- schema/Str]
   (rr/not-found (i18n/tru "Could not find task ''{0}''" task)))
-
-(schema/defn ^:always-validate
-  environment-class-info-fn :- IFn
-  "Middleware function for constructing a Ring response from an incoming
-  request for environment_classes information."
-  [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
-   environment-class-cache-enabled :- schema/Bool]
-  (fn [request]
-    (let [environment (jruby-request/get-environment-from-request request)
-          cache-generation-id
-          (jruby-protocol/get-environment-class-info-cache-generation-id!
-           jruby-service
-           environment)]
-      (if-let [class-info
-               (jruby-protocol/get-environment-class-info jruby-service
-                                                          (:jruby-instance
-                                                           request)
-                                                          environment)]
-        (environment-class-response! class-info
-                                     environment
-                                     jruby-service
-                                     (if-none-match-from-request request)
-                                     cache-generation-id
-                                     environment-class-cache-enabled)
-        (environment-not-found environment)))))
 
 (schema/defn ^:always-validate
   module-info-from-jruby->module-info-for-json  :- EnvironmentModulesInfo
@@ -605,7 +537,7 @@
 (schema/defn ^:always-validate
   wrap-with-etag-check :- IFn
   "Middleware function which validates whether or not the If-None-Match
-  header on an incoming environment_classes request matches the last Etag
+  header on an incoming cacheable request matches the last Etag
   computed for the environment whose info is being requested.  If the two
   match, the middleware function returns an HTTP 304 (Not Modified) Ring
   response.  If the two do not match, the request is threaded through to the
@@ -624,19 +556,6 @@
         (handler request)))))
 
 (schema/defn ^:always-validate
-  environment-class-handler :- IFn
-  "Handler for processing an incoming environment_classes Ring request"
-  [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
-   environment-class-cache-enabled :- schema/Bool]
-  (->
-   (environment-class-info-fn jruby-service
-                              environment-class-cache-enabled)
-   (jruby-request/wrap-with-jruby-instance jruby-service)
-   (wrap-with-etag-check jruby-service)
-   jruby-request/wrap-with-environment-validation
-   jruby-request/wrap-with-error-handling))
-
-(schema/defn ^:always-validate
   raw-transports->response-map
   [data :- List
    env :- schema/Str]
@@ -644,63 +563,61 @@
    :transports data})
 
 (schema/defn ^:always-validate
-  transport-response! :- ringutils/RingResponse
-  "Conditionally honors etag info if cache is enabled.
-  Updates cache if enabled but out of date.
-  Note: takes raw Java data and calls hardcoded conversion fn"
-  [raw-info :- List
+  check-cache! :- ringutils/RingResponse
+  "Updates cache if new data does not match previous data
+
+  We must use the cache version generated at the start of the request.
+  The cache will check to see that the version given to it is the same
+  as its internal version (eg that it hasn't been reset since handing
+  out that version). If the given and internal versions do not match the
+  request to set the tag is ignored, if they match the tag is stored and
+  the internal version is incremented."
+  [info :- {schema/Any schema/Any}
    env :- schema/Str
    jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
    request-tag :- (schema/maybe String)
-   cache-id :- (schema/maybe schema/Int)
-   cache-enabled? :- schema/Bool]
-  (let [resp-map (raw-transports->response-map raw-info env)
-        serialized-resp (cheshire/generate-string resp-map)]
-    (if cache-enabled?
-      (let [;; This isn't going to work with two different data sets per environmnt, is it?
-            tag (ks/utf8-string->sha1 serialized-resp)]
+   cache-version :- (schema/maybe schema/Int)]
+  (let [body (cheshire/encode info)
+        tag (ks/utf8-string->sha1 body)]
+    (if (= tag request-tag)
+      (not-modified-response tag)
+      (do
         (jruby-protocol/set-environment-class-info-tag!
          jruby-service
          env
          tag
-         cache-id)
-        (if (= tag request-tag)
-          (not-modified-response tag)
-          (-> (response-with-etag serialized-resp tag)
-              (rr/content-type "application/json"))))
-      (middleware-utils/json-response 200 serialized-resp))))
+         cache-version)
+        (-> (response-with-etag body tag)
+            (rr/content-type "application/json"))))))
 
 (schema/defn ^:always-validate
-  transport-info-fn :- IFn
-  "Returns the handler fn which attempts to retrieve data from jruby and if
-  successful passes it to a fn to build a response, otherwise returns not-found"
-  [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
+  mk-cacheable-handler :- IFn
+  "Given a retrieval fn of the jruby protocol, builds a handler for fn that
+  honors the environment cache."
+  [info-fn :- IFn
+   jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
    cache-enabled? :- schema/Bool]
   (fn [request]
     (let [env (jruby-request/get-environment-from-request request)
           cache-id
-          (jruby-protocol/get-environment-class-info-cache-generation-id!
-           jruby-service
-           env)]
-      (if-let [transport-info
-               (jruby-protocol/get-environment-transport-info
-                 jruby-service
-                 (:jruby-instance request)
-                 env)]
-        (transport-response! transport-info
-                             env
-                             jruby-service
-                             (if-none-match-from-request request)
-                             cache-id
-                             cache-enabled?)
+           (jruby-protocol/get-environment-class-info-cache-generation-id!
+            jruby-service
+            env)]
+      (if-let [info (info-fn (:jruby-instance request) env)]
+        (let [known-tag (if-none-match-from-request request)]
+          (if cache-enabled?
+            (check-cache! info env jruby-service known-tag cache-id)
+            (middleware-utils/json-response 200 info)))
         (environment-not-found env)))))
 
 (schema/defn ^:always-validate
-  environment-transport-handler :- IFn
-  "Handler for processing an incoming environment_transport Ring request"
-  [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
+  wrap-cacheable-environment-info-handler :- IFn
+  "Calls the creation of a cacheable environment info handler and
+  wraps it in appropriate middleware."
+  [info-fn :- IFn
+   jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
    cache-enabled :- schema/Bool]
-  (-> (transport-info-fn jruby-service cache-enabled)
+  (-> (mk-cacheable-handler info-fn jruby-service cache-enabled)
    (jruby-request/wrap-with-jruby-instance jruby-service)
    (wrap-with-etag-check jruby-service)
    jruby-request/wrap-with-environment-validation
@@ -886,15 +803,25 @@
    get-code-content-fn :- IFn
    current-code-id-fn :- IFn
    cache-enabled :- schema/Bool]
-  (let [class-handler (environment-class-handler jruby-service
-                                                 cache-enabled)
+  (let [class-handler (wrap-cacheable-environment-info-handler
+                        (fn [jruby env]
+                          (some-> jruby-service
+                                  (jruby-protocol/get-environment-class-info jruby env)
+                                  (class-info-from-jruby->class-info-for-json env)))
+                        jruby-service
+                        cache-enabled)
 
         module-handler (environment-module-handler jruby-service)
 
         tasks-handler (all-tasks-handler jruby-service)
 
-        transport-handler (environment-transport-handler jruby-service
-                                                         cache-enabled)
+        transport-handler (wrap-cacheable-environment-info-handler
+                            (fn [jruby env]
+                              (some-> jruby-service
+                                      (jruby-protocol/get-environment-transport-info jruby env)
+                                      (raw-transports->response-map env)))
+                            jruby-service
+                            cache-enabled)
 
         task-handler (task-details-handler jruby-service
                                            get-code-content-fn

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -618,9 +618,10 @@
     (let [env (jruby-request/get-environment-from-request request)
           svc-id (info-service request)
           cache-id
-           (jruby-protocol/get-environment-class-info-cache-generation-id!
+           (jruby-protocol/get-environment-cache-version!
             jruby-service
-            env)]
+            env
+            svc-id)]
       (if-let [info (info-fn (:jruby-instance request) env)]
         (let [known-tag (if-none-match-from-request request)]
           (if cache-enabled?

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -199,8 +199,7 @@
   This function was copypasta'd from clj-kitchensink's core/sort-nested-maps.
   sort-nested-maps can only deep sort a structure that contains native Clojure
   types, whereas this function includes a couple of changes which handle the
-  sorting of the data structure returned from JRuby for a call to get
-  environment class info:
+  sorting of the data structure returned from JRuby:
 
   1) This function sorts keys within any `java.util.Map`, as opposed to just an
      object for which `map?` returns true.
@@ -574,8 +573,9 @@
   raw-transports->response-map
   [data :- List
    env :- schema/Str]
-  {:name env
-   :transports data})
+  (sort-nested-info-maps
+    {:name env
+     :transports data}))
 
 (schema/defn ^:always-validate
   check-cache! :- ringutils/RingResponse

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -59,6 +59,20 @@
     'cache-generation-id' value stored in the cache for the environment, the
     cache will remain unchanged as a result of this call.")
 
+  (set-environment-info-tag!
+    [this env-name info-id tag prior-cache-id]
+    "Set the tag computed for the latest info service parsed for a
+    specific environment.  prior-cache-id should represent what the client
+    received for a 'get-environment-class-info-cache-generation-id!' call for
+    the environment made before it started doing the work to parse environment
+    info / compute the new tag.  If prior-cache-id equals the
+    'cache-generation-id' value stored in the cache for the environment, the
+    new 'tag' will be stored for the environment and the corresponding
+    'cache-generation-id' value will be incremented.  If
+    prior-cache-id is different than the 'cache-generation-id' value stored in
+    the cache for the environment, the cache will remain unchanged as a result
+    of this call.")
+
   (compile-catalog
     [this jruby-instance request-options]
     "Compile the catalog for a given certname")

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -32,6 +32,11 @@
     "Get a tag for the latest class information parsed for a specific
     environment")
 
+  (get-environment-info-tag
+    [this env-name info-svc]
+    "Get a tag for the latest information parsed for a specific
+    environment and info service")
+
   (get-environment-class-info-cache-generation-id!
     [this env-name]
     "Get the current cache generation id for a specific environment's class

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -29,32 +29,37 @@
 
   (get-environment-class-info-tag
     [this env-name]
-    "Get a tag for the latest class information parsed for a specific
+    "DEPRECATED: see get-cached-info-tag
+
+    Get a tag for the latest class information parsed for a specific
     environment")
 
-  (get-environment-info-tag
-    [this env-name info-svc]
+  (get-cached-info-tag
+    [this env-name info-service]
     "Get a tag for the latest information parsed for a specific
     environment and info service")
 
   (get-environment-class-info-cache-generation-id!
     [this env-name]
-    "DEPRECATED
+    "DEPRECATED: see `get-cache-content-version`
+
     Get the current cache generation id for a specific environment's class
     info.  If no entry for the environment had existed at the point this
     function was called this function would, as a side effect, populate a new
     entry for that environment into the cache.")
 
-  (get-environment-cache-version!
-    [this env-name info-svc]
-    "Get the current cache version for a specific service's cache within an
+  (get-cached-content-version
+    [this env-name info-service]
+    "Get the cached content version for a specific service's cache within an
     environment.  If no entry for the environment had existed at the point
     this function was called this function would, as a side effect, populate
     a new entry for that environment into the cache.")
 
   (set-environment-class-info-tag!
     [this env-name tag cache-generation-id-before-tag-computed]
-    "Set the tag computed for the latest class information parsed for a
+    "DEPRECATED: see `set-cache-info-tag!`
+
+    Set the tag computed for the latest class information parsed for a
     specific environment.  cache-generation-id-before-tag-computed should
     represent what the client received for a
     'get-environment-class-info-cache-generation-id!' call for the environment
@@ -67,19 +72,17 @@
     'cache-generation-id' value stored in the cache for the environment, the
     cache will remain unchanged as a result of this call.")
 
-  (set-environment-info-tag!
-    [this env-name info-id tag prior-cache-id]
+  (set-cache-info-tag!
+    [this env-name info-service-id tag initial-content-version]
     "Set the tag computed for the latest info service parsed for a
-    specific environment.  prior-cache-id should represent what the client
-    received for a 'get-environment-class-info-cache-generation-id!' call for
-    the environment made before it started doing the work to parse environment
-    info / compute the new tag.  If prior-cache-id equals the
-    'cache-generation-id' value stored in the cache for the environment, the
-    new 'tag' will be stored for the environment and the corresponding
-    'cache-generation-id' value will be incremented.  If
-    prior-cache-id is different than the 'cache-generation-id' value stored in
-    the cache for the environment, the cache will remain unchanged as a result
-    of this call.")
+    specific environment.  initial-content-version should represent what the
+    client received for a `get-cached-content-version` call for the
+    environment made before it started doing the work to parse environment
+    info & compute the new tag.
+
+    If initial-content-version equals the value stored in the cache for the
+    environment, the new 'tag' will be stored for the environment and the
+    corresponding content version will be incremented.")
 
   (compile-catalog
     [this jruby-instance request-options]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -23,6 +23,10 @@
     [this jruby-instance env-name]
     "Get class information for a specific environment")
 
+  (get-environment-transport-info
+    [this jruby-instance env-name]
+    "Get transport information for a specific environment")
+
   (get-environment-class-info-tag
     [this env-name]
     "Get a tag for the latest class information parsed for a specific

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -39,10 +39,18 @@
 
   (get-environment-class-info-cache-generation-id!
     [this env-name]
-    "Get the current cache generation id for a specific environment's class
+    "DEPRECATED
+    Get the current cache generation id for a specific environment's class
     info.  If no entry for the environment had existed at the point this
     function was called this function would, as a side effect, populate a new
     entry for that environment into the cache.")
+
+  (get-environment-cache-version!
+    [this env-name info-svc]
+    "Get the current cache version for a specific service's cache within an
+    environment.  If no entry for the environment had existed at the point
+    this function was called this function would, as a side effect, populate
+    a new entry for that environment into the cache.")
 
   (set-environment-class-info-tag!
     [this env-name tag cache-generation-id-before-tag-computed]

--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -19,6 +19,7 @@ public interface JRubyPuppet {
     Map getTaskData(String environment, String module, String task);
     List getTasks(String environment);
     Map getClassInfoForEnvironment(String environment);
+    List getTransportInfoForEnvironment(String environment);
     List getModuleInfoForEnvironment(String environment);
     Map compileCatalog(Map requestBody);
     Map getModuleInfoForAllEnvironments();

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -84,7 +84,6 @@ class Puppet::Server::Master
     environment = @env_loader.get!(env)
     Puppet.override({current_environment: environment}) do
       @transports_loader.loadall(environment)
-      Puppet::Util::Autoload.reload_changed(environment)
       Puppet::ResourceApi::Transport.list.values.map(&:definition)
     end
   end

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -77,6 +77,19 @@ class Puppet::Server::Master
     end
   end
 
+  def getTransportInfoForEnvironment(env)
+    [{
+      name: "foo_transport",
+      desc: "A mock transport schema",
+      connection_info: {
+        host: {
+          type: "String",
+          desc: "The host"
+        }
+      }
+    }]
+  end
+
   def getModuleInfoForEnvironment(env)
     environment = @env_loader.get(env)
     unless environment.nil?

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -568,7 +568,7 @@
     (let [expected-etag "abcd1234"
           body-length 200000
           jruby-service (reify jruby-protocol/JRubyPuppetService
-                          (get-environment-class-info-tag [_ _]
+                          (get-environment-info-tag [_ _ _]
                             expected-etag))
           app (->
                (fn [_]

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -568,14 +568,14 @@
     (let [expected-etag "abcd1234"
           body-length 200000
           jruby-service (reify jruby-protocol/JRubyPuppetService
-                          (get-environment-info-tag [_ _ _]
+                          (get-cached-info-tag [_ _ _]
                             expected-etag))
           app (->
                (fn [_]
                  (master-core/response-with-etag
                   (apply str (repeat body-length "a"))
                   expected-etag))
-               (master-core/wrap-with-etag-check jruby-service))]
+               (master-core/wrap-with-cache-check jruby-service))]
       (jetty9/with-test-webserver
        app
        port

--- a/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
@@ -479,7 +479,7 @@
     (let [expected-etag "abcd1234"
           body-length 200000
           jruby-service (reify jruby-protocol/JRubyPuppetService
-                          (get-environment-class-info-tag [_ _]
+                          (get-environment-info-tag [_ _ _]
                             expected-etag))
           app (->
                (fn [_]

--- a/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
@@ -1,0 +1,607 @@
+(ns puppetlabs.services.master.environment-transports-int-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as str]
+            [clojure.walk :as walk]
+            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
+            [puppetlabs.puppetserver.testutils :as testutils]
+            [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap-testutils]
+            [puppetlabs.trapperkeeper.testutils.webserver :as jetty9]
+            [puppetlabs.services.master.master-core :as master-core]
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
+            [cheshire.core :as json]
+            [me.raynes.fs :as fs]
+            [clojure.tools.logging :as log]
+            [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils])
+  (:import (com.puppetlabs.puppetserver JRubyPuppetResponse JRubyPuppet)
+           (java.util HashMap ArrayList)))
+
+(def test-resources-dir
+  "./dev-resources/puppetlabs/services/master/environment_transports_int_test")
+
+(def gem-path
+  [(ks/absolute-path jruby-testutils/gem-path)])
+
+
+(def mock-transport
+  {:name "foo_transport"
+    :desc "A mock transport schema"
+    :connection_info {
+      :host {
+        :type "String"
+        :desc "The host"}}})
+
+(def mock-response
+  {:name "production"
+    :transports [mock-transport]})
+
+(defn purge-env-dir
+  []
+  (-> testutils/conf-dir
+      (fs/file "environments")
+      fs/delete-dir))
+
+(use-fixtures :once
+              (testutils/with-puppet-conf
+               (fs/file test-resources-dir "puppet.conf")))
+
+(use-fixtures :each
+              (fn [f]
+                (purge-env-dir)
+                (try
+                  (f)
+                  (finally
+                    (purge-env-dir)))))
+
+(defn get-env-transports
+  ([env-name]
+   (get-env-transports env-name nil))
+  ([env-name if-none-match]
+   (let [opts (if if-none-match
+                {:headers {"If-None-Match" if-none-match}})]
+     (try
+       (http-client/get
+        (str "https://localhost:8140/puppet/v3/"
+             "environment_transports?"
+             "environment="
+             env-name)
+        (merge
+         testutils/ssl-request-options
+         {:as :text}
+         opts))
+       (catch Exception e
+         (throw (Exception. "environment_transports http get failed" e)))))))
+
+(defn purge-all-env-caches
+  []
+  (http-client/delete
+   "https://localhost:8140/puppet-admin-api/v1/environment-cache"
+   testutils/ssl-request-options))
+
+(defn purge-env-cache
+  [env]
+  (http-client/delete
+   (str "https://localhost:8140/puppet-admin-api/v1/environment-cache?"
+        "environment="
+        env)
+   testutils/ssl-request-options))
+
+(defn response-etag
+  [request]
+  (get-in request [:headers "etag"]))
+
+(defn etag-with-gzip-suffix
+  [etag]
+  (if (.endsWith etag "--gzip")
+    etag
+    (str etag "--gzip")))
+
+(defn etag-without-gzip-suffix
+  [etag]
+  (str/replace etag #"--gzip$" ""))
+
+(defn response->map
+  [response]
+  (-> response :body (json/parse-string true)))
+
+
+(deftest ^:integration environment-transports-integration-cache-disabled-test
+  (testing "when environment cache is disabled for a transport request"
+    (bootstrap/with-puppetserver-running-with-config
+     app
+     (-> {:jruby-puppet {:gem-path gem-path
+                         :max-active-instances 1}}
+         (bootstrap/load-dev-config-with-overrides)
+         (ks/dissoc-in [:jruby-puppet
+                        :environment-class-cache-enabled]))
+     (let [foo-file (testutils/write-foo-pp-file
+                     "some kind of test data")
+           expected-response (json/encode mock-response)
+           response (get-env-transports "production")]
+       (testing "a successful status code is returned"
+         (is (= 200 (:status response))
+             (str
+              "unexpected status code for response, response: "
+              (ks/pprint-to-string response))))
+       (testing "no etag is returned"
+         (is (false? (contains? (:headers response) "etag"))))
+       (testing "the expected response body is returned"
+         (is (= expected-response
+                (response->map response))))))))
+
+
+(deftest ^:integration environment-transports-integration-cache-enabled-test1
+  (bootstrap/with-puppetserver-running app
+   {:jruby-puppet {:gem-path gem-path
+                   :max-active-instances 1
+                   :environment-class-cache-enabled true}}
+   (let [foo-file (str "tbd test data")
+         expected-initial-response (json/encode mock-response)
+         initial-response (get-env-transports "production")
+         initial-etag (response-etag initial-response)
+         initial-etag-with-gzip-suffix (etag-with-gzip-suffix initial-etag)
+         initial-etag-without-gzip-suffix (etag-without-gzip-suffix initial-etag)]
+     (testing "environment transport cache invalidation for one environment"
+       ;; This test is about ensuring that when the environment-cache
+       ;; endpoint is hit for a single environment that only that the
+       ;; environment class info cached for that environment - but not the
+       ;; info cached for other environments - is invalidated, meaning that
+       ;; the next request for class info for that environment will get fresh
+       ;; data.
+       ;;
+       ;; The test has the following basic steps:
+       ;;
+       ;; 1) Purge the current environment files on disk and hit the
+       ;;    environment-cache endpoint to flush the cache for all
+       ;;    environments, basically to ensure nothing is left around from
+       ;;    other tests.
+       ;; 2) Populate code for the 'test' and 'production' environments and
+       ;;    see that environment_transports queries return the right info for
+       ;;    them.
+       ;; 3) Do one more environment_transports query for each environment,
+       ;;    using the etag from the initial queries, to ensure that a 304
+       ;;    (Not Modified) is returned.
+       ;; 4) Change code on disk for both the 'test' and 'production'
+       ;;    environments.
+       ;; 5) Hit the environment-cache endpoint for the 'production'
+       ;;    environment (but not for the 'test' environment).
+       ;; 6) Do two more environment_transports queries for the 'test' and
+       ;;    'production' environments using the etags from the initial
+       ;;    queries.  Confirm that the information reflects the latest data on
+       ;;    disk for the 'production' environment but still reflects the old
+       ;;    data for the 'test' environment - expected, in this case, because
+       ;;    the 'test' environment was not flushed.
+       (purge-env-dir)
+       (purge-all-env-caches)
+       (let [prod-file (str "test data")
+             test-file (str "test data")
+             production-response-initial (get-env-transports "production")
+             production-etag-initial (response-etag production-response-initial)
+             production-etag-initial-without-gzip-suffix (etag-without-gzip-suffix production-etag-initial)
+             test-response-initial (get-env-transports "test")
+             test-etag-initial (response-etag test-response-initial)
+             test-etag-initial-without-gzip-suffix (etag-without-gzip-suffix
+                                                     (response-etag test-response-initial))]
+         (is (= 200 (:status production-response-initial))
+             (str
+              "unexpected status code for initial production response"
+              "response: "
+              (ks/pprint-to-string production-response-initial)))
+         (is (not (nil? production-etag-initial))
+             "no etag returned for production response")
+         (is (= mock-response
+                (response->map production-response-initial))
+             "unexpected body for production response")
+         (comment
+           "We are currently only returning mock data for prod"
+           (is (= 200 (:status test-response-initial))
+               (str
+                "unexpected status code for initial test response"
+                "response: "
+                (ks/pprint-to-string test-response-initial)))
+           (is (not (nil? test-etag-initial))
+               "no etag returned for test response")
+           (is (= mock-response
+                  (response->map test-response-initial))
+               "unexpected body for test response"))
+
+         (comment
+           (write-some-test-data "test data")
+           (write-some-test-data "test data")
+
+           "The following tests verify even though we just wrote new data
+           to disk the response is still honoring the cache since it has
+           yet to be purged.
+
+           Since the writing of data is not done, these tests basically
+           repeat the above section of tests. They are left here for a
+           future commit when we write realistic transports to disk"
+
+           (let [production-response-before-flush (get-env-transports
+                                                   "production"
+                                                   production-etag-initial)
+                 test-response-before-flush (get-env-transports
+                                             "test"
+                                             test-etag-initial)]
+             (is (= 304 (:status production-response-before-flush))
+                 (str
+                  "unexpected status code for prod response after code change "
+                  "but before flush"))
+             (is (= production-etag-initial-without-gzip-suffix (response-etag
+                                                                  production-response-before-flush))
+                 "unexpected etag change when no production environment change")
+             (is (empty? (:body production-response-before-flush))
+                 "unexpected body for production response")
+             (is (= 304 (:status test-response-before-flush))
+                 (str
+                  "unexpected status code for test response after code change "
+                  "but before flush"))
+             (is (= test-etag-initial-without-gzip-suffix (response-etag
+                                                            test-response-before-flush))
+                 "unexpected etag change when no test environment change")
+             (is (empty? (:body test-response-before-flush))
+                 "unexpected body for test response")))
+
+           (comment
+             "The following tests require the code that was written _prior_
+             to the previous set of tests. The following tests validate
+             that, once we've purged the cache new data based on those
+             written files will be returned first and then cached."
+             (purge-env-cache "production")
+             (let [production-response-after-prod-flush (get-env-transports
+                                                         "production"
+                                                         production-etag-initial)
+                   production-etag-after-prod-flush (response-etag
+                                                     production-response-after-prod-flush)
+                   test-response-after-prod-flush (get-env-transports
+                                                   "test"
+                                                   test-etag-initial)]
+               (is (= 200 (:status production-response-after-prod-flush))
+                   (str
+                    "unexpected status code for prod response after code change "
+                    "and prod flush"))
+               (is (not (nil? production-etag-after-prod-flush))
+                   "no etag returned for production response")
+               (is (not= production-etag-initial
+                         production-etag-after-prod-flush)
+                   (str
+                    "etag unexpectedly stayed the same even though "
+                    "the production environment changed"))
+               (is (= mock-response
+                      (response->map
+                       production-response-after-prod-flush))
+                   "unexpected body for production response")
+               (is (= 304 (:status test-response-after-prod-flush))
+               (is (= test-etag-initial-without-gzip-suffix (response-etag
+                                                              test-response-after-prod-flush))
+                   "unexpected etag change when test environment not invalidated")
+               (is (empty? (:body test-response-after-prod-flush))
+                   "unexpected body for test response")))))))))
+
+
+(deftest ^:integration environment-transports-integration-cache-enabled-test2
+  (bootstrap/with-puppetserver-running app
+   {:jruby-puppet {:gem-path gem-path
+                   :max-active-instances 1
+                   :environment-class-cache-enabled true}}
+   (let [foo-file (str "tbd test data")
+         expected-initial-response mock-response
+         initial-response (get-env-transports "production")
+         initial-etag (response-etag initial-response)
+         initial-etag-with-gzip-suffix (etag-with-gzip-suffix initial-etag)
+         initial-etag-without-gzip-suffix (etag-without-gzip-suffix initial-etag)]
+     (testing "initial fetch of environment_transports info is good"
+       (is (= 200 (:status initial-response))
+           (str
+            "unexpected status code for initial response, response: "
+            (ks/pprint-to-string initial-response)))
+       (is (not (nil? initial-etag))
+           "no etag found for initial response")
+       (is (= expected-initial-response
+              (response->map initial-response))
+           "unexpected body for initial response"))
+     (testing "etag not updated when code has not changed"
+       (let [response (get-env-transports "production")]
+         (is (= 200 (:status response))
+             "unexpected status code for response following no code change")
+         (is (= initial-etag (response-etag response))
+             "etag changed even though code did not")
+         (is (= expected-initial-response
+                (response->map response))
+             "unexpected body for response")))
+     (testing (str "HTTP 304 (not modified) returned when request "
+                   "roundtrips last etag and code has not changed")
+       (let [response (get-env-transports "production" initial-etag)]
+         (is (= 304 (:status response))
+             (str
+              "unexpected status code for response for no code change and "
+              "original etag roundtripped"))
+         (is (= initial-etag-without-gzip-suffix (response-etag response))
+             "etag changed even though code did not")
+         (is (empty? (:body response))
+             "unexpected body for response")))
+     (testing (str "SERVER-1153 - HTTP 304 (not modified) returned when "
+                   "request roundtrips last etag with '--gzip' suffix and "
+                   "code has not changed")
+       (let [response (get-env-transports "production"
+                                       initial-etag-with-gzip-suffix)]
+         (is (= 304 (:status response))
+             (str
+              "unexpected status code for response for no code change and "
+              "etag with '--gzip' suffix roundtripped"))
+         (is (= initial-etag-without-gzip-suffix (response-etag response))
+             "etag changed even though code did not")
+         (is (empty? (:body response))
+             "unexpected body for response")))
+     (comment
+       "Not valid until we write new data out"
+       (testing (str "environment_transport fetch without if-none-match "
+                     "header includes latest info after code update")
+         (str "test data")
+         (str "test data")
+         (let [baz-file (str "test data")
+               borked-file (str "test data")
+               _ (purge-all-env-caches)
+               response (get-env-transports "production")]
+           (is (= 200 (:status response))
+               (str
+                "unexpected status code for response following code change,"
+                "response: "
+                (ks/pprint-to-string response)))
+           (is (not= initial-etag (response-etag response))
+               "etag did not change even though code did")
+           (is (= mock-response
+                  (response->map response))
+               "unexpected body following code change")))))))
+
+
+#_(deftest ^:integration environment-transports-integration-cache-enabled-test3
+  (bootstrap/with-puppetserver-running app
+   {:jruby-puppet {:gem-path gem-path
+                   :max-active-instances 1
+                   :environment-class-cache-enabled true}}
+   (let [foo-file (str "tbd test data")
+         expected-initial-response mock-response
+         initial-response (get-env-transports "production")
+         initial-etag (response-etag initial-response)
+         initial-etag-with-gzip-suffix (etag-with-gzip-suffix initial-etag)
+         initial-etag-without-gzip-suffix (etag-without-gzip-suffix initial-etag)]
+     (testing "environment transports cache invalidation for all environments"
+       ;; This test is about ensuring that when the environment-cache
+       ;; endpoint is hit with no environment parameter that any previously
+       ;; cached environment class info is invalidated, meaning that
+       ;; the next request for class info for all environments will get fresh
+       ;; data.
+       ;;
+       ;; To eliminate some of the redundancy between tests, this test doesn't
+       ;; repeat the intermediate step of checking to see that the first two
+       ;; environment queries were cached - 304 (Not Modified) returns -
+       ;; between the first set of environment_transports queries and the second
+       ;; set, done after the code on disk for both environments has changed.
+       ;;
+       ;; The test has the following basic steps:
+       ;;
+       ;; 1) Purge the current environment files on disk and hit the
+       ;;    environment-cache endpoint to flush the cache for all
+       ;;    environments, basically to ensure nothing is left around from
+       ;;    other tests.
+       ;; 2) Populate code for the 'test' and 'production' environments and
+       ;;    see that environment_transports queries return the right info for
+       ;;    them.
+       ;; 3) Change code on disk for both the 'test' and 'production'
+       ;;    environments.
+       ;; 4) Hit the environment-cache endpoint with no environment
+       ;;    parameter, expected to have the effect of flushing the cache for
+       ;;    all environments.
+       ;; 5) Do two more environment_transports queries for the 'test' and
+       ;;    'production' environments with the corresponding etags returned
+       ;;    from the first two queries.  Confirm that the information
+       ;;    reflects the latest data on disk for both environments.
+       (purge-env-dir)
+       (purge-all-env-caches)
+       (let [prod-file (str "test data")
+             test-file (str "test data")
+             production-response-initial (get-env-transports "production")
+             production-etag-initial (response-etag production-response-initial)
+             test-response-initial (get-env-transports "test")
+             test-etag-initial (response-etag test-response-initial)]
+         (is (= 200 (:status production-response-initial))
+             (str
+              "unexpected status code for initial production response"
+              "response: "
+              (ks/pprint-to-string production-response-initial)))
+         (is (not (nil? production-etag-initial))
+             "no etag returned for production response")
+         (is (= mock-response
+                (response->map production-response-initial))
+             "unexpected body for production response")
+         (is (= 200 (:status test-response-initial))
+             (str
+              "unexpected status code for initial test response"
+              "response: "
+              (ks/pprint-to-string test-response-initial)))
+         (is (not (nil? test-etag-initial))
+             "no etag returned for test response")
+         (is (= mock-response
+                (response->map test-response-initial))
+             "unexpected body for test response")
+
+         (str "test data")
+         (str "test data")
+         (purge-all-env-caches)
+
+         (let [production-response-after-all-flush (get-env-transports
+                                                    "production"
+                                                    production-etag-initial)
+               production-etag-after-all-flush (response-etag
+                                                production-response-after-all-flush)]
+           (is (= 200 (:status production-response-after-all-flush))
+               (str
+                "unexpected status code for prod response after code change "
+                "and all environment flush"))
+           (is (not (nil? production-etag-after-all-flush))
+               "no etag returned for production response")
+           (is (not= production-etag-initial production-etag-after-all-flush)
+               (str
+                "etag unexpectedly stayed the same even though "
+                "the production environment changed"))
+           (is (= mock-response
+                  (response->map
+                   production-response-after-all-flush))
+               "unexpected body for production response"))
+
+         (let [test-response-after-all-flush (get-env-transports
+                                              "test"
+                                              test-etag-initial)
+               test-etag-after-all-flush (response-etag
+                                          test-response-after-all-flush)]
+           (is (= 200 (:status test-response-after-all-flush))
+               (str
+                "unexpected status code for test response after code change "
+                "and all environment flush"))
+           (is (not (nil? test-etag-after-all-flush))
+               "no etag returned for test response")
+           (is (not= test-etag-initial test-etag-after-all-flush)
+               (str
+                "etag unexpectedly stayed the same even though "
+                "the test environment changed"))
+           (is (= mock-response
+                  (response->map
+                   test-response-after-all-flush))
+               "unexpected body for test response")))))))
+
+(deftest ^:integration
+         not-modified-returned-for-environment-transports-info-request-with-gzip-tag
+  (testing (str "SERVER-1153 - when the webserver gzips the response "
+                "containing environment_transports etag, the next request "
+                "roundtripping that etag returns an HTTP 304 (Not Modified)")
+    (let [expected-etag "abcd1234"
+          body-length 200000
+          jruby-service (reify jruby-protocol/JRubyPuppetService
+                          (get-environment-class-info-tag [_ _]
+                            expected-etag))
+          app (->
+               (fn [_]
+                 (master-core/response-with-etag
+                  (apply str (repeat body-length "a"))
+                  expected-etag))
+               (master-core/wrap-with-etag-check jruby-service))]
+      (jetty9/with-test-webserver
+       app
+       port
+       (let [request-url (str "http://localhost:" port)
+             initial-response (http-client/get request-url {:as :text})
+             response-tag (response-etag initial-response)
+             response-with-tag (http-client/get
+                                request-url
+                                {:headers {"If-None-Match" response-tag}
+                                 :as :text})]
+         (is (= 200 (:status initial-response))
+             "response for initial request is not 'successful'")
+         (is (= (get-in initial-response [:headers "content-encoding"]) "gzip")
+             "response from initial request was not gzipped")
+         (is (= body-length (count (:body initial-response)))
+             "unexpected response body length for initial response")
+         (is (= (str expected-etag "--gzip") response-tag)
+             "unexpected etag returned for initial response")
+         (is (= 304 (:status response-with-tag))
+             (str "request with prior etag did not return http 304 (not "
+                  "modified) status code"))
+         (is (empty? (:body response-with-tag))
+             "unexpected body for request with prior etag")
+         (is (= expected-etag (response-etag response-with-tag))
+             "unexpected etag returned for request with prior etag"))))))
+
+(defn create-jruby-instance-with-mock-transports-info
+  [wait-atom transports-info-atom config]
+  (let [puppet-config (jruby-testutils/mock-puppet-config-settings
+                       (:jruby-puppet config))]
+    (reify JRubyPuppet
+      (getSetting [_ setting]
+        (get puppet-config setting))
+      (getClassInfoForEnvironment [_ _]
+        (let [class-info
+              {"/some/file"
+               (doto (HashMap.)
+                 (.put
+                  "classes"
+                  @transports-info-atom))}]
+          (when-let [promises @wait-atom]
+            (deliver (:wait-promise promises) true)
+            @(:continue-promise promises))
+          class-info))
+      (getTransportInfoForEnvironment [_ _]
+        (let [a (ArrayList.)
+              t (walk/stringify-keys mock-transport)]
+          (.add a t)
+          a))
+      (handleRequest [_ _]
+        (JRubyPuppetResponse. 0 nil nil nil))
+      (puppetVersion [_]
+        "1.2.3")
+      (terminate [_]
+        (log/info "Terminating Master")))))
+
+#_(deftest ^:integration transports-info-updated-after-cache-flush-during-prior-request
+  (let [transports-info-atom (atom [{"name" "someclass" "params" []}])
+        wait-atom (atom nil)
+        config (bootstrap/load-dev-config-with-overrides
+                {:jruby-puppet {:gem-path gem-path
+                                :max-active-instances 1
+                                :environment-class-cache-enabled true}})
+        mock-jruby-fn (partial create-jruby-instance-with-mock-transports-info
+                               wait-atom
+                               transports-info-atom)]
+    ;; This test uses a mock jruby instance function which can provide mock
+    ;; data for an environment class info query and can suspend a request
+    ;; long enough for the cached environment data to be invalidated.
+    (tk-bootstrap-testutils/with-app-with-config
+     app
+     (bootstrap/services-from-dev-bootstrap-plus-mock-jruby-pool-manager-service
+      config
+      mock-jruby-fn)
+     config
+     (let [continue-promise (promise)
+           wait-promise (promise)
+           _ (reset! wait-atom {:continue-promise continue-promise
+                                :wait-promise wait-promise})
+           initial-response-future (future (get-env-transports "production"))]
+       (is (true? (deref wait-promise 10000 :timed-out))
+           (str "timed out waiting for get transports info call to be reached "
+                "in mock jrubypuppet instance"))
+       (reset! transports-info-atom [{"name" "updatedclass"
+                                 "params" []}])
+       (purge-env-cache "production")
+       (deliver continue-promise true)
+       (let [initial-response @initial-response-future
+             initial-response-etag (response-etag initial-response)
+             _ (reset! wait-atom nil)
+             response-after-update (get-env-transports "production"
+                                                    initial-response-etag)]
+         (testing (str "initial request in progress while environment "
+                       "cache is invalidated contains original transports info")
+           (is (= 200 (:status initial-response))
+               (str
+                "unexpected status code for initial response"
+                "response: "
+                (ks/pprint-to-string initial-response)))
+           (is (not (nil? initial-response-etag))
+               "no etag returned for initial response")
+           (is (= mock-response
+                  (response->map initial-response))
+               "unexpected body for initial response"))
+         (testing (str "transports info updated properly for "
+                       "request made after environment cache was purged "
+                       "during a previous transports info request")
+           (is (= 200 (:status response-after-update))
+               (str
+                "unexpected status code for response after update, "
+                "response: "
+                (ks/pprint-to-string response-after-update)))
+           (is (not= initial-response-etag
+                     (response-etag response-after-update))
+               "unexpected etag for response after update")
+           (is (= mock-response
+                  (response->map response-after-update))
+               "unexpected body for response after update")))))))

--- a/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
@@ -86,6 +86,37 @@ Puppet::ResourceApi.register_transport(
      :desc "A secret to protect."
      :sensitive true}}})
 
+(defn create-jruby-instance-with-mock-transports-info
+  ([transports-info-atom config]
+   (create-jruby-instance-with-mock-transports-info
+     (atom {:wait-promise (promise)
+            :continue-promise (-> (promise) (deliver true))})
+     transports-info-atom
+     config))
+  ([wait-atom transports-info-atom config]
+   (let [puppet-config (jruby-testutils/mock-puppet-config-settings
+                        (:jruby-puppet config))]
+     (reify JRubyPuppet
+       (getSetting [_ setting]
+         (get puppet-config setting))
+       (getClassInfoForEnvironment [_ _]
+         (let [class-info {"/some/file" {"classes" "foo"}}]
+           class-info))
+       (getTransportInfoForEnvironment [_ _]
+         (let [a (ArrayList.)]
+           (doseq [t @transports-info-atom]
+             (.add a t))
+           (when-let [promises @wait-atom]
+             (deliver (:wait-promise promises) true)
+             @(:continue-promise promises))
+           a))
+       (handleRequest [_ _]
+         (JRubyPuppetResponse. 0 nil nil nil))
+       (puppetVersion [_]
+         "1.2.3")
+       (terminate [_]
+         (log/info "Terminating Master"))))))
+
 (defn mkmod
   ([] (mkmod "production"))
   ([env]
@@ -174,334 +205,369 @@ Puppet::ResourceApi.register_transport(
 
 (deftest ^:integration environment-transports-integration-cache-disabled-test
   (testing "when environment cache is disabled for a transport request"
-    (bootstrap/with-puppetserver-running-with-config
-     app
-     (-> {:jruby-puppet {:gem-path gem-path
-                         :max-active-instances 1}}
-         (bootstrap/load-dev-config-with-overrides)
-         (ks/dissoc-in [:jruby-puppet
-                        :environment-class-cache-enabled]))
-     (let [_ (mkmod)
-           expected-response {:name "production" :transports [schema1-serialized]}
-           response (get-env-transports "production")]
-       (testing "a successful status code is returned"
-         (is (= 200 (:status response))
-             (str
-              "unexpected status code for response, response: "
-              (ks/pprint-to-string response))))
-       (testing "no etag is returned"
-         (is (false? (contains? (:headers response) "etag"))))
-       (testing "the expected response body is returned"
-         (is (= expected-response
-                (response->map response))))))))
+    (let [transports-info-atom (atom [(walk/stringify-keys schema1-serialized)])
+          config (bootstrap/load-dev-config-with-overrides
+                  {:jruby-puppet {:gem-path gem-path
+                                  :max-active-instances 1
+                                  :environment-class-cache-enabled false}})
+          mock-jruby-fn (partial create-jruby-instance-with-mock-transports-info
+                                 transports-info-atom)
+          expected-response {:name "production" :transports [schema1-serialized]}]
+      (tk-bootstrap-testutils/with-app-with-config
+       app
+       (bootstrap/services-from-dev-bootstrap-plus-mock-jruby-pool-manager-service
+        config
+        mock-jruby-fn)
+       config
+       (let [response (get-env-transports "production")]
+         (testing "a successful status code is returned"
+           (is (= 200 (:status response))
+               (str
+                "unexpected status code for response, response: "
+                (ks/pprint-to-string response))))
+         (testing "no etag is returned"
+           (is (false? (contains? (:headers response) "etag"))))
+         (testing "the expected response body is returned"
+           (is (= expected-response
+                  (response->map response)))))))))
 
 
 (deftest ^:integration environment-transports-integration-cache-enabled-test1
-  (bootstrap/with-puppetserver-running app
-   {:jruby-puppet {:gem-path gem-path
-                   :max-active-instances 1
-                   :environment-class-cache-enabled true}}
-   (testing "environment transport cache invalidation for one environment"
-     ;; This test is about ensuring that when the environment-cache
-     ;; endpoint is hit for a single environment that only that the
-     ;; environment class info cached for that environment - but not the
-     ;; info cached for other environments - is invalidated, meaning that
-     ;; the next request for class info for that environment will get fresh
-     ;; data.
-     ;;
-     ;; The test has the following basic steps:
-     ;;
-     ;; 1) Purge the current environment files on disk and hit the
-     ;;    environment-cache endpoint to flush the cache for all
-     ;;    environments, basically to ensure nothing is left around from
-     ;;    other tests.
-     ;; 2) Populate code for the 'test' and 'production' environments and
-     ;;    see that environment_transports queries return the right info for
-     ;;    them.
-     ;; 3) Do one more environment_transports query for each environment,
-     ;;    using the etag from the initial queries, to ensure that a 304
-     ;;    (Not Modified) is returned.
-     ;; 4) Change code on disk for both the 'test' and 'production'
-     ;;    environments.
-     ;; 5) Hit the environment-cache endpoint for the 'production'
-     ;;    environment (but not for the 'test' environment).
-     ;; 6) Do two more environment_transports queries for the 'test' and
-     ;;    'production' environments using the etags from the initial
-     ;;    queries.  Confirm that the information reflects the latest data on
-     ;;    disk for the 'production' environment but still reflects the old
-     ;;    data for the 'test' environment - expected, in this case, because
-     ;;    the 'test' environment was not flushed.
-     (purge-env-dir)
-     (purge-all-env-caches)
-     (let [prod-schema-dir (mkmod) ;; should this have different content then above?
-           test-schema-dir (mkmod "test")
-           production-response-initial (get-env-transports "production")
-           production-etag-initial (response-etag production-response-initial)
-           production-etag-initial-without-gzip-suffix (etag-without-gzip-suffix production-etag-initial)
-           test-response-initial (get-env-transports "test")
-           test-etag-initial (response-etag test-response-initial)
-           test-etag-initial-without-gzip-suffix (etag-without-gzip-suffix
-                                                   (response-etag test-response-initial))]
-       (is (= 200 (:status production-response-initial))
-           (str
-            "unexpected status code for initial production response"
-            "response: "
-            (ks/pprint-to-string production-response-initial)))
-       (is (not (nil? production-etag-initial))
-           "no etag returned for production response")
-       (is (= {:name "production" :transports [schema1-serialized]}
-              (response->map production-response-initial))
-           "unexpected body for production response")
-       (is (= 200 (:status test-response-initial))
-           (str
-            "unexpected status code for initial test response"
-            "response: "
-            (ks/pprint-to-string test-response-initial)))
-       (is (not (nil? test-etag-initial))
-           "no etag returned for test response")
-       (is (= {:name "test" :transports [schema1-serialized]}
-              (response->map test-response-initial))
-           "unexpected body for test response")
-
-       (spit (str prod-schema-dir "/test_device.rb") schema2)
-       (spit (str test-schema-dir "/test_device.rb") schema2)
-
-       (let [production-response-before-flush (get-env-transports
-                                               "production"
-                                               production-etag-initial)
-             test-response-before-flush (get-env-transports
-                                         "test"
-                                         test-etag-initial)]
-         (is (= 304 (:status production-response-before-flush))
+  (let [transports-info-atom (atom [(walk/stringify-keys schema1-serialized)])
+        config (bootstrap/load-dev-config-with-overrides
+                {:jruby-puppet {:gem-path gem-path
+                                :max-active-instances 1
+                                :environment-class-cache-enabled true}})
+        mock-jruby-fn (partial create-jruby-instance-with-mock-transports-info
+                               transports-info-atom)]
+    (tk-bootstrap-testutils/with-app-with-config
+     app
+     (bootstrap/services-from-dev-bootstrap-plus-mock-jruby-pool-manager-service
+      config
+      mock-jruby-fn)
+     config
+     (testing "environment transport cache invalidation for one environment"
+       ;; This test is about ensuring that when the environment-cache
+       ;; endpoint is hit for a single environment that only that the
+       ;; environment class info cached for that environment - but not the
+       ;; info cached for other environments - is invalidated, meaning that
+       ;; the next request for class info for that environment will get fresh
+       ;; data.
+       ;;
+       ;; The test has the following basic steps:
+       ;;
+       ;; 1) Purge the current environment files on disk and hit the
+       ;;    environment-cache endpoint to flush the cache for all
+       ;;    environments, basically to ensure nothing is left around from
+       ;;    other tests.
+       ;; 2) Populate code for the 'test' and 'production' environments and
+       ;;    see that environment_transports queries return the right info for
+       ;;    them.
+       ;; 3) Do one more environment_transports query for each environment,
+       ;;    using the etag from the initial queries, to ensure that a 304
+       ;;    (Not Modified) is returned.
+       ;; 4) Change code on disk for both the 'test' and 'production'
+       ;;    environments.
+       ;; 5) Hit the environment-cache endpoint for the 'production'
+       ;;    environment (but not for the 'test' environment).
+       ;; 6) Do two more environment_transports queries for the 'test' and
+       ;;    'production' environments using the etags from the initial
+       ;;    queries.  Confirm that the information reflects the latest data on
+       ;;    disk for the 'production' environment but still reflects the old
+       ;;    data for the 'test' environment - expected, in this case, because
+       ;;    the 'test' environment was not flushed.
+       (purge-env-dir)
+       (purge-all-env-caches)
+       (let [;; prod-schema-dir (mkmod)
+             ;; test-schema-dir (mkmod "test")
+             production-response-initial (get-env-transports "production")
+             production-etag-initial (response-etag production-response-initial)
+             production-etag-initial-without-gzip-suffix (etag-without-gzip-suffix production-etag-initial)
+             test-response-initial (get-env-transports "test")
+             test-etag-initial (response-etag test-response-initial)
+             test-etag-initial-without-gzip-suffix (etag-without-gzip-suffix
+                                                     (response-etag test-response-initial))]
+         (is (= 200 (:status production-response-initial))
              (str
-              "unexpected status code for prod response after code change "
-              "but before flush"))
-         (is (= production-etag-initial-without-gzip-suffix (response-etag
-                                                              production-response-before-flush))
-             "unexpected etag change when no production environment change")
-         (is (empty? (:body production-response-before-flush))
+              "unexpected status code for initial production response"
+              "response: "
+              (ks/pprint-to-string production-response-initial)))
+         (is (not (nil? production-etag-initial))
+             "no etag returned for production response")
+         (is (= {:name "production" :transports [schema1-serialized]}
+                (response->map production-response-initial))
              "unexpected body for production response")
-         (is (= 304 (:status test-response-before-flush))
+         (is (= 200 (:status test-response-initial))
              (str
-              "unexpected status code for test response after code change "
-              "but before flush"))
-         (is (= test-etag-initial-without-gzip-suffix (response-etag
-                                                        test-response-before-flush))
-             "unexpected etag change when no test environment change")
-         (is (empty? (:body test-response-before-flush))
-             "unexpected body for test response"))
+              "unexpected status code for initial test response"
+              "response: "
+              (ks/pprint-to-string test-response-initial)))
+         (is (not (nil? test-etag-initial))
+             "no etag returned for test response")
+         (is (= {:name "test" :transports [schema1-serialized]}
+                (response->map test-response-initial))
+             "unexpected body for test response")
 
-         (purge-env-cache "production")
-         (let [production-response-after-prod-flush (get-env-transports
-                                                     "production"
-                                                     production-etag-initial)
-               production-etag-after-prod-flush (response-etag
-                                                 production-response-after-prod-flush)
-               test-response-after-prod-flush (get-env-transports
-                                               "test"
-                                               test-etag-initial)]
-           (is (= 200 (:status production-response-after-prod-flush))
+         ;; (spit (str prod-schema-dir "/test_device.rb") schema2)
+         ;; (spit (str test-schema-dir "/test_device.rb") schema2)
+         (reset! transports-info-atom [(walk/stringify-keys schema2-serialized)])
+
+         (let [production-response-before-flush (get-env-transports
+                                                 "production"
+                                                 production-etag-initial)
+               test-response-before-flush (get-env-transports
+                                           "test"
+                                           test-etag-initial)]
+           (is (= 304 (:status production-response-before-flush))
                (str
                 "unexpected status code for prod response after code change "
-                "and prod flush"))
-           (is (not (nil? production-etag-after-prod-flush))
-               "no etag returned for production response")
-           (is (not= production-etag-initial
-                     production-etag-after-prod-flush)
-               (str
-                "etag unexpectedly stayed the same even though "
-                "the production environment changed"))
-           (is (= {:name "production" :transports [schema1-serialized schema2-serialized]}
-                  (response->map
-                   production-response-after-prod-flush))
+                "but before flush"))
+           (is (= production-etag-initial-without-gzip-suffix (response-etag
+                                                                production-response-before-flush))
+               "unexpected etag change when no production environment change")
+           (is (empty? (:body production-response-before-flush))
                "unexpected body for production response")
-           (is (= 304 (:status test-response-after-prod-flush)))
+           (is (= 304 (:status test-response-before-flush))
+               (str
+                "unexpected status code for test response after code change "
+                "but before flush"))
            (is (= test-etag-initial-without-gzip-suffix (response-etag
-                                                          test-response-after-prod-flush))
-               "unexpected etag change when test environment not invalidated")
-           (is (empty? (:body test-response-after-prod-flush))
-               "unexpected body for test response"))))))
+                                                          test-response-before-flush))
+               "unexpected etag change when no test environment change")
+           (is (empty? (:body test-response-before-flush))
+               "unexpected body for test response"))
+
+           (purge-env-cache "production")
+           (let [production-response-after-prod-flush (get-env-transports
+                                                       "production"
+                                                       production-etag-initial)
+                 production-etag-after-prod-flush (response-etag
+                                                   production-response-after-prod-flush)
+                 test-response-after-prod-flush (get-env-transports
+                                                 "test"
+                                                 test-etag-initial)]
+             (is (= 200 (:status production-response-after-prod-flush))
+                 (str
+                  "unexpected status code for prod response after code change "
+                  "and prod flush"))
+             (is (not (nil? production-etag-after-prod-flush))
+                 "no etag returned for production response")
+             (is (not= production-etag-initial
+                       production-etag-after-prod-flush)
+                 (str
+                  "etag unexpectedly stayed the same even though "
+                  "the production environment changed"))
+             (is (= {:name "production" :transports [schema2-serialized]}
+                    (response->map
+                     production-response-after-prod-flush))
+                 "unexpected body for production response")
+             (is (= 304 (:status test-response-after-prod-flush)))
+             (is (= test-etag-initial-without-gzip-suffix (response-etag
+                                                            test-response-after-prod-flush))
+                 "unexpected etag change when test environment not invalidated")
+             (is (empty? (:body test-response-after-prod-flush))
+                 "unexpected body for test response")))))))
 
 
 (deftest ^:integration environment-transports-integration-cache-enabled-test2
-  (bootstrap/with-puppetserver-running app
-   {:jruby-puppet {:gem-path gem-path
-                   :max-active-instances 1
-                   :environment-class-cache-enabled true}}
-   (let [schema-dir (mkmod)
-         expected-initial-response {:name "production" :transports [schema1-serialized]}
-         initial-response (get-env-transports "production")
-         initial-etag (response-etag initial-response)
-         initial-etag-with-gzip-suffix (etag-with-gzip-suffix initial-etag)
-         initial-etag-without-gzip-suffix (etag-without-gzip-suffix initial-etag)]
-     (testing "initial fetch of environment_transports info is good"
-       (is (= 200 (:status initial-response))
-           (str
-            "unexpected status code for initial response, response: "
-            (ks/pprint-to-string initial-response)))
-       (is (not (nil? initial-etag))
-           "no etag found for initial response")
-       (is (= expected-initial-response
-              (response->map initial-response))
-           "unexpected body for initial response"))
-     (testing "etag not updated when code has not changed"
-       (let [response (get-env-transports "production")]
-         (is (= 200 (:status response))
-             "unexpected status code for response following no code change")
-         (is (= initial-etag (response-etag response))
-             "etag changed even though code did not")
+  (let [transports-info-atom (atom [(walk/stringify-keys schema1-serialized)])
+        config (bootstrap/load-dev-config-with-overrides
+                {:jruby-puppet {:gem-path gem-path
+                                :max-active-instances 1
+                                :environment-class-cache-enabled true}})
+        mock-jruby-fn (partial create-jruby-instance-with-mock-transports-info
+                               transports-info-atom)]
+    (tk-bootstrap-testutils/with-app-with-config
+     app
+     (bootstrap/services-from-dev-bootstrap-plus-mock-jruby-pool-manager-service
+      config
+      mock-jruby-fn)
+     config
+     (let [;; schema-dir (mkmod)
+           expected-initial-response {:name "production" :transports [schema1-serialized]}
+           initial-response (get-env-transports "production")
+           initial-etag (response-etag initial-response)
+           initial-etag-with-gzip-suffix (etag-with-gzip-suffix initial-etag)
+           initial-etag-without-gzip-suffix (etag-without-gzip-suffix initial-etag)]
+       (testing "initial fetch of environment_transports info is good"
+         (is (= 200 (:status initial-response))
+             (str
+              "unexpected status code for initial response, response: "
+              (ks/pprint-to-string initial-response)))
+         (is (not (nil? initial-etag))
+             "no etag found for initial response")
          (is (= expected-initial-response
-                (response->map response))
-             "unexpected body for response")))
-     (testing (str "HTTP 304 (not modified) returned when request "
-                   "roundtrips last etag and code has not changed")
-       (let [response (get-env-transports "production" initial-etag)]
-         (is (= 304 (:status response))
-             (str
-              "unexpected status code for response for no code change and "
-              "original etag roundtripped"))
-         (is (= initial-etag-without-gzip-suffix (response-etag response))
-             "etag changed even though code did not")
-         (is (empty? (:body response))
-             "unexpected body for response")))
-     (testing (str "SERVER-1153 - HTTP 304 (not modified) returned when "
-                   "request roundtrips last etag with '--gzip' suffix and "
-                   "code has not changed")
-       (let [response (get-env-transports "production"
-                                       initial-etag-with-gzip-suffix)]
-         (is (= 304 (:status response))
-             (str
-              "unexpected status code for response for no code change and "
-              "etag with '--gzip' suffix roundtripped"))
-         (is (= initial-etag-without-gzip-suffix (response-etag response))
-             "etag changed even though code did not")
-         (is (empty? (:body response))
-             "unexpected body for response")))
-     (testing (str "environment_transport fetch without if-none-match "
-                   "header includes latest info after code update")
-       (let [_ (spit (str schema-dir "/test_device.rb") schema2)
-             _ (purge-all-env-caches)
-             response (get-env-transports "production")]
-         (is (= 200 (:status response))
-             (str
-              "unexpected status code for response following code change,"
-              "response: "
-              (ks/pprint-to-string response)))
-         (is (not= initial-etag (response-etag response))
-             "etag did not change even though code did")
-         (is (= {:name "production" :transports [schema1-serialized schema2-serialized]}
-                (response->map response))
-             "unexpected body following code change"))))))
+                (response->map initial-response))
+             "unexpected body for initial response"))
+       (testing "etag not updated when code has not changed"
+         (let [response (get-env-transports "production")]
+           (is (= 200 (:status response))
+               "unexpected status code for response following no code change")
+           (is (= initial-etag (response-etag response))
+               "etag changed even though code did not")
+           (is (= expected-initial-response
+                  (response->map response))
+               "unexpected body for response")))
+       (testing (str "HTTP 304 (not modified) returned when request "
+                     "roundtrips last etag and code has not changed")
+         (let [response (get-env-transports "production" initial-etag)]
+           (is (= 304 (:status response))
+               (str
+                "unexpected status code for response for no code change and "
+                "original etag roundtripped"))
+           (is (= initial-etag-without-gzip-suffix (response-etag response))
+               "etag changed even though code did not")
+           (is (empty? (:body response))
+               "unexpected body for response")))
+       (testing (str "SERVER-1153 - HTTP 304 (not modified) returned when "
+                     "request roundtrips last etag with '--gzip' suffix and "
+                     "code has not changed")
+         (let [response (get-env-transports "production"
+                                            initial-etag-with-gzip-suffix)]
+           (is (= 304 (:status response))
+               (str
+                "unexpected status code for response for no code change and "
+                "etag with '--gzip' suffix roundtripped"))
+           (is (= initial-etag-without-gzip-suffix (response-etag response))
+               "etag changed even though code did not")
+           (is (empty? (:body response))
+               "unexpected body for response")))
+       (testing (str "environment_transport fetch without if-none-match "
+                     "header includes latest info after code update")
+         (let [;; _ (spit (str schema-dir "/test_device.rb") schema2)
+               _ (reset! transports-info-atom [(walk/stringify-keys schema2-serialized)])
+               _ (purge-all-env-caches)
+               response (get-env-transports "production")]
+           (is (= 200 (:status response))
+               (str
+                "unexpected status code for response following code change,"
+                "response: "
+                (ks/pprint-to-string response)))
+           (is (not= initial-etag (response-etag response))
+               "etag did not change even though code did")
+           (is (= {:name "production" :transports [schema2-serialized]}
+                  (response->map response))
+               "unexpected body following code change")))))))
 
 
 (deftest ^:integration environment-transports-integration-cache-enabled-test3
-  (bootstrap/with-puppetserver-running app
-   {:jruby-puppet {:gem-path gem-path
-                   :max-active-instances 1
-                   :environment-class-cache-enabled true}}
-   (testing "environment transports cache invalidation for all environments"
-     ;; This test is about ensuring that when the environment-cache
-     ;; endpoint is hit with no environment parameter that any previously
-     ;; cached environment class info is invalidated, meaning that
-     ;; the next request for class info for all environments will get fresh
-     ;; data.
-     ;;
-     ;; To eliminate some of the redundancy between tests, this test doesn't
-     ;; repeat the intermediate step of checking to see that the first two
-     ;; environment queries were cached - 304 (Not Modified) returns -
-     ;; between the first set of environment_transports queries and the second
-     ;; set, done after the code on disk for both environments has changed.
-     ;;
-     ;; The test has the following basic steps:
-     ;;
-     ;; 1) Purge the current environment files on disk and hit the
-     ;;    environment-cache endpoint to flush the cache for all
-     ;;    environments, basically to ensure nothing is left around from
-     ;;    other tests.
-     ;; 2) Populate code for the 'test' and 'production' environments and
-     ;;    see that environment_transports queries return the right info for
-     ;;    them.
-     ;; 3) Change code on disk for both the 'test' and 'production'
-     ;;    environments.
-     ;; 4) Hit the environment-cache endpoint with no environment
-     ;;    parameter, expected to have the effect of flushing the cache for
-     ;;    all environments.
-     ;; 5) Do two more environment_transports queries for the 'test' and
-     ;;    'production' environments with the corresponding etags returned
-     ;;    from the first two queries.  Confirm that the information
-     ;;    reflects the latest data on disk for both environments.
-     (purge-env-dir)
-     (purge-all-env-caches)
-     (let [prod-schema-dir (mkmod)
-           test-schema-dir (mkmod "test")
-           production-response-initial (get-env-transports "production")
-           production-etag-initial (response-etag production-response-initial)
-           test-response-initial (get-env-transports "test")
-           test-etag-initial (response-etag test-response-initial)]
-       (is (= 200 (:status production-response-initial))
-           (str
-            "unexpected status code for initial production response"
-            "response: "
-            (ks/pprint-to-string production-response-initial)))
-       (is (not (nil? production-etag-initial))
-           "no etag returned for production response")
-       (is (= {:name "production" :transports [schema1-serialized]}
-              (response->map production-response-initial))
-           "unexpected body for production response")
-       (is (= 200 (:status test-response-initial))
-           (str
-            "unexpected status code for initial test response"
-            "response: "
-            (ks/pprint-to-string test-response-initial)))
-       (is (not (nil? test-etag-initial))
-           "no etag returned for test response")
-       (is (= {:name "test" :transports [schema1-serialized]}
-              (response->map test-response-initial))
-           "unexpected body for test response")
-
-       (spit (str prod-schema-dir "/test_device.rb") schema2)
-       (spit (str test-schema-dir "/test_device.rb") schema2)
+  (let [transports-info-atom (atom [(walk/stringify-keys schema1-serialized)])
+        config (bootstrap/load-dev-config-with-overrides
+                {:jruby-puppet {:gem-path gem-path
+                                :max-active-instances 1
+                                :environment-class-cache-enabled true}})
+        mock-jruby-fn (partial create-jruby-instance-with-mock-transports-info
+                               transports-info-atom)]
+    (tk-bootstrap-testutils/with-app-with-config
+     app
+     (bootstrap/services-from-dev-bootstrap-plus-mock-jruby-pool-manager-service
+      config
+      mock-jruby-fn)
+     config
+     (testing "environment transports cache invalidation for all environments"
+       ;; This test is about ensuring that when the environment-cache
+       ;; endpoint is hit with no environment parameter that any previously
+       ;; cached environment class info is invalidated, meaning that
+       ;; the next request for class info for all environments will get fresh
+       ;; data.
+       ;;
+       ;; To eliminate some of the redundancy between tests, this test doesn't
+       ;; repeat the intermediate step of checking to see that the first two
+       ;; environment queries were cached - 304 (Not Modified) returns -
+       ;; between the first set of environment_transports queries and the second
+       ;; set, done after the code on disk for both environments has changed.
+       ;;
+       ;; The test has the following basic steps:
+       ;;
+       ;; 1) Purge the current environment files on disk and hit the
+       ;;    environment-cache endpoint to flush the cache for all
+       ;;    environments, basically to ensure nothing is left around from
+       ;;    other tests.
+       ;; 2) Populate code for the 'test' and 'production' environments and
+       ;;    see that environment_transports queries return the right info for
+       ;;    them.
+       ;; 3) Change code on disk for both the 'test' and 'production'
+       ;;    environments.
+       ;; 4) Hit the environment-cache endpoint with no environment
+       ;;    parameter, expected to have the effect of flushing the cache for
+       ;;    all environments.
+       ;; 5) Do two more environment_transports queries for the 'test' and
+       ;;    'production' environments with the corresponding etags returned
+       ;;    from the first two queries.  Confirm that the information
+       ;;    reflects the latest data on disk for both environments.
+       (purge-env-dir)
        (purge-all-env-caches)
-
-       (let [production-response-after-all-flush (get-env-transports
-                                                  "production"
-                                                  production-etag-initial)
-             production-etag-after-all-flush (response-etag
-                                              production-response-after-all-flush)]
-         (is (= 200 (:status production-response-after-all-flush))
+       (let [;; prod-schema-dir (mkmod)
+             ;; test-schema-dir (mkmod "test")
+             production-response-initial (get-env-transports "production")
+             production-etag-initial (response-etag production-response-initial)
+             test-response-initial (get-env-transports "test")
+             test-etag-initial (response-etag test-response-initial)]
+         (is (= 200 (:status production-response-initial))
              (str
-              "unexpected status code for prod response after code change "
-              "and all environment flush"))
-         (is (not (nil? production-etag-after-all-flush))
+              "unexpected status code for initial production response"
+              "response: "
+              (ks/pprint-to-string production-response-initial)))
+         (is (not (nil? production-etag-initial))
              "no etag returned for production response")
-         (is (not= production-etag-initial production-etag-after-all-flush)
+         (is (= {:name "production" :transports [schema1-serialized]}
+                (response->map production-response-initial))
+             "unexpected body for production response")
+         (is (= 200 (:status test-response-initial))
              (str
-              "etag unexpectedly stayed the same even though "
-              "the production environment changed"))
-         (is (= {:name "production" :transports [schema1-serialized schema2-serialized]}
-                (response->map
-                 production-response-after-all-flush))
-             "unexpected body for production response"))
-
-       (let [test-response-after-all-flush (get-env-transports
-                                            "test"
-                                            test-etag-initial)
-             test-etag-after-all-flush (response-etag
-                                        test-response-after-all-flush)]
-         (is (= 200 (:status test-response-after-all-flush))
-             (str
-              "unexpected status code for test response after code change "
-              "and all environment flush"))
-         (is (not (nil? test-etag-after-all-flush))
+              "unexpected status code for initial test response"
+              "response: "
+              (ks/pprint-to-string test-response-initial)))
+         (is (not (nil? test-etag-initial))
              "no etag returned for test response")
-         (is (not= test-etag-initial test-etag-after-all-flush)
-             (str
-              "etag unexpectedly stayed the same even though "
-              "the test environment changed"))
-         (is (= {:name "test" :transports [schema1-serialized schema2-serialized]}
-                (response->map
-                 test-response-after-all-flush))
-             "unexpected body for test response"))))))
+         (is (= {:name "test" :transports [schema1-serialized]}
+                (response->map test-response-initial))
+             "unexpected body for test response")
+
+         ;; (spit (str prod-schema-dir "/test_device.rb") schema2)
+         ;; (spit (str test-schema-dir "/test_device.rb") schema2)
+         (reset! transports-info-atom [(walk/stringify-keys schema2-serialized)])
+         (purge-all-env-caches)
+
+         (let [production-response-after-all-flush (get-env-transports
+                                                    "production"
+                                                    production-etag-initial)
+               production-etag-after-all-flush (response-etag
+                                                production-response-after-all-flush)]
+           (is (= 200 (:status production-response-after-all-flush))
+               (str
+                "unexpected status code for prod response after code change "
+                "and all environment flush"))
+           (is (not (nil? production-etag-after-all-flush))
+               "no etag returned for production response")
+           (is (not= production-etag-initial production-etag-after-all-flush)
+               (str
+                "etag unexpectedly stayed the same even though "
+                "the production environment changed"))
+           (is (= {:name "production" :transports [schema2-serialized]}
+                  (response->map
+                   production-response-after-all-flush))
+               "unexpected body for production response"))
+
+         (let [test-response-after-all-flush (get-env-transports
+                                              "test"
+                                              test-etag-initial)
+               test-etag-after-all-flush (response-etag
+                                          test-response-after-all-flush)]
+           (is (= 200 (:status test-response-after-all-flush))
+               (str
+                "unexpected status code for test response after code change "
+                "and all environment flush"))
+           (is (not (nil? test-etag-after-all-flush))
+               "no etag returned for test response")
+           (is (not= test-etag-initial test-etag-after-all-flush)
+               (str
+                "etag unexpectedly stayed the same even though "
+                "the test environment changed"))
+           (is (= {:name "test" :transports [schema2-serialized]}
+                  (response->map
+                   test-response-after-all-flush))
+               "unexpected body for test response")))))))
 
 (deftest ^:integration
          not-modified-returned-for-environment-transports-info-request-with-gzip-tag
@@ -545,32 +611,8 @@ Puppet::ResourceApi.register_transport(
          (is (= expected-etag (response-etag response-with-tag))
              "unexpected etag returned for request with prior etag"))))))
 
-(defn create-jruby-instance-with-mock-transports-info
-  [wait-atom transports-info-atom config]
-  (let [puppet-config (jruby-testutils/mock-puppet-config-settings
-                       (:jruby-puppet config))]
-    (reify JRubyPuppet
-      (getSetting [_ setting]
-        (get puppet-config setting))
-      (getClassInfoForEnvironment [_ _]
-        (let [class-info {"/some/file" {"classes" "foo"}}]
-          class-info))
-      (getTransportInfoForEnvironment [_ _]
-        (let [a (ArrayList.)]
-          (.add a @transports-info-atom)
-          (when-let [promises @wait-atom]
-            (deliver (:wait-promise promises) true)
-            @(:continue-promise promises))
-          a))
-      (handleRequest [_ _]
-        (JRubyPuppetResponse. 0 nil nil nil))
-      (puppetVersion [_]
-        "1.2.3")
-      (terminate [_]
-        (log/info "Terminating Master")))))
-
 (deftest ^:integration transports-info-updated-after-cache-flush-during-prior-request
-  (let [transports-info-atom (atom {:name "transport1"})
+  (let [transports-info-atom (atom [{:name "transport1"}])
         wait-atom (atom nil)
         config (bootstrap/load-dev-config-with-overrides
                 {:jruby-puppet {:gem-path gem-path
@@ -596,7 +638,7 @@ Puppet::ResourceApi.register_transport(
        (is (true? (deref wait-promise 10000 :timed-out))
            (str "timed out waiting for get transports info call to be reached "
                 "in mock jrubypuppet instance"))
-       (reset! transports-info-atom {:name "transport2"})
+       (reset! transports-info-atom [{:name "transport2"}])
        (purge-env-cache "production")
        (deliver continue-promise true)
        (let [initial-response @initial-response-future

--- a/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
@@ -117,8 +117,8 @@ Puppet::ResourceApi.register_transport(
        (terminate [_]
          (log/info "Terminating Master"))))))
 
-(defn mkmod
-  ([] (mkmod "production"))
+(defn make-module
+  ([] (make-module "production"))
   ([env]
     (let [module-dir (testutils/create-module "test_module"
                                               {:env-name env})
@@ -278,8 +278,8 @@ Puppet::ResourceApi.register_transport(
        ;;    the 'test' environment was not flushed.
        (purge-env-dir)
        (purge-all-env-caches)
-       (let [;; prod-schema-dir (mkmod)
-             ;; test-schema-dir (mkmod "test")
+       (let [;; prod-schema-dir (make-module)
+             ;; test-schema-dir (make-module "test")
              production-response-initial (get-env-transports "production")
              production-etag-initial (response-etag production-response-initial)
              production-etag-initial-without-gzip-suffix (etag-without-gzip-suffix production-etag-initial)
@@ -383,7 +383,7 @@ Puppet::ResourceApi.register_transport(
       config
       mock-jruby-fn)
      config
-     (let [;; schema-dir (mkmod)
+     (let [;; schema-dir (make-module)
            expected-initial-response {:name "production" :transports [schema1-serialized]}
            initial-response (get-env-transports "production")
            initial-etag (response-etag initial-response)
@@ -497,8 +497,8 @@ Puppet::ResourceApi.register_transport(
        ;;    reflects the latest data on disk for both environments.
        (purge-env-dir)
        (purge-all-env-caches)
-       (let [;; prod-schema-dir (mkmod)
-             ;; test-schema-dir (mkmod "test")
+       (let [;; prod-schema-dir (make-module)
+             ;; test-schema-dir (make-module "test")
              production-response-initial (get-env-transports "production")
              production-etag-initial (response-etag production-response-initial)
              test-response-initial (get-env-transports "test")
@@ -577,14 +577,14 @@ Puppet::ResourceApi.register_transport(
     (let [expected-etag "abcd1234"
           body-length 200000
           jruby-service (reify jruby-protocol/JRubyPuppetService
-                          (get-environment-info-tag [_ _ _]
+                          (get-cached-info-tag [_ _ _]
                             expected-etag))
           app (->
                (fn [_]
                  (master-core/response-with-etag
                   (apply str (repeat body-length "a"))
                   expected-etag))
-               (master-core/wrap-with-etag-check jruby-service))]
+               (master-core/wrap-with-cache-check jruby-service))]
       (jetty9/with-test-webserver
        app
        port

--- a/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
@@ -117,7 +117,7 @@
                         :environment-class-cache-enabled]))
      (let [foo-file (testutils/write-foo-pp-file
                      "some kind of test data")
-           expected-response (json/encode mock-response)
+           expected-response mock-response
            response (get-env-transports "production")]
        (testing "a successful status code is returned"
          (is (= 200 (:status response))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -115,7 +115,7 @@
             etag #(-> %
                       (class-info-from-jruby->class-info-for-json "production")
                       json/encode
-                      ks/utf8-string->sha1)
+                      ks/utf8-string->sha256)
             map-with-classes #(doto (HashMap.)
                                (.put "classes" %))]
         (testing "returns 200 for environment that exists"

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -106,9 +106,9 @@
                             (get-environment-class-info [_ _ env]
                               (if (= env "production")
                                 {}))
-                            (get-environment-cache-version!
+                            (get-cached-content-version
                               [_ _ _])
-                            (set-environment-info-tag! [_ _ _ _ _]))
+                            (set-cache-info-tag! [_ _ _ _ _]))
             handler (fn ([req] {:request req}))
             app (build-ring-handler handler "1.2.3" jruby-service)
             request (partial app-request app)

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -113,13 +113,9 @@
             app (build-ring-handler handler "1.2.3" jruby-service)
             request (partial app-request app)
             etag #(-> %
-                      (environment-class-response!
-                       "production"
-                       jruby-service
-                       nil
-                       nil
-                       true)
-                      (rr/get-header "Etag"))
+                      (class-info-from-jruby->class-info-for-json "production")
+                      json/encode
+                      ks/utf8-string->sha1)
             map-with-classes #(doto (HashMap.)
                                (.put "classes" %))]
         (testing "returns 200 for environment that exists"

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -108,7 +108,7 @@
                                 {}))
                             (get-environment-class-info-cache-generation-id!
                               [_ _])
-                            (set-environment-class-info-tag! [_ _ _ _]))
+                            (set-environment-info-tag! [_ _ _ _ _]))
             handler (fn ([req] {:request req}))
             app (build-ring-handler handler "1.2.3" jruby-service)
             request (partial app-request app)

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -106,8 +106,8 @@
                             (get-environment-class-info [_ _ env]
                               (if (= env "production")
                                 {}))
-                            (get-environment-class-info-cache-generation-id!
-                              [_ _])
+                            (get-environment-cache-version!
+                              [_ _ _])
                             (set-environment-info-tag! [_ _ _ _ _]))
             handler (fn ([req] {:request req}))
             app (build-ring-handler handler "1.2.3" jruby-service)


### PR DESCRIPTION
This depends on https://github.com/puppetlabs/puppetserver/pull/2065 see https://github.com/justinstoller/puppetserver/compare/server2471-3...justinstoller:server2532 for a realistic diff.

I need to update the tests at a minimum. Though I'd love to go through and rename all our caching, but I'm not sure if that's just a nice to have, that could potentially do later.