### PR TITLE
(maint) Don't override leiningen's default repositories by default

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -98,9 +98,6 @@
   :test-paths ["test/unit" "test/integration"]
   :resource-paths ["resources" "src/ruby"]
 
-  :repositories [["releases" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-releases__local/"]
-                 ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/"]]
-
   :plugins [[lein-parent "0.3.1"]
             [puppetlabs/i18n "0.8.0"]]
 
@@ -118,9 +115,6 @@
                 :resources {:dir "tmp/ezbake-resources"}
                 :config-dir "ezbake/config"
                 :system-config-dir "ezbake/system-config"}
-
-  :deploy-repositories [["releases" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-releases__local/")]
-                        ["snapshots" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/")]]
 
   ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar
   ;; during `lein jar` that has all the code in the test/ directory. Downstream projects can then
@@ -144,6 +138,12 @@
                    ;; SERVER-332, enable SSLv3 for unit tests that exercise SSLv3
                    :jvm-opts      ["-Djava.security.properties=./dev-resources/java.security"]}
 
+             :internal {:repositories [["releases" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-releases__local/"]
+                                       ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/"]]
+
+                        :deploy-repositories [["releases" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-releases__local/")]
+                                              ["snapshots" ~(deploy-info "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/")]]
+                        }
              :testutils {:source-paths ["test/unit" "test/integration"]}
              :test {
                     ;; NOTE: In core.async version 0.2.382, the default size for


### PR DESCRIPTION
With the current repository setup in `project.clj`, `:repositories` and
`:deploy-repositories` are set to point to internal-to-puppet
infrastructure. While builds still succeed with these settings on
external networks, there is a noticible slowdown while waiting for
network timeouts.

This commit also adds an `internal` profile that can be used for builds
running on Puppet's internal network to access local repos/mirrors. To
use this new profile, run `lein with-profile ezbake,internal ezbake
build` in instances where you are currently running `lein with-profile
ezbake ezbake build`.