### PR TITLE
(SERVER-2555) Make test suite run in FIPS mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 4.1')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 4.11')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
   gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1.3")

--- a/acceptance/scripts/generic/testrun.sh
+++ b/acceptance/scripts/generic/testrun.sh
@@ -10,6 +10,7 @@ export BEAKER_OPTIONS="${BEAKER_OPTIONS:-acceptance/config/beaker/options.rb}"
 export BEAKER_CONFIG="${BEAKER_CONFIG:-acceptance/scripts/hosts.cfg}"
 export BEAKER_KEYFILE="${BEAKER_KEYFILE:-~/.ssh/id_rsa-acceptance}"
 export BEAKER_HELPER="${BEAKER_HELPER:-acceptance/lib/helper.rb}"
+export BEAKER_LOADPATH="${BEAKER_LOADPATH:-acceptance/lib}"
 
 bundle install --path vendor/bundle
 
@@ -20,7 +21,10 @@ BEAKER="$BEAKER --keyfile $BEAKER_KEYFILE"
 BEAKER="$BEAKER --helper $BEAKER_HELPER"
 BEAKER="$BEAKER --options-file $BEAKER_OPTIONS"
 BEAKER="$BEAKER --post-suite $BEAKER_POSTSUITE"
-BEAKER="$BEAKER --load-path acceptance/lib"
+BEAKER="$BEAKER --load-path $BEAKER_LOADPATH"
+if [[ -n $BEAKER_TAG ]]; then
+  BEAKER="$BEAKER --tag $BEAKER_TAG"
+fi
 
 if [ -z "$PACKAGE_BUILD_VERSION" ];
   #TODO: curl builds.puppetlabs.lan/puppetserver.  Parse HTML, find most recent folder name.

--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -1,6 +1,6 @@
 
 matching_puppetdb_platform = puppetdb_supported_platforms.select { |r| r =~ master.platform }
-skip_test unless matching_puppetdb_platform.length > 0
+skip_test if matching_puppetdb_platform.length == 0 || master.fips_mode?
 
 
 test_name 'PuppetDB setup'

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -18,7 +18,7 @@
 # We only run this test if we'll have puppetdb installed, which is gated in
 # acceptance/suites/pre_suite/foss/95_install_pdb.rb using the same conditional
 matching_puppetdb_platform = puppetdb_supported_platforms.select { |r| r =~ master.platform }
-skip_test unless matching_puppetdb_platform.length > 0
+skip_test if matching_puppetdb_platform.length == 0 || master.fips_mode?
 skip_test if master.is_pe?
 
 require 'json'


### PR DESCRIPTION
Tests that involve installing puppet modules will not work in FIPS mode. This restriction also precludes installing PuppetDB. This commit skips tests that rely on modules or PDB being installed.