### PR TITLE
(SERVER-2198) Add JRuby borrow time to the access log

### DIFF
--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -11,7 +11,7 @@
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D %i{Content-Length}</pattern>
+            <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D %i{Content-Length} %mdc{jruby.borrow-time:--}</pattern>
         </encoder>
     </appender>
     <appender-ref ref="FILE" />

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -11,7 +11,7 @@
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
+            <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D %i{Content-Length}</pattern>
         </encoder>
     </appender>
     <appender-ref ref="FILE" />

--- a/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
@@ -15,7 +15,8 @@
            (puppetlabs.services.jruby_pool_manager.jruby_schemas JRubyInstance)
            (java.util.concurrent TimeUnit)
            (org.joda.time DateTime)
-           (org.joda.time.format DateTimeFormatter)))
+           (org.joda.time.format DateTimeFormatter)
+           (org.slf4j MDC)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
@@ -285,6 +286,7 @@
               per-reason-timer (timer-for-borrow-reason metrics ta)]
           (.update borrow-timer elapsed-time (TimeUnit/MILLISECONDS))
           (.update per-reason-timer elapsed-time (TimeUnit/MILLISECONDS))
+          (MDC/put "jruby.borrow-time" (Long/toString elapsed-time))
           (swap! borrowed-instances dissoc id))
         (log/warn (trs "JRuby instance ''{0}'' returned, but no record of when it was borrowed!" id))))))
 


### PR DESCRIPTION
This changeset updates the jruby-metrics implementation to store the
elapsed borrow time in the Logback mapped diagnostic context. The
default request log pattern is also updated to include the stored
borrow time in the puppet server access log using the mechanisms
added to trapperkeeper-webserver-jetty9 in TK-470.

Ref. puppetlabs/trapperkeeper-webserver-jetty9#192

The `Content-Length` header added to the `pe-puppetserver` access log in puppetlabs/pe-puppetserver#308 is also ported over.