### PR TITLE
(maint) sed zypper list when installing puppet-agent 1.x

### DIFF
--- a/acceptance/suites/pre_suite/upgrade/10_install_puppet.rb
+++ b/acceptance/suites/pre_suite/upgrade/10_install_puppet.rb
@@ -23,6 +23,8 @@ def install_pc1_repo(host)
   end
 
   if variant =~ /sles/
+    # Hack around RE-12490's invalid sles repo lists for pc1.
+    on host, "sed -i 's,==,=,' /etc/zypp/repos.d/puppetlabs-pc1.repo"
     on host, "rpmkeys --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppet"
   end
 


### PR DESCRIPTION
When moving to our archives the puppet-agent 1.x series (which contains
Puppet 4.x) had its zypper repo list corrupted. The invalid repo list
contains an extra "=" in it. See
https://tickets.puppetlabs.com/browse/RE-12490 for more info.

This works around it by using sed to remove the extraneous "="s.