### PR TITLE
(maint) Use protocol in egd java parameter

### DIFF
--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -14,7 +14,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=/dev/urandom \
+"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/irb.erb
+++ b/resources/ext/cli/irb.erb
@@ -12,7 +12,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=/dev/urandom \
+"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.irb \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/ruby.erb
+++ b/resources/ext/cli/ruby.erb
@@ -12,7 +12,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=/dev/urandom \
+"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.ruby \
     --config "${CONFIG}" -- "$@"


### PR DESCRIPTION
On OpenJDK 8 the security.egd and securerandom.sourcefile parameters,
if set, should have a protocol attached their path. When using
`-Djava.security.debug=provider` one can see this error with the
previous value:

```
puppetserver[24654]: provider: Failed to create seed generator with /dev/urandom: java.net.MalformedURLException: no protocol: /dev/urandom
```

With this change service start up time (measure with just
`while true; do time systemctl restart puppetserver; done`)
goes from 27 seconds on redhat 7 to 20 seconds and from 23 seconds on
debian 8 to 18 seconds.

For gem install with the same loop but `puppetserver gem install r10k`
times go on redhat 7 from 20s to 14s.

I should note that removing this line completely also has the same
effect. It appears that in OpenJDK 8 and above the JVM simply does the
right thing. Instead of removing the line I've left if for FOSS users
that may be using our software on other implementations/OSes.