### PR TITLE
(maint) Remove `--server` usage from tests

### DIFF
--- a/acceptance/lib/puppetserver/acceptance/compat_utils.rb
+++ b/acceptance/lib/puppetserver/acceptance/compat_utils.rb
@@ -15,7 +15,7 @@ class { 'simmons':
 SITEPP
   on(master, "chmod 644 #{sitepp}")
   with_puppet_running_on(master, {"master" => {"autosign" => true}}) do
-    on(agent, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2])
+    on(agent, puppet("agent --test"), :acceptable_exit_codes => [0,2])
   end
 end
 

--- a/acceptance/suites/compat_tests/020_backwards_compat/binary_file_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/binary_file_test.rb
@@ -20,7 +20,7 @@ agents.each do |agent|
 
   step "Validate binary-file filebucket backup" do
     old_md5 = on(agent, "md5sum #{studio}/binary-file-old | awk '{print $1}'").stdout.chomp
-    on(agent, puppet("filebucket restore #{studio}/binary-file-backup #{old_md5} --server #{master}"))
+    on(agent, puppet("filebucket restore #{studio}/binary-file-backup #{old_md5}"))
     diff = on(agent, "diff #{studio}/binary-file-old #{studio}/binary-file-backup").exit_code
     assert_equal(0, diff, 'binary-file was not backed up to filebucket')
   end

--- a/acceptance/suites/compat_tests/020_backwards_compat/source_file_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/source_file_test.rb
@@ -20,7 +20,7 @@ agents.each do |agent|
 
   step "Validate source-file filebucket backup" do
     old_md5 = on(agent, "md5sum #{studio}/source-file-old | awk '{print $1}'").stdout.chomp
-    on(agent, puppet("filebucket restore #{studio}/source-file-backup #{old_md5} --server #{master}"))
+    on(agent, puppet("filebucket restore #{studio}/source-file-backup #{old_md5}"))
     diff = on(agent, "diff #{studio}/source-file-old #{studio}/source-file-backup").exit_code
     assert_equal(0, diff, 'source-file was not backed up to filebucket')
   end

--- a/acceptance/suites/externalCA_tests/020-external-ca/010_setup_remote_ca.rb
+++ b/acceptance/suites/externalCA_tests/020-external-ca/010_setup_remote_ca.rb
@@ -131,6 +131,6 @@ step 'Restart Puppet Services' do
 end
 
 step 'if we can not do an agent run, we should fail' do
-  on(master, "puppet agent -t --server #{master}", :acceptable_error_code => [0,2])
+  on(master, "puppet agent -t", :acceptable_error_code => [0,2])
 end
 

--- a/acceptance/suites/externalCA_tests/020-external-ca/020_retrieve_new_cert.rb
+++ b/acceptance/suites/externalCA_tests/020-external-ca/020_retrieve_new_cert.rb
@@ -11,6 +11,6 @@ step 'Run puppet agent --test on all agents to retrieve new certificates' do
       sleep 5
       result = shell("test -e #{lockfile}", {:accept_all_exit_codes => true})
     end
-    on(my_agent, puppet('agent', '--test', "--server #{master}"), :acceptable_exit_codes => [0,2])
+    on(my_agent, puppet('agent', '--test'), :acceptable_exit_codes => [0,2])
   end
 end

--- a/acceptance/suites/externalCA_tests/020-external-ca/030_revoke_agents.rb
+++ b/acceptance/suites/externalCA_tests/020-external-ca/030_revoke_agents.rb
@@ -2,7 +2,7 @@ test_name 'QA-1393 - C62573 - Revoke Agent Certificate on a Puppet Master using 
 skip_test('This test is destructive.  It works, but it is disabled until it can be improved to recertify the agents')
 step 'Run puppet agent -t on all agents to retreive new certificates' do
   agents.each do |my_agent|
-    on(my_agent, puppet('agent','--test', "--server #{master}"), :acceptable_exit_codes => [0,2])
+    on(my_agent, puppet('agent','--test'), :acceptable_exit_codes => [0,2])
   end
 end
 
@@ -19,9 +19,9 @@ end
 step 'Push CRL to master & HUP puppetserver' do
   pm_fqdn = fact_on(master, "fqdn").chomp
   on(ca, "cd /root/rakeca/intermediate;scp -o stricthostkeychecking=no ca_crl.pem root@#{pm_fqdn}:/etc/puppetlabs/puppet/ssl/ca/ca_crl.pem")
-  on(master, puppet('agent','--test', "--server #{master}"), :acceptable_exit_codes => [0,2])
+  on(master, puppet('agent','--test'), :acceptable_exit_codes => [0,2])
   reload_server
-  on(master, puppet('agent','--test', "--server #{master}"), :acceptable_exit_codes => [0,2])
+  on(master, puppet('agent','--test'), :acceptable_exit_codes => [0,2])
 end
 
 step 'Verify Cert revoked on Non-Master Agents' do
@@ -29,7 +29,7 @@ step 'Verify Cert revoked on Non-Master Agents' do
     agent_fqdn = fact_on(my_agent, "fqdn").chomp
     pm_fqdn = fact_on(master, "fqdn").chomp
     if agent_fqdn != pm_fqdn
-      on(my_agent, puppet('agent','--test', "--server #{master}"), :acceptable_exit_codes => [1])
+      on(my_agent, puppet('agent','--test'), :acceptable_exit_codes => [1])
     end
   end
 end

--- a/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
@@ -1,10 +1,17 @@
 step "Configure puppet.conf" do
   hostname = on(master, 'facter hostname').stdout.strip
   fqdn = on(master, 'facter fqdn').stdout.strip
-  dir = master.tmpdir(File.basename('/tmp'))
 
-  lay_down_new_puppet_conf( master,
-                           {"main" => {"dns_alt_names" => "puppet,#{hostname},#{fqdn}",
-                                       "verbose" => true,
-                                       "server" => fqdn}}, dir)
+  hosts.each do |host|
+    dir = host.tmpdir('configure_puppet')
+
+    if host == master
+      lay_down_new_puppet_conf( host,
+                               {"main" => {"dns_alt_names" => "puppet,#{hostname},#{fqdn}",
+                                           "verbose" => true,
+                                           "server" => fqdn}}, dir)
+    else
+      lay_down_new_puppet_conf(host, {"main" => {"server" => fqdn}}, dir)
+    end
+  end
 end

--- a/acceptance/suites/tests/00_smoke/master_starts_if_agent_run_before_ssl_files_inited.rb
+++ b/acceptance/suites/tests/00_smoke/master_starts_if_agent_run_before_ssl_files_inited.rb
@@ -51,7 +51,7 @@ end
 step 'Do an agent run with the server stopped so a public/private key can be created' do
   # The agent run is expected to return a '1' (failure) here because the server
   # it tries to contact would be down.
-  on(master, puppet('agent', '--test', '--certname', master, '--server', master),
+  on(master, puppet('agent', '--test', '--certname', master),
      {:acceptable_exit_codes => [1]})
 end
 
@@ -66,6 +66,6 @@ end
 step 'Ensure an agent run with the generated master cert is now successful' do
   # Exit code of 0 (success, no changes) or 2 (success, some changes) allowed
   # since only interested in determining that the run is successful.
-  on(master, puppet('agent', '--test', '--certname', master, '--server', master),
+  on(master, puppet('agent', '--test', '--certname', master),
      {:acceptable_exit_codes => [0, 2]})
 end

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -71,7 +71,6 @@ EOM
     end
 
     on(master, puppet_agent('--test', '--noop',
-                            '--server', master_fqdn,
                             '--certname', 'resource-exporter.test'),
               :acceptable_exit_codes => [0,2])
   end
@@ -80,7 +79,7 @@ EOM
     # ISO 8601 timestamp, with milliseconds and time zone. Local time is used
     # instead of UTC as both PuppetDB and Puppet Server log in local time.
     run_timestamp = Time.iso8601(on(master, 'date +"%Y-%m-%dT%H:%M:%S.%3N%:z"').stdout.chomp)
-    on(master, puppet_agent("--test --server #{master_fqdn}"), :acceptable_exit_codes => [0,2]) do
+    on(master, puppet_agent("--test"), :acceptable_exit_codes => [0,2]) do
       assert_match(/Notice: #{random_string}/, stdout,
                   'Puppet run collects exported Notify')
     end

--- a/acceptance/suites/tests/00_smoke/run_with_jruby9k.rb
+++ b/acceptance/suites/tests/00_smoke/run_with_jruby9k.rb
@@ -70,7 +70,7 @@ step 'Restart master with JRuby 9k' do
 end
 
 step 'Ensure that the server is running Ruby language version 2+' do
-   on(master, puppet('agent', '--test', '--server', master),
+   on(master, puppet('agent', '--test'),
       {:acceptable_exit_codes => [0, 2]}) do
      assert_match(/Notify\[rubyvers\]\/message: defined 'message' as '2/,
                   stdout,

--- a/acceptance/suites/tests/authorization/x509_auth.rb
+++ b/acceptance/suites/tests/authorization/x509_auth.rb
@@ -1,7 +1,7 @@
 test_name "(SERVER-1268)/(TK-293) TK-AUTH uses certificate extensions for authentication" do
 
 confine :except, :platform => 'windows'
-  
+
 server = master.puppet['certname']
 ssldir = master.puppet['ssldir']
 confdir = master.puppet['confdir']
@@ -19,12 +19,14 @@ step "Backup the tk auth.conf file" do
 end
 
 # Do we have a functioning cert?
-step "Confirm agent can connect with existing cert" do
-  agents.each do |a|
-    if (not_controller(a))
-      rc = on(a,
-              puppet("agent --test --server #{server} --detailed-exitcodes"),
-              {:acceptable_exit_codes => [0,2]})
+with_puppet_running_on master, {} do
+  step "Confirm agent can connect with existing cert" do
+    agents.each do |a|
+      if (not_controller(a))
+        rc = on(a,
+                puppet("agent --test --detailed-exitcodes"),
+                {:acceptable_exit_codes => [0,2]})
+      end
     end
   end
 end
@@ -35,106 +37,102 @@ end
 
 # Not anymore we don't
 step "Revoke and destroy the existing cert on the server" do
-  agents.each do |a| 
+  agents.each do |a|
     if (not_controller(a))
-      rc = on(master, 
+      rc = on(master,
               puppet("cert destroy #{a.hostname}"),
               {:acceptable_exit_codes => [0,2]})
     end
   end
 end
 
-step "Reload the server" do
-  reload_server
-end
-
-# After a server HUP, the agent cert should be rejected
-step "Confirm agent can't connect with existing cert" do
-  agents.each do |a|
-    if (not_controller(a))
-      rc = on(a,
-              puppet("agent --test --server #{server} --detailed-exitcodes"),
-              {:acceptable_exit_codes => [1]})
+with_puppet_running_on master, {} do
+  # After a server HUP, the agent cert should be rejected
+  step "Confirm agent can't connect with existing cert" do
+    agents.each do |a|
+      if (not_controller(a))
+        rc = on(a,
+                puppet("agent --test --detailed-exitcodes"),
+                {:acceptable_exit_codes => [1]})
+      end
     end
   end
-end
 
-step "Remove the old certs on the agents so they'll make new ones" do
-  agents.each do |a|
-    if (not_controller(a))
-      rc = on(a,
-              "find #{confdir} -name #{a.hostname}.pem -delete",
-              {:acceptable_exit_codes => [0,1]})
+  step "Remove the old certs on the agents so they'll make new ones" do
+    agents.each do |a|
+      if (not_controller(a))
+        rc = on(a,
+                "find #{confdir} -name #{a.hostname}.pem -delete",
+                {:acceptable_exit_codes => [0,1]})
+      end
     end
   end
-end
 
-# Lay down an attributes file for puppet to read when creating
-# a new cert
-# TODO: Make this a here doc with extensions that exist as vars so that they 
-# can be passed into our tk auth.conf rule generator.
-step "Copy the CSR attributes file into place" do
-  agents.each do |a|
-    if (not_controller(a))
-      rc = scp_to(a,
-                  'acceptance/suites/tests/authorization/fixtures/csr_attributes.yaml',
-                  "#{confdir}",
-                  {:acceptable_exit_codes => [0]})
+  # Lay down an attributes file for puppet to read when creating
+  # a new cert
+  # TODO: Make this a here doc with extensions that exist as vars so that they
+  # can be passed into our tk auth.conf rule generator.
+  step "Copy the CSR attributes file into place" do
+    agents.each do |a|
+      if (not_controller(a))
+        rc = scp_to(a,
+                    'acceptance/suites/tests/authorization/fixtures/csr_attributes.yaml',
+                    "#{confdir}",
+                    {:acceptable_exit_codes => [0]})
+      end
     end
   end
-end
 
-step "Generate a new cert with a cert extension" do
-  agents.each do |a|
-    if (not_controller(a))
-      rc = on(a,
-              puppet("agent --test --server #{server} --detailed-exitcodes"),
-              {:acceptable_exit_codes => [1]})
+  step "Generate a new cert with a cert extension" do
+    agents.each do |a|
+      if (not_controller(a))
+        rc = on(a,
+                puppet("agent --test --detailed-exitcodes"),
+                {:acceptable_exit_codes => [1]})
+      end
     end
   end
-end
 
-step "Sign the certs" do
-  rc = on(master, 
-          puppet("cert sign --all"),
-          {:accept_all_exit_codes => true})
+  step "Sign the certs" do
+    rc = on(master,
+            puppet("cert sign --all"),
+            {:accept_all_exit_codes => true})
+  end
 end
 
 # tk_auth file that allows catalogs based on extensions rather than node names.
-# This will create a weakness in that if the DEFAULT tk_auth.conf file is 
-# modified in the future, 
+# This will create a weakness in that if the DEFAULT tk_auth.conf file is
+# modified in the future,
 # we may need to modify our test tk_auth.conf file.
 # FIXME / TODO: create helper methods so that we can modify the tk auth.conf
 # file in place (and therefore test more use cases.)
 step "Lay down a test tk-auth.conf file" do
-  scp_to( master, 
+  scp_to( master,
     'acceptance/suites/tests/authorization/fixtures/extensions_test_auth.conf',
     '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
     :acceptable_exit_codes => 0 )
 end
 
-step "Reload the server" do
-  reload_server
-end
+with_puppet_running_on master, {} do
+  # Confirm agents can connect with new cert
+  step "Confirm agent can connect with the new cert" do
+    agents.each do |a|
+      if (not_controller(a))
+        rc = on(a,
+                puppet("agent --test --detailed-exitcodes"),
+                {:acceptable_exit_codes => [0,2]})
+      end
 
-# Confirm agents can connect with new cert
-step "Confirm agent can connect with the new cert" do
-  agents.each do |a|
-    if (not_controller(a))
-      rc = on(a,
-              puppet("agent --test --server #{server} --detailed-exitcodes"),
-              {:acceptable_exit_codes => [0,2]})
-    end
-
-    # Can we poke an HTTP API endpoint?
-    cert = get_cert(a)
-    key = get_key(a)
-    rc = https_request("https://#{server}:8140/puppet/v3/catalog/#{a.hostname}?environment=production",
-                       :get,
-                       cert,
-                       key)
-    if (rc.code != '200')
-      fail_test "Unexpected HTTP status code: #{rc.code}"
+      # Can we poke an HTTP API endpoint?
+      cert = get_cert(a)
+      key = get_key(a)
+      rc = https_request("https://#{server}:8140/puppet/v3/catalog/#{a.hostname}?environment=production",
+                         :get,
+                         cert,
+                         key)
+      if (rc.code != '200')
+        fail_test "Unexpected HTTP status code: #{rc.code}"
+      end
     end
   end
 end


### PR DESCRIPTION
This lays down a puppet.conf that contains a `server` setting in `main` for all nodes, not just the master.

It then removes the usage of `--server` from all tests and helpers that we can be sure are used in tests (there are pre-suites and helpers that are used in setup that continue to specify `--server`).

This also refactors the x509 auth test to use `with_puppet_running_on` vs HUPing the server.