### PR TITLE
(SERVER-2543) Add endpoints for plans list and plan metadata

### DIFF
--- a/dev-resources/puppetlabs/services/master/plans_int_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/plans_int_test/puppet.conf
@@ -1,0 +1,5 @@
+[main]
+
+certname = localhost
+environmentpath = $confdir/environments
+environment_timeout = 0

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -155,6 +155,14 @@
     [this jruby-instance env-name]
     (.getTasks jruby-instance env-name))
 
+  (get-plan-data
+   [this jruby-instance env-name module-name plan-name]
+   (.getPlanData jruby-instance env-name module-name plan-name))
+
+  (get-plans
+    [this jruby-instance env-name]
+    (.getPlans jruby-instance env-name))
+
   (flush-jruby-pool!
    [this]
    (let [service-context (tk-services/service-context this)

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -108,6 +108,14 @@
     [this jruby-instance env-name]
     "Get list of task names and environment information.")
 
+  (get-plan-data
+    [this jruby-instance env-name module-name plan-name]
+    "Get information (:metadata_file and :files) for a specific plan. Returns a JRuby hash.")
+
+  (get-plans
+    [this jruby-instance env-name]
+    "Get list of plan names and environment information.")
+
   (flush-jruby-pool!
     [this]
     "Flush all the current JRuby instances and repopulate the pool.")

--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -18,6 +18,8 @@ import java.util.List;
 public interface JRubyPuppet {
     Map getTaskData(String environment, String module, String task);
     List getTasks(String environment);
+    Map getPlanData(String environment, String module, String plan);
+    List getPlans(String environment);
     Map getClassInfoForEnvironment(String environment);
     List getTransportInfoForEnvironment(String environment);
     List getModuleInfoForEnvironment(String environment);

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -144,6 +144,24 @@ class Puppet::Server::Master
     Puppet::InfoService.task_data(environment_name, module_name, qualified_task_name)
   end
 
+  def getPlans(env)
+    environment = @env_loader.get(env)
+    unless environment.nil?
+      # Pass the original env string. environment.name is a symbol
+      # while the environment cache is primarily used with strings.
+      # Pass as a string to ensure we re-use a cached environment
+      # if available.
+      Puppet::InfoService.plans_per_environment(env)
+    end
+  end
+
+  def getPlanData(environment_name, module_name, plan_name)
+    # the 'init' plan is special-cased to be just the name of the module,
+    # otherwise we have to request 'module::planname'
+    qualified_plan_name = plan_name == 'init' ? module_name : "#{module_name}::#{plan_name}"
+    Puppet::InfoService.plan_data(environment_name, module_name, qualified_plan_name)
+  end
+
   private
 
   def convert_java_args_to_ruby(hash)

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -197,6 +197,26 @@
    (write-tasks-files module-name task-name task-file-contents
                       (json/encode {"description" "This is a description. It describes a thing."}))))
 
+(schema/defn ^:always-validate write-plans-files :- schema/Str
+  ([module-name :- schema/Str
+    plan-name :- schema/Str
+    plan-arguments :- schema/Str
+    plan-body :- schema/Str]
+   (let [module-dir (create-module module-name {})
+         plans-dir (fs/file module-dir "plans")
+         plan-path (fs/file plans-dir (str plan-name ".pp"))
+         scoped-plan-name (if (= plan-name "init")
+                              module-name
+                              (str module-name "::" plan-name))
+         plan-file-contents (str scoped-plan-name "(" plan-arguments ") {" plan-body "}")]
+     (create-file plan-path
+                  plan-file-contents)
+     (.getCanonicalPath plan-path)))
+  ([module-name :- schema/Str
+    plan-name :- schema/Str
+    plan-body :- schema/Str]
+   (write-plans-files module-name plan-name "" plan-body)))
+
 (defn create-env-conf
   [env-dir content]
   (create-file (fs/file env-dir "environment.conf")

--- a/test/integration/puppetlabs/services/master/plans_int_test.clj
+++ b/test/integration/puppetlabs/services/master/plans_int_test.clj
@@ -1,0 +1,143 @@
+(ns puppetlabs.services.master.plans-int-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
+            [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
+            [puppetlabs.puppetserver.testutils :as testutils]
+            [cheshire.core :as json]
+            [me.raynes.fs :as fs]))
+
+(def test-resources-dir
+  (ks/absolute-path "./dev-resources/puppetlabs/services/master/plans_int_test"))
+
+(defn plan-path
+  [plan-name]
+  (str test-resources-dir "/" plan-name))
+
+(defn purge-env-dir
+  []
+  (-> testutils/conf-dir
+      (fs/file "environments")
+      fs/delete-dir))
+
+(use-fixtures :once
+              (testutils/with-puppet-conf
+               (fs/file test-resources-dir "puppet.conf")))
+
+(use-fixtures :each
+              (fn [f]
+                (purge-env-dir)
+                (try
+                  (f)
+                  (finally
+                    (purge-env-dir)))))
+
+(def request-as-text-with-ssl (assoc testutils/ssl-request-options :as :text))
+
+(defn get-all-plans
+  [env-name]
+  (let [url (str "https://localhost:8140/puppet/v3/plans"
+                 (if env-name (str "?environment=" env-name)))]
+    (try
+      (http-client/get url request-as-text-with-ssl)
+      (catch Exception e
+        (throw (Exception. "plans http get failed" e))))))
+
+(defn get-plan-details
+  "plan-name is the plan's full name, e.g. 'apache::reboot'."
+  [env-name full-plan-name]
+  (let [[module-name plan-name]  (str/split full-plan-name #"::")
+        url (str "https://localhost:8140/puppet/v3/plans/" module-name "/" plan-name
+                 (if env-name (str "?environment=" env-name)))]
+    (try
+      (http-client/get url request-as-text-with-ssl)
+      (catch Exception e
+        (throw (Exception. "plan info http get failed" e))))))
+
+(defn parse-response
+  [response]
+  (-> response :body json/parse-string))
+
+(defn sort-plans
+  [plans]
+  (sort-by #(get % "name") plans))
+
+(def puppet-config
+  (-> (bootstrap/load-dev-config-with-overrides {:jruby-puppet
+                                                 {:gem-path [(ks/absolute-path jruby-testutils/gem-path)]
+                                                  :max-active-instances 1}})
+      (ks/dissoc-in [:jruby-puppet
+                     :environment-class-cache-enabled])))
+
+(deftest ^:integration all-plans-with-env
+  (testing "full stack plans listing smoke test"
+    (bootstrap/with-puppetserver-running-with-config
+      app
+      puppet-config
+      (do
+        (testutils/write-plans-files "apache" "announce" "return 'Hi!'")
+        (testutils/write-plans-files "graphite" "init" "return 'Wheeeee'")
+        (let [expected-response '({"name" "apache::announce"
+                                   "environment" [{"name" "production"
+                                                   "code_id" nil}]}
+                                  {"name" "graphite"
+                                   "environment" [{"name" "production"
+                                                   "code_id" nil}]})
+              response (get-all-plans "production")]
+          (testing "a successful status code is returned"
+            (is (= 200 (:status response))
+                (str
+                  "unexpected status code for response, response: "
+                  (ks/pprint-to-string response))))
+          (testing "the expected response body is returned"
+            (is (= expected-response
+                   (sort-plans (parse-response response))))))))))
+
+(deftest ^:integration plan-details
+  (testing "full stack plan metadata smoke test:"
+    (bootstrap/with-puppetserver-running-with-config
+      app
+      puppet-config
+      (let [metadata {}]
+        (testutils/write-plans-files "shell" "poc" "String $message" "return $message")
+
+        (testing "on a successful request,"
+          (let [response (get-plan-details "production" "shell::poc")
+                code (:status response)]
+            (testing "a successful status code is returned"
+              (is (= 200 code)
+                  (str "unexpected status code " code " for response: "
+                       (ks/pprint-to-string response))))
+
+            (testing "the expected response body is returned"
+              (let [expected-response {"metadata" metadata
+                                       "name" "shell::poc"}]
+                (is (= expected-response (parse-response response)))))))
+
+        (testing "on a request that should error,"
+          (let [assert-plan-error (fn [status pattern env full-plan-name]
+                               (let [result (get-plan-details env full-plan-name)]
+                                 (is (= status (:status result)))
+                                 (is (re-find pattern (:body result)))))]
+
+            (testing "returns 404 when the environment does not exist"
+              (assert-plan-error 404 #"Could not find environment"
+                                 "nopers" "shell::poc"))
+
+            (testing "returns 404 when the module does not exist"
+              (assert-plan-error 404 #"Could not find module"
+                                 "production" "nomodule::poc"))
+
+            (testing "returns 404 when the module name is invalid"
+              (assert-plan-error 404 #"Could not find module"
+                                 "production" "000::poc"))
+
+            (testing "returns 404 when the plan does not exist"
+              (assert-plan-error 404 #"Could not find plan"
+                                 "production" "shell::noplan"))
+
+            (testing "returns 404 when the plan name is invalid"
+              (assert-plan-error 404 #"Could not find plan"
+                                 "production" "shell::..."))))))))


### PR DESCRIPTION
This adds the endpoints to expose the plan information service
from Puppet as an HTTP service.

Primarily this code is copy&paste from the similar glue for tasks,
with bits removed as needed (mostly around metadata and file lists,
since currently plans have neither of those). It seemed better to
duplicate rather than try to share code paths, since task and plan
metadata formats are more likely to diverge than converge.

The test for this currently includes an assertion that plan metadata
is empty, which will be a nice reminder for us to add tests for
metadata when it becomes available :sunglasses: