### PR TITLE
Cache health check variables to avoid pegging CPU every 10 sec

### DIFF
--- a/docker/puppetserver-standalone/healthcheck.sh
+++ b/docker/puppetserver-standalone/healthcheck.sh
@@ -1,14 +1,27 @@
 #!/usr/bin/env bash
+#
+# shellcheck disable=SC1091,SC2154
+
 
 set -x
 set -e
 
-hostname=$(puppet config print certname) && \
+# since it takes ~1 second at 100% CPU to receive a single setting using `puppet
+# config` we cache them
+if [[ ! -f /tmp/puppet_env ]]; then
+  puppet config print --render-as yaml certname hostcert hostprivkey localcacert | tail -n+2 | sed -re 's/^/puppet_/g' -e 's/: /=/g' > /tmp/puppet_env
+fi
+
+set -a
+. /tmp/puppet_env
+set +a
+
+hostname="${puppet_certname}" && \
 curl --fail \
 --resolve "${hostname}:8140:127.0.0.1" \
---cert   $(puppet config print hostcert) \
---key    $(puppet config print hostprivkey) \
---cacert $(puppet config print localcacert) \
+--cert   "${puppet_hostcert}" \
+--key    "${puppet_hostprivkey}" \
+--cacert "${puppet_localcacert}" \
 "https://${hostname}:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test" \
 |  grep -q '"is_alive":true' \
 || exit 1


### PR DESCRIPTION
I use the Puppetserver docker image in development quite often, and it's been bugging me to see the `puppet config print somevariable` processes appear every few seconds and then use 100% CPU for a second or two.

This PR writes the values necessary for the Docker health check into `/tmp/puppet_env` on the first run, and uses that for future runs.

Of course, this has the downside of being a tad less flexible, but I doubt that many people actually go and change hostname on their Docker containers...

The below example is from the health check prior to this patch, where it takes ~6 seconds with 98% CPU use just to run a simple health check:

~~~
root@puppet:/# \time ./healthcheck.sh
+ set -e
++ puppet config print certname
+ hostname=puppet.lan
+ grep -q '"is_alive":true'
++ puppet config print hostcert
++ puppet config print hostprivkey
++ puppet config print localcacert
+ curl --fail --resolve puppet.lan:8140:127.0.0.1 --cert /etc/puppetlabs/puppet/ssl/certs/puppet.lan.pem --key /etc/puppetlabs/puppet/ssl/private_keys/puppet.lan.pem --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem https://puppet.lan:8140/production/status/test
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    35  100    35    0     0    296      0 --:--:-- --:--:-- --:--:--   296
5.52user 0.47system 0:06.07elapsed 98%CPU (0avgtext+0avgdata 54432maxresident)k
0inputs+0outputs (0major+42059minor)pagefaults 0swaps
~~~

After the change the first invocation of the check returns in <2 seconds and subsequent invocations in <0.1 seconds:

~~~
root@puppet:/# \time ./healthcheck.sh
+ set -e
+ [[ ! -f /tmp/puppet_env ]]
+ puppet config print --render-as yaml certname hostcert hostprivkey localcacert
+ tail -n+2
+ sed -re 's/^/puppet_/g' -e 's/: /=/g'
+ set -a
+ . /tmp/puppet_env
++ puppet_certname=puppet.lan
++ puppet_hostcert=/etc/puppetlabs/puppet/ssl/certs/puppet.lan.pem
++ puppet_hostprivkey=/etc/puppetlabs/puppet/ssl/private_keys/puppet.lan.pem
++ puppet_localcacert=/etc/puppetlabs/puppet/ssl/certs/ca.pem
+ set +a
+ hostname=puppet.lan
+ curl --fail --resolve puppet.lan:8140:127.0.0.1 --cert /etc/puppetlabs/puppet/ssl/certs/puppet.lan.pem --key /etc/puppetlabs/puppet/ssl/private_keys/puppet.lan.pem --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem https://puppet.lan:8140/production/status/test
+ grep -q '"is_alive":true'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    35  100    35    0     0    380      0 --:--:-- --:--:-- --:--:--   380
1.62user 0.13system 0:01.80elapsed 97%CPU (0avgtext+0avgdata 54596maxresident)k
0inputs+8outputs (0major+11307minor)pagefaults 0swaps
root@puppet:/# \time ./healthcheck.sh
+ set -e
+ [[ ! -f /tmp/puppet_env ]]
+ set -a
+ . /tmp/puppet_env
++ puppet_certname=puppet.lan
++ puppet_hostcert=/etc/puppetlabs/puppet/ssl/certs/puppet.lan.pem
++ puppet_hostprivkey=/etc/puppetlabs/puppet/ssl/private_keys/puppet.lan.pem
++ puppet_localcacert=/etc/puppetlabs/puppet/ssl/certs/ca.pem
+ set +a
+ hostname=puppet.lan
+ curl --fail --resolve puppet.lan:8140:127.0.0.1 --cert /etc/puppetlabs/puppet/ssl/certs/puppet.lan.pem --key /etc/puppetlabs/puppet/ssl/private_keys/puppet.lan.pem --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem https://puppet.lan:8140/production/status/test
+ grep -q '"is_alive":true'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    35  100    35    0     0    324      0 --:--:-- --:--:-- --:--:--   324
0.07user 0.00system 0:00.11elapsed 62%CPU (0avgtext+0avgdata 5624maxresident)k
0inputs+0outputs (0major+698minor)pagefaults 0swaps
~~~