### PR TITLE
(SERVER-2529) Allow request handling with one shared JRuby instance

### DIFF
--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -87,6 +87,10 @@ jruby-puppet: {
     # (optional) Whether or not to track lookups during compilation; turning
     # this on will send that information to puppetdb
     # track-lookups: true
+
+    # For testing running requests through a single JRuby instance. DO NOT ENABLE unless
+    # explicitly testing this functionality.
+    # multithreaded: true
 }
 
 # Settings related to HTTP client requests made by Puppet Server.

--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -47,6 +47,14 @@
      jruby-puppet jruby-service {:request (dissoc request :ssl-client-cert)}
      (handler (assoc request :jruby-instance jruby-puppet)))))
 
+(defn wrap-with-multithreaded-jruby-instance
+  "Middleware that makes the provided jruby instance available in the request as
+  `:jruby-instance`. When using this handler, the provided JRuby instance will be
+  shared with other requests."
+  [handler jruby-instance]
+  (fn [request]
+    (handler (assoc request :jruby-instance (:jruby-puppet jruby-instance)))))
+
 (schema/defn ^:always-validate
   wrap-with-request-queue-limit :- IFn
   "Middleware fn that short-circuits incoming requests with a 503 'Service

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -165,6 +165,12 @@
    [this]
    (:pool-context (tk-services/service-context this)))
 
+  (borrow-instance
+    [this reason]
+    (let [pool-context (:pool-context (tk-services/service-context this))
+          event-callbacks (jruby-core/get-event-callbacks pool-context)]
+      (jruby-core/borrow-from-pool pool-context reason event-callbacks)))
+
   (register-event-handler
     [this callback-fn]
     (let [pool-context (:pool-context (tk-services/service-context this))]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -112,6 +112,10 @@
     [this]
     "Flush all the current JRuby instances and repopulate the pool.")
 
+  (borrow-instance
+    [this reason]
+    "Borrow a JRuby instance from the pool directly. For use with multithreaded Puppet.")
+
   (get-pool-context
     [this]
     "Get the pool context out of the service context.")

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -282,3 +282,11 @@
   (-> (jruby-request-handler config current-code-id)
       (jruby-request/wrap-with-jruby-instance jruby-service)
       jruby-request/wrap-with-error-handling))
+
+(defn build-multithreaded-request-handler
+  "Build the request handler fn for JRuby requests, when
+  using a multithreaded Puppet architecture."
+  [jruby-instance config current-code-id]
+  (-> (jruby-request-handler config current-code-id)
+      (jruby-request/wrap-with-multithreaded-jruby-instance jruby-instance)
+      jruby-request/wrap-with-error-handling))


### PR DESCRIPTION
This commit allows you to specify "jruby-puppet.multithreaded=true" to
switch into a mode where all requests requiring a jruby instance are
passed through a single JRuby, designed to be running a thread-safe
puppet implementation.

It does not address other uses of JRuby instances (like settings
loading), it does not respect `max-requests-per-instance`, and it does
not work with pool locking (the instance is never returned so a request
to lock will block forever).