### PR TITLE
(MAINT) Add CA_ALLOW_SUBJECT_ALT_NAMES toggle

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -21,6 +21,7 @@ ENV PUPPET_MASTERPORT=8140
 ENV PUPPETSERVER_MAX_ACTIVE_INSTANCES=1
 ENV PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE=0
 ENV CA_ENABLED=true
+ENV CA_ALLOW_SUBJECT_ALT_NAMES=false
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppetserver-standalone/README.md
+++ b/docker/puppetserver-standalone/README.md
@@ -61,6 +61,10 @@ The following environment variables are supported:
 
   The port the CA is listening on. Does nothing unless `CA_ENABLED=false`. Defaults to `PUPPET_MASTERPORT` when set, otherwise '8140'.
 
+- `CA_ALLOW_SUBJECT_ALT_NAMES`
+
+  Whether or not SSL certificates containing Subject Alternative Names should be signed by the CA. Does nothing unless `CA_ENABLED=true`. Defaults to `false`.
+
 - `CONSUL_ENABLED`
 
   Whether or not to register the `puppet` service with an external consul server. Defaults to 'false'.

--- a/docker/puppetserver-standalone/docker-entrypoint.d/80-ca.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/80-ca.sh
@@ -42,4 +42,8 @@ EOF
 
     puppet agent --noop --server="${CA_HOSTNAME}" --masterport="${CA_MASTERPORT}"
   fi
+else
+  # we are the CA
+  hocon -f /etc/puppetlabs/puppetserver/conf.d/ca.conf \
+    set certificate-authority.allow-subject-alt-names "${CA_ALLOW_SUBJECT_ALT_NAMES}"
 fi

--- a/docker/puppetserver/README.md
+++ b/docker/puppetserver/README.md
@@ -65,6 +65,10 @@ The following environment variables are supported:
 
   The port the CA is listening on. Does nothing unless `CA_ENABLED=false`. Defaults to `PUPPET_MASTERPORT` when set, otherwise '8140'.
 
+- `CA_ALLOW_SUBJECT_ALT_NAMES`
+
+  Whether or not SSL certificates containing Subject Alternative Names should be signed by the CA. Does nothing unless `CA_ENABLED=true`. Defaults to `false`.
+
 - `CONSUL_ENABLED`
 
   Whether or not to register the `puppet` service with an external consul server. Defaults to 'false'.


### PR DESCRIPTION
Add a specific ENV variable to the docker image that controls whether
the CA accepts or rejects SSL certs with subject alt names.