### PR TITLE
(maint) Update puppetserver healthcheck to not use `puppet config print`

### DIFF
--- a/docker/puppetserver-standalone/healthcheck.sh
+++ b/docker/puppetserver-standalone/healthcheck.sh
@@ -4,7 +4,7 @@ set -x
 set -e
 
 certname=$(ls /etc/puppetlabs/puppet/ssl/certs | grep --invert-match ca.pem) && \
-hostname=${certname%.*} && \
+hostname=$(basename $certname .pem) && \
 hostprivkey=/etc/puppetlabs/puppet/ssl/private_keys/$certname && \
 hostcert=/etc/puppetlabs/puppet/ssl/certs/$certname && \
 localcacert=/etc/puppetlabs/puppet/ssl/certs/ca.pem && \

--- a/docker/puppetserver-standalone/healthcheck.sh
+++ b/docker/puppetserver-standalone/healthcheck.sh
@@ -3,12 +3,16 @@
 set -x
 set -e
 
-hostname=$(puppet config print certname) && \
+certname=$(ls /etc/puppetlabs/puppet/ssl/certs | grep --invert-match ca.pem) && \
+hostname=${certname%.*} && \
+hostprivkey=/etc/puppetlabs/puppet/ssl/private_keys/$certname && \
+hostcert=/etc/puppetlabs/puppet/ssl/certs/$certname && \
+localcacert=/etc/puppetlabs/puppet/ssl/certs/ca.pem && \
 curl --fail \
 --resolve "${hostname}:8140:127.0.0.1" \
---cert   $(puppet config print hostcert) \
---key    $(puppet config print hostprivkey) \
---cacert $(puppet config print localcacert) \
+--cert   $hostcert \
+--key    $hostprivkey \
+--cacert $localcacert \
 "https://${hostname}:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test" \
 |  grep -q '"is_alive":true' \
 || exit 1


### PR DESCRIPTION
Rather than using `puppet config print` to determine hostname and cert
locations, we hard-code directory paths and figure out the certname
based on what certificate we find on the filesystem.

This has some significant performance improvements over the previous
healthcheck.

Tested on a macbook, with old script:
$ time ./healthcheck.sh

real    0m2.405s
user    0m2.130s
sys     0m0.160s

tested on the same macbook, with new script:
$ time ./healthcheck.sh

real    0m0.092s
user    0m0.030s
sys     0m0.000s