### PR TITLE
(SERVER-2540) Compile AST snippets

### DIFF
--- a/documentation/puppet-api/v3/compile.markdown
+++ b/documentation/puppet-api/v3/compile.markdown
@@ -36,7 +36,7 @@ The request body must look like:
   "transaction_uuid": "<uuid string>",
   "job_id": "<id string>",
   "options": { "capture_logs": <true/false>,
-               "log_level": <one of debug/info/warn>}
+               "log_level": <one of debug/info/warning/err>}
 }
 ```
 

--- a/spec/puppet-server-lib/puppet/jvm/ast_compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/ast_compiler_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+require 'puppet_pal'
+
+require 'puppet/server/ast_compiler'
+
+def generate_ast(code)
+  Puppet::Pal.in_tmp_environment("ast") do |pal|
+    pal.with_catalog_compiler do |compiler|
+      ast = compiler.parse_string(code)
+      Puppet::Pops::Serialization::ToDataConverter.convert(ast,
+                                                           rich_data: true,
+                                                           symbol_to_string: true)
+    end
+  end
+end
+
+def request(code)
+  {"certname" => "localhost",
+   "facts" => {"values" => {"my_fact" => "fact_value"}},
+   "trusted_facts" => {"values" => {"my_trusted" => "trusted_value"}},
+   "options" => {"capture_logs" => false},
+   "environment" => "production",
+   "code_ast" => generate_ast(code).to_json,
+   "variables" => {"values" => {"foo" => "bar"}}}
+end
+
+def find_notify(catalog)
+  catalog['resources'].find do |item|
+    item['type'] == 'Notify'
+  end
+end
+
+describe Puppet::Server::ASTCompiler do
+  context 'when compiling AST' do
+    it 'handles basic resources' do
+      response = Puppet::Server::ASTCompiler.compile(request("notify { 'my_notify': }"))
+      notify = find_notify(response[:catalog])
+      expect(notify).not_to be_nil
+      expect(notify['title']).to eq("my_notify")
+    end
+
+    it 'correctly interpolates supplied variables' do
+      response = Puppet::Server::ASTCompiler.compile(request('notify { "$foo": }'))
+      notify = find_notify(response[:catalog])
+      expect(notify).not_to be_nil
+      expect(notify['title']).to eq("bar")
+    end
+
+    it 'correctly interpolates supplied facts' do
+      response = Puppet::Server::ASTCompiler.compile(request('notify { "$my_fact": }'))
+      notify = find_notify(response[:catalog])
+      expect(notify).not_to be_nil
+      expect(notify['title']).to eq("fact_value")
+    end
+
+    it 'correctly interpolates supplied trusted facts' do
+      response = Puppet::Server::ASTCompiler.compile(request('notify { "${trusted[\'my_trusted\']}": }'))
+      notify = find_notify(response[:catalog])
+      expect(notify).not_to be_nil
+      expect(notify['title']).to eq("trusted_value")
+    end
+  end
+end

--- a/src/ruby/puppetserver-lib/puppet/server/ast_compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/ast_compiler.rb
@@ -1,0 +1,53 @@
+require 'puppet_pal'
+require 'puppet/server/log_collector'
+require 'puppet/server/logging'
+
+module Puppet
+  module Server
+    class ASTCompiler
+      def self.compile(compile_options)
+        options = compile_options['options'] || {}
+
+        log_level = options['log_level']
+        code = JSON.parse(compile_options['code_ast'])
+
+        if options['capture_logs']
+          catalog, logs = Logging.capture_logs(log_level) do
+            compile_ast(code, compile_options)
+          end
+
+          { catalog: catalog, logs: logs }
+        else
+          catalog = compile_ast(code, compile_options)
+          { catalog: catalog }
+        end
+      end
+
+      def self.compile_ast(code, compile_options)
+        Puppet[:node_name_value] = compile_options['certname']
+
+        # Use the existing environment with the requested name
+        Puppet::Pal.in_environment(compile_options['environment'],
+                                   envpath: Puppet[:environmentpath],
+                                   facts: compile_options['facts']['values'],
+                                   variables: compile_options['variables']['values']) do |pal|
+          Puppet.lookup(:pal_current_node).trusted_data = compile_options['trusted_facts']['values']
+
+          # This compiler has been configured with a node containing
+          # the requested environment, facts, and variables, and is used
+          # to compile a catalog in that context from the supplied AST.
+          pal.with_catalog_compiler do |compiler|
+            # We have to parse the AST inside the compiler block, because it
+            # initializes the necessary type loaders for us.
+            ast = Puppet::Pops::Serialization::FromDataConverter.convert(code)
+
+            compiler.evaluate(ast)
+            compiler.compile_additions
+            compiler.catalog_data_hash
+          end
+        end
+      end
+      private_class_method :compile_ast
+    end
+  end
+end

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -73,10 +73,6 @@ module Puppet
           node.environment = requested_environment
         end
 
-        # Merges facts into the node parameters.
-        # Ensures that facts will be surfaced as top-scope variables,
-        # along with other node parameters.
-        node.merge(facts.values)
         node.trusted_data = trusted_facts
         node.add_server_facts(@server_facts)
         node

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -10,6 +10,7 @@ require 'puppet/server/config'
 require 'puppet/server/puppet_config'
 require 'puppet/server/network/http/handler'
 require 'puppet/server/compiler'
+require 'puppet/server/ast_compiler'
 
 require 'java'
 
@@ -69,7 +70,7 @@ class Puppet::Server::Master
   end
 
   def compileAST(compile_options)
-    {mock: "data"}
+    Puppet::Server::ASTCompiler.compile(convert_java_args_to_ruby(compile_options))
   end
 
   def getClassInfoForEnvironment(env)


### PR DESCRIPTION
This adds the Ruby logic to compile catalogs from snippets of Puppet AST. It is built on https://github.com/puppetlabs/puppetserver/pull/2069 (logging refactor) and https://github.com/puppetlabs/puppetserver/pull/2069 (Clojure endpoint exposure).

See https://github.com/puppetlabs/bolt/blob/master/lib/bolt/catalog.rb#L63-L90 for the bolt version of this functionality.