### PR TITLE
(SERVER-2465) Allow ca certs and crl bundles to be in any order

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.7.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "3.0.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1129,7 +1129,7 @@
    {:kind :duplicate-cert
     :msg  <specific error message>}"
   [csr :- CertificateRequest
-   {:keys [allow-duplicate-certs cacrl csrdir signeddir]} :- CaSettings]
+   {:keys [allow-duplicate-certs cacert cacrl cakey csrdir signeddir]} :- CaSettings]
   (let [subject (get-csr-subject csr)
         cert (path-to-cert signeddir subject)
         existing-cert? (fs/exists? cert)
@@ -1137,7 +1137,8 @@
     (when (or existing-cert? existing-csr?)
       (let [status (if existing-cert?
                      (if (utils/revoked?
-                           (utils/pem->ca-crl cacrl) (utils/pem->cert cert))
+                          (utils/pem->ca-crl cacrl (utils/pem->ca-cert cacert cakey))
+                          (utils/pem->cert cert))
                        "revoked"
                        "signed")
                      "requested")]
@@ -1340,15 +1341,15 @@
   "Get the status of the subject's certificate or certificate request.
    The status includes the state of the certificate (signed, revoked, requested),
    DNS alt names, and several different fingerprint hashes of the certificate."
-  [{:keys [csrdir signeddir cacrl]} :- CaSettings
+  [{:keys [csrdir signeddir cacert cacrl cakey]} :- CaSettings
    subject :- schema/Str]
-  (let [crl (utils/pem->ca-crl cacrl)]
+  (let [crl (utils/pem->ca-crl cacrl (utils/pem->ca-cert cacert cakey))]
     (get-certificate-status* signeddir csrdir crl subject)))
 
 (schema/defn ^:always-validate get-certificate-statuses :- [CertificateStatusResult]
   "Get the status of all certificates and certificate requests."
-  [{:keys [csrdir signeddir cacrl]} :- CaSettings]
-  (let [crl           (utils/pem->ca-crl cacrl)
+  [{:keys [csrdir signeddir cacert cacrl cakey]} :- CaSettings]
+  (let [crl           (utils/pem->ca-crl cacrl (utils/pem->ca-cert cacert cakey))
         pem-pattern   #"^.+\.pem$"
         all-subjects  (map #(fs/base-name % ".pem")
                            (concat (fs/find-files csrdir pem-pattern)

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -398,12 +398,12 @@
                  (let [revoke-response (cert-status-request "revoked" subject)]
                    ;; If the revocation was successful infra CRL should contain above revoked compile master cert
                    (is (= 204 (:status revoke-response)))
-                   (is (utils/revoked? (utils/pem->ca-crl (str master-conf-dir "/ssl/ca/infra_crl.pem")) cm-cert))))
+                   (is (utils/revoked? (utils/pem->ca-crl (str master-conf-dir "/ssl/ca/infra_crl.pem") ca-cert) cm-cert))))
 
               (testing "Infra CRL should NOT contain a revoked non compile master certificate"
                  (let [revoke-response (cert-status-request "revoked" node-subject)]
                    (is (= 204 (:status revoke-response)))
-                   (is (not (utils/revoked? (utils/pem->ca-crl (str master-conf-dir "/ssl/ca/infra_crl.pem")) node-cert)))))))
+                   (is (not (utils/revoked? (utils/pem->ca-crl (str master-conf-dir "/ssl/ca/infra_crl.pem") ca-cert) node-cert)))))))
 
            (testing "Verify correct CRL is returned depending on enable-infra-crl"
              (let [request (mock/request :get

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -474,9 +474,10 @@
           cert     (-> (:signeddir settings)
                        (path-to-cert "localhost")
                        (utils/pem->cert))
+          ca-cert (utils/pem->ca-cert (:cacert settings) (:cakey settings))
           revoked? (fn [cert]
                      (-> (:cacrl settings)
-                         (utils/pem->ca-crl)
+                         (utils/pem->ca-crl ca-cert)
                          (utils/revoked? cert)))]
       (is (false? (revoked? cert)))
       (revoke-existing-cert! settings "localhost")


### PR DESCRIPTION
Use the ca key to detect the correct certificate to use from a
certificate bundle on the ca, and the ca cert to detect the correct crl
from a crl bundle.