### PR TITLE
(maint) Bump EZBake to 2.0.4 for egd source change

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -177,7 +177,7 @@
                                                [puppetlabs/puppetserver ~ps-version :exclusions [puppetlabs/jruby-deps]]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]
-                      :plugins [[puppetlabs/lein-ezbake "1.9.7"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.0.4"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 nil]]}


### PR DESCRIPTION
This moves us from 1.9.7 to 2.0.4. The impetus is to pick up a change
that properly specifies the source of randomness when we start our
services. It will also be needed to pick up fips building in later
branches when this is merged up. The "breaking" changes from 1.x to 2.x
seem to be in build internals:

"Remove legacy-build action that used the removed artifacts. Packages
can only be built using FPM."

Which I don't think we care about. Molly says there's no reason we
shouldn't be on 2.x by now.