### PR TITLE
(maint) Clean up project.clj

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: 2.8.1
+lein: 2.9.1
 dist: xenial
 script:
   - ./ext/travisci/test.sh

--- a/project.clj
+++ b/project.clj
@@ -149,8 +149,7 @@
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]]}
              :ci {:plugins [[lein-pprint "1.1.1"]
-                            [lein-exec "0.3.7"]]}
-             :voom {:plugins [[lein-voom "0.1.0-20150115_230705-gd96d771" :exclusions [org.clojure/clojure]]]}}
+                            [lein-exec "0.3.7"]]}}
 
   :test-selectors {:integration :integration
                    :unit (complement :integration)}

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
 (defproject puppetlabs/puppetserver ps-version
   :description "Puppet Server"
 
-  :min-lein-version "2.7.1"
+  :min-lein-version "2.8.1"
 
   :parent-project {:coords [puppetlabs/clj-parent "3.0.0"]
                    :inherit [:managed-dependencies]}
@@ -113,8 +113,8 @@
 
   :profiles {:dev {:source-paths  ["dev"]
                    :dependencies  [[org.clojure/tools.namespace]
-                                   [puppetlabs/trapperkeeper-webserver-jetty9 nil]
-                                   [puppetlabs/trapperkeeper-webserver-jetty9 nil :classifier "test"]
+                                   [puppetlabs/trapperkeeper-webserver-jetty9]
+                                   [puppetlabs/trapperkeeper-webserver-jetty9 :classifier "test"]
                                    [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
                                    [puppetlabs/trapperkeeper-metrics :classifier "test" :scope "test"]
                                    [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
@@ -138,31 +138,18 @@
                     :jvm-opts ["-Dclojure.core.async.pool-size=50"]
                     }
 
-             :ezbake {:dependencies ^:replace [;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-                                               ;; NOTE: we need to explicitly pass in `nil` values
-                                               ;; for the version numbers here in order to correctly
-                                               ;; inherit the versions from our parent project.
-                                               ;; This is because of a bug in lein 2.7.1 that
-                                               ;; prevents the deps from being processed properly
-                                               ;; with `:managed-dependencies` when you specify
-                                               ;; dependencies in a profile.  See:
-                                               ;; https://github.com/technomancy/leiningen/issues/2216
-                                               ;; Hopefully we can remove those `nil`s (if we care)
-                                               ;; and this comment when lein 2.7.2 is available.
-                                               ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-                                               ;; we need to explicitly pull in our parent project's
+             :ezbake {:dependencies ^:replace [ ;; we need to explicitly pull in our parent project's
                                                ;; clojure version here, because without it, lein
                                                ;; brings in its own version, and older versions of
                                                ;; lein depend on clojure 1.6.
-                                               [org.clojure/clojure nil]
+                                               [org.clojure/clojure]
                                                [puppetlabs/puppetserver ~ps-version]
-                                               [puppetlabs/trapperkeeper-webserver-jetty9 nil]
-                                               [org.clojure/tools.nrepl nil]]
+                                               [puppetlabs/trapperkeeper-webserver-jetty9]
+                                               [org.clojure/tools.nrepl]]
                       :plugins [[puppetlabs/lein-ezbake "2.0.4"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
-                       :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 nil]]}
+                       :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]]}
              :ci {:plugins [[lein-pprint "1.1.1"]
                             [lein-exec "0.3.7"]]}
              :voom {:plugins [[lein-voom "0.1.0-20150115_230705-gd96d771" :exclusions [org.clojure/clojure]]]}}

--- a/project.clj
+++ b/project.clj
@@ -22,10 +22,6 @@
     heap-size-from-profile-clj
     default-heap-size))
 
-(def figwheel-version "0.3.7")
-(def cljsbuild-version "1.1.7")
-(def clojurescript-version "1.10.238")
-
 (defproject puppetlabs/puppetserver ps-version
   :description "Puppet Server"
 
@@ -168,10 +164,6 @@
                                                ;; brings in its own version, and older versions of
                                                ;; lein depend on clojure 1.6.
                                                [org.clojure/clojure nil]
-                                               ;; I honestly don't know why we should need this
-                                               ;; But building with ezbake is consistently failing and
-                                               ;; pulling in an old build of clojurescript without it.
-                                               [org.clojure/clojurescript ~clojurescript-version]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 nil]
                                                [org.clojure/tools.nrepl nil]]

--- a/project.clj
+++ b/project.clj
@@ -138,14 +138,12 @@
                     :jvm-opts ["-Dclojure.core.async.pool-size=50"]
                     }
 
-             :ezbake {:dependencies ^:replace [ ;; we need to explicitly pull in our parent project's
+             :ezbake {:dependencies ^:replace [;; we need to explicitly pull in our parent project's
                                                ;; clojure version here, because without it, lein
-                                               ;; brings in its own version, and older versions of
-                                               ;; lein depend on clojure 1.6.
+                                               ;; brings in its own version.
                                                [org.clojure/clojure]
                                                [puppetlabs/puppetserver ~ps-version]
-                                               [puppetlabs/trapperkeeper-webserver-jetty9]
-                                               [org.clojure/tools.nrepl]]
+                                               [puppetlabs/trapperkeeper-webserver-jetty9]]
                       :plugins [[puppetlabs/lein-ezbake "2.0.4"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]

--- a/project.clj
+++ b/project.clj
@@ -16,16 +16,11 @@
         (get-in [:user :puppetserver-heap-size])))))
 
 (defn heap-size
-  [default-heap-size heap-size-type]
+  [default-heap-size]
   (or
     (System/getenv "PUPPETSERVER_HEAP_SIZE")
     heap-size-from-profile-clj
-    (do
-      (println "Using" default-heap-size heap-size-type
-        "heap since not set via PUPPETSERVER_HEAP_SIZE environment variable or"
-        "user.puppetserver-heap-size in ~/.lein/profiles.clj file. Set to at"
-        "least 5G for best performance during test runs.")
-      default-heap-size)))
+    default-heap-size))
 
 (def figwheel-version "0.3.7")
 (def cljsbuild-version "1.1.7")
@@ -197,8 +192,8 @@
 
   :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
                "-XX:+UseG1GC"
-               ~(str "-Xms" (heap-size "1G" "min"))
-               ~(str "-Xmx" (heap-size "2G" "max"))
+               ~(str "-Xms" (heap-size "1G"))
+               ~(str "-Xmx" (heap-size "2G"))
                "-XX:+IgnoreUnrecognizedVMOptions"
                "--add-modules=java.xml.bind"
                "--add-modules=java.xml.ws"]

--- a/project.clj
+++ b/project.clj
@@ -52,10 +52,6 @@
                  ;; We do not currently use this dependency directly, but
                  ;; we have documentation that shows how users can use it to
                  ;; send their logs to logstash, so we include it in the jar.
-                 ;; we may use it directly in the future
-                 ;; We are using an exlusion here because logback dependencies should
-                 ;; be inherited from trapperkeeper to avoid accidentally bringing
-                 ;; in different versions of the three different logback artifacts
                  [net.logstash.logback/logstash-logback-encoder]
 
                  [puppetlabs/jruby-utils "2.0.0"]

--- a/project.clj
+++ b/project.clj
@@ -57,10 +57,6 @@
                  [puppetlabs/jruby-utils "2.0.0"]
                  [puppetlabs/jruby-deps "9.1.16.0-1"]
 
-                 ;; JRuby 1.7.x and trapperkeeper (via core.async) both bring in
-                 ;; asm dependencies.  Deferring to clj-parent to resolve the version.
-                 [org.ow2.asm/asm-all]
-
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-comidi-metrics]

--- a/project.clj
+++ b/project.clj
@@ -84,7 +84,7 @@
   :repositories [["releases" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-releases__local/"]
                  ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/"]]
 
-  :plugins [[lein-parent "0.3.1"]
+  :plugins [[lein-parent "0.3.7"]
             [puppetlabs/i18n "0.8.0" :hooks false]]
 
   :uberjar-name "puppet-server-release.jar"

--- a/project.clj
+++ b/project.clj
@@ -25,15 +25,12 @@
 (defproject puppetlabs/puppetserver ps-version
   :description "Puppet Server"
 
-  :min-lein-version "2.8.1"
+  :min-lein-version "2.9.1"
 
   :parent-project {:coords [puppetlabs/clj-parent "3.0.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
-
-                 ;; See SERVER-2216
-                 [org.clojure/tools.nrepl "0.2.13"]
 
                  [slingshot]
                  [circleci/clj-yaml]

--- a/project.clj
+++ b/project.clj
@@ -85,7 +85,7 @@
                  ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/"]]
 
   :plugins [[lein-parent "0.3.1"]
-            [puppetlabs/i18n "0.8.0"]]
+            [puppetlabs/i18n "0.8.0" :hooks false]]
 
   :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"


### PR DESCRIPTION
The commit b8e8ade that removes the hook may be a bad idea, or at least need a cjc change, I'm not sure.

I'm also not sure if the profile twiddling is better than the top level nrepl dependency or not.

I'd like to wait until I can get a lein-parent release of 0.3.7 to fix some warnings. See https://github.com/achin/lein-parent/pull/20 .

I didn't update the versions of voom, but I also don't _think_ it's used, but couldn't find the CI configs to confirm one way or the other.