### PR TITLE
Build puppetserver snapshot packages for use in docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+/lib/
+/classes/
+/targets/
+target/
+/.bundle/
+/resources/puppetlabs/puppetserver/*.class
+/tmp/
+/dev-resources/i18n/bin

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,9 @@
-/lib/
-/classes/
-/targets/
-target/
-/.bundle/
-/resources/puppetlabs/puppetserver/*.class
-/tmp/
-/dev-resources/i18n/bin
+*
+!.git
+!project.clj
+!docker
+!documentation
+!ezbake
+!resources
+!ruby
+!src

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 docker/puppetserver/*               text  eol=lf
 docker/puppetserver-standalone/*    text  eol=lf
 docker/puppetserver-standalone/docker-entrypoint.d/*    text  eol=lf
+resources/ext/build-scripts/*       text  eol=lf
+resources/ext/cli_defaults/*        text  eol=lf
+resources/ext/cli/*                 text  eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ pom.xml
 *jar
 /lib/
 /classes/
+/output/
 /targets/
 .lein-deps-sum
 .lein-failures

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ matrix:
         - DOCKER_COMPOSE_VERSION=1.24.0
       script:
         - |
-          if [ -n "$TRAVIS_COMMIT_RANGE" ]; then
-            git diff --name-only $TRAVIS_COMMIT_RANGE | grep docker || {
-              echo "No changes made to 'docker' directory, skipping container tests"
-              exit
-            }
-          fi
           set -ex
           sudo rm /usr/local/bin/docker-compose
           curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ steps:
   name: lint_puppetserver_dockerfile
 - powershell: |
     . ./docker/ci/build.ps1
-    Build-Container -Name puppetserver-standalone -Namespace $ENV:NAMESPACE
+    Build-Container -Name puppetserver-standalone -Namespace $ENV:NAMESPACE -Context ..
   displayName: Build PuppetServer-Standalone Container
   name: build_puppetserverstandalone_container
 - powershell: |

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -38,8 +38,7 @@ build: prep
 		--build-arg version=$(version) \
 		--build-arg pupperware_analytics_stream=$(PUPPERWARE_ANALYTICS_STREAM) \
 		--file puppetserver-standalone/$(dockerfile) \
-		--tag $(NAMESPACE)/puppetserver-standalone:$(version) \
-		puppetserver-standalone
+		--tag $(NAMESPACE)/puppetserver-standalone:$(version) $(pwd)/..
 	@docker build \
 		--build-arg namespace=$(NAMESPACE) \
 		--build-arg vcs_ref=$(vcs_ref) \

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -47,7 +47,7 @@ function Build-Container(
     $docker_args += '--pull'
   }
 
-  docker build $docker_args $Name
+  docker build $docker_args ..
 
   Pop-Location
 }

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -27,6 +27,7 @@ function Lint-Dockerfile($Path)
 function Build-Container(
   $Name,
   $Namespace = 'puppet',
+  $Context = "$Name",
   $Version = (Get-ContainerVersion),
   $Vcs_ref = $(git rev-parse HEAD),
   $Pull = $true)
@@ -48,7 +49,7 @@ function Build-Container(
     $docker_args += '--pull'
   }
 
-  docker build $docker_args ..
+  docker build $docker_args $Context
 
   Pop-Location
 }

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -21,7 +21,7 @@ function Get-ContainerVersion
 
 function Lint-Dockerfile($Path)
 {
-  hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001 $Path
+  hadolint --ignore DL3008 --ignore DL3018 --ignore DL3028 --ignore DL4000 --ignore DL4001 $Path
 }
 
 function Build-Container(

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -39,6 +39,7 @@ function Build-Container(
     '--build-arg', "build_date=$build_date",
     '--build-arg', "version=$Version",
     '--build-arg', "namespace=$Namespace",
+    '--memory', '4g',
     '--file', "$Name/Dockerfile",
     '--tag', "$Namespace/${Name}:$Version"
   )

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -1,3 +1,26 @@
+FROM ubuntu:16.04 as build
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+            openjdk-8-jdk-headless \
+            curl \
+            git \
+            ruby \
+            ruby-dev \
+            g++ \
+            make && \
+    git config --global user.name "Puppet Release Team" && \
+    git config --global user.email "release@puppet.com" && \
+    curl --output /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
+    chmod 0755 /usr/local/bin/lein && \
+    /usr/local/bin/lein && \
+    gem install --no-doc bundler fpm
+
+COPY . /puppetserver
+WORKDIR /puppetserver
+RUN lein clean && lein install
+RUN EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true COW=base-xenial-amd64.cow MOCK='' GEM_SOURCE=https://rubygems.org lein with-profile ezbake ezbake local-build
+
 FROM ubuntu:16.04
 
 ARG vcs_ref
@@ -35,6 +58,8 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
+COPY --from=build /puppetserver/output/deb/xenial/*/*.deb /puppetserver.deb
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget=1.17.1-1ubuntu1 ca-certificates && \
     wget https://apt.puppetlabs.com/puppet6-release-"$UBUNTU_CODENAME".deb && \
@@ -43,31 +68,32 @@ RUN apt-get update && \
     dpkg -i dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
     rm puppet6-release-"$UBUNTU_CODENAME".deb dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
     apt-get update && \
-    apt-get install --no-install-recommends git -y puppetserver="$PUPPET_SERVER_VERSION"-1"$UBUNTU_CODENAME" && \
+    apt-get install --no-install-recommends -y git && \
+    apt install -y /puppetserver.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     gem install --no-rdoc --no-ri r10k
 
-COPY puppetserver /etc/default/puppetserver
-COPY logback.xml /etc/puppetlabs/puppetserver/
-COPY request-logging.xml /etc/puppetlabs/puppetserver/
-COPY puppetserver.conf /etc/puppetlabs/puppetserver/conf.d/
+COPY docker/puppetserver-standalone/puppetserver /etc/default/puppetserver
+COPY docker/puppetserver-standalone/logback.xml /etc/puppetlabs/puppetserver/
+COPY docker/puppetserver-standalone/request-logging.xml /etc/puppetlabs/puppetserver/
+COPY docker/puppetserver-standalone/puppetserver.conf /etc/puppetlabs/puppetserver/conf.d/
 
 RUN puppet config set autosign true --section master && \
     cp -pr /etc/puppetlabs/puppet /var/tmp && \
     rm -rf /var/tmp/puppet/ssl
 
-COPY docker-entrypoint.sh /
+COPY docker/puppetserver-standalone/docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
-COPY docker-entrypoint.d /docker-entrypoint.d
+COPY docker/puppetserver-standalone/docker-entrypoint.d /docker-entrypoint.d
 
 EXPOSE 8140
 
 ENTRYPOINT ["dumb-init", "/docker-entrypoint.sh"]
 CMD ["foreground"]
 
-COPY healthcheck.sh /
+COPY docker/puppetserver-standalone/healthcheck.sh /
 RUN chmod +x /healthcheck.sh
 HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD ["/healthcheck.sh"]
 
-COPY Dockerfile /
+COPY docker/puppetserver-standalone/Dockerfile /

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -20,6 +20,7 @@ COPY . /puppetserver
 WORKDIR /puppetserver
 RUN lein clean && lein install
 RUN EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true COW=base-xenial-amd64.cow MOCK='' GEM_SOURCE=https://rubygems.org lein with-profile ezbake ezbake local-build
+RUN mv /puppetserver/output/deb/xenial/*/*.deb /puppetserver.deb
 
 FROM ubuntu:16.04
 
@@ -58,7 +59,7 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
-COPY --from=build /puppetserver/output/deb/xenial/*/*.deb /puppetserver.deb
+COPY --from=build /puppetserver.deb /puppetserver.deb
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget=1.17.1-1ubuntu1 ca-certificates && \

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get update && \
     rm puppet6-release-"$UBUNTU_CODENAME".deb dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
     apt-get update && \
     apt-get install --no-install-recommends -y git && \
-    apt install -y /puppetserver.deb && \
+    apt-get install --no-install-recommends -y /puppetserver.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     gem install --no-rdoc --no-ri r10k


### PR DESCRIPTION
The docker image build has been updated to start with an ezbake
local-build so that we're running puppetserver 'from source' in the
containers.