### PR TITLE
SERVER-2597: Set HTTP basic auth on GET in HttpClient

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
@@ -33,6 +33,48 @@ describe 'Puppet::Server::HttpClient' do
     end
   end
 
+  context 'when making a request with basic auth' do
+    let(:url) { '/' }
+    let(:headers) { {} }
+    let(:options) { {} }
+
+    describe '#create_common_request_options' do
+      subject { client.create_common_request_options(url, headers, options) }
+
+      context 'with auth provided via options' do
+        let(:options) { {basic_auth: {user: 'username', password: 'secret'}} }
+
+        it 'has the Authorization header set' do
+          expect(subject.headers['Authorization']).to eq('Basic dXNlcm5hbWU6c2VjcmV0')
+        end
+      end
+
+      context 'with auth provided via headers' do
+        let(:headers) { {'Authorization' => 'Basic dXNlcm5hbWU6c2VjcmV0'} }
+
+        it 'has the Authorization header set' do
+          expect(subject.headers['Authorization']).to eq('Basic dXNlcm5hbWU6c2VjcmV0')
+        end
+
+        context 'with match auth via options' do
+          let(:options) { {basic_auth: {user: 'username', password: 'secret'}} }
+
+          it 'has the Authorization header set' do
+            expect(subject.headers['Authorization']).to eq('Basic dXNlcm5hbWU6c2VjcmV0')
+          end
+        end
+
+        context 'with non-match auth via options' do
+          let(:options) { {basic_auth: {user: 'username', password: 'mismatch'}} }
+
+          it 'raises an exception' do
+            expect { subject }.to raise_error(StandardError, /Existing 'Authorization' header conflicts/)
+          end
+        end
+      end
+    end
+  end
+
   context "when making a request that triggers a Java exception" do
     let :requests do
       headers = {}


### PR DESCRIPTION
By moving the credential code handling from `post()` to `create_common_request_options()` the HttpClient will handle HTTP basic auth on `get()` as well.

Any code that already uses `HttpClient` (such as Hiera lookup functions) and manually sets Authorization as a workaround, would start to fail. To handle this, the header values are compared and an exception is only raised when the values differ.