### PR TITLE
(SERVER-2585) hiera lookup config setting

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -10,9 +10,15 @@ teardown do
   on(master, "rm -f #{sitepp}")
 end
 
-step 'Install Puppet Release Repo' do
-  install_puppetlabs_release_repo_on(master, 'puppet5')
-end
+# Install the SNAPSHOT with the necessary modifications to the
+# puppetdb terminus; once PuppetDB has tagged and released, revert
+# this commit and update the `install_puppetlabs_release_repo_on`
+# to use 'puppet6'
+
+# step 'Install Puppet Release Repo' do
+#   install_puppetlabs_release_repo_on(master, 'puppet5')
+# end
+install_puppetlabs_dev_repo master, 'puppetdb', "6.4.1.SNAPSHOT.2019.08.13T0822"
 
 step 'Install PuppetDB module' do
   on(master, puppet('module install puppetlabs-puppetdb'))

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -29,12 +29,32 @@ run_timestamp = nil
 master_fqdn = on(master, '/opt/puppetlabs/bin/facter fqdn').stdout.chomp
 random_string = SecureRandom.urlsafe_base64.freeze
 
+puppetserver_conf_path = '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
+old_puppetserver_conf = on(master, "cat #{puppetserver_conf_path}").stdout
+
+common_yaml_path = '/etc/puppetlabs/code/environments/production/data/common.yaml'
+
+create_remote_file(master, common_yaml_path, <<EOM)
+---
+some-test-key: test-key-value
+EOM
+
+on(master, "chmod 644 #{common_yaml_path}")
+
+step 'Configure puppetserver to track hiera lookups' do
+  conf = read_tk_config_string(old_puppetserver_conf)
+  conf['jruby-puppet']['track-hiera-lookups'] = true
+  modify_tk_config(master, puppetserver_conf_path, conf, replace=true)
+end
+
 step 'Configure site.pp for PuppetDB' do
   sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
   create_remote_file(master, sitepp, <<EOM)
 node 'resource-exporter.test' {
   @@notify{'#{random_string}': }
 }
+
+lookup('some-test-key')
 
 node '#{master_fqdn}' {
   Notify<<| title == '#{random_string}' |>>
@@ -46,7 +66,8 @@ EOM
   on(master, "chmod 644 #{sitepp}")
 
   teardown do
-    on(master, "rm -f #{sitepp}")
+    modify_tk_config(master, puppetserver_conf_path, read_tk_config_string(old_puppetserver_conf), replace=true)
+    on(master, "rm -f #{sitepp} #{common_yaml_path}")
   end
 end
 
@@ -67,6 +88,7 @@ EOM
 
     teardown do
       on(master, puppet('node', 'deactivate', 'resource-exporter.test'))
+      on(master, "puppet ssl clean --certname resource-exporter.test")
       on(master, 'puppetserver ca clean --certname=resource-exporter.test')
     end
 
@@ -144,4 +166,34 @@ data submission.
 Check puppetdb.log for errors that may have ocurred during
 data processing.
 EOS
+end
+
+step 'Validate PuppetDB stored lookup data sent from puppetserver' do
+  query = "curl -X POST http://localhost:8080/pdb/query/v4/catalog-input-contents" <<
+    " -H 'Content-Type:application/json'" <<
+    " -d '{\"query\": \"\" }'"
+
+  retries = 3
+
+  (1..(retries + 1)).each do |i|
+
+    if i > retries
+      raise "Attempted #{retries} times to get lookup data from puppetdb, but none found"
+    end
+
+    logger.debug("PuppetDB query attempt #{i} for catalog inputs")
+    response = JSON.parse(on(master, query).stdout.chomp)
+
+    # Give PuppetDB some time to process it is running slow
+    if response.empty?
+      sleep 1
+      next
+    end
+
+    response.each do |input|
+      assert_equal('some-test-key', input['name'])
+      assert_equal('hiera', input['type'])
+    end
+    break
+  end
 end

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -43,7 +43,7 @@ on(master, "chmod 644 #{common_yaml_path}")
 
 step 'Configure puppetserver to track hiera lookups' do
   conf = read_tk_config_string(old_puppetserver_conf)
-  conf['jruby-puppet']['track-hiera-lookups'] = true
+  conf['jruby-puppet']['track-lookups'] = true
   modify_tk_config(master, puppetserver_conf_path, conf, replace=true)
 end
 

--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -83,6 +83,10 @@ jruby-puppet: {
     # (optional) whether to use the environment class cache. If unspecified
     # defaults to false
     environment-class-cache-enabled: true
+
+    # (optional) Whether or not to track hiera lookups during compilation; turning
+    # this on will send that information to puppetdb
+    # track-hiera-lookups: true
 }
 
 # Settings related to HTTP client requests made by Puppet Server.

--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -84,9 +84,9 @@ jruby-puppet: {
     # defaults to false
     environment-class-cache-enabled: true
 
-    # (optional) Whether or not to track hiera lookups during compilation; turning
+    # (optional) Whether or not to track lookups during compilation; turning
     # this on will send that information to puppetdb
-    # track-hiera-lookups: true
+    # track-lookups: true
 }
 
 # Settings related to HTTP client requests made by Puppet Server.

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -52,6 +52,10 @@ jruby-puppet: {
     # specified in the Puppet Server HOCON-formatted auth.conf (if false or not
     # specified).
     #use-legacy-auth-conf: true
+
+    # (optional) Whether or not to track hiera lookups during compilation; turning
+    # this on will send that information to puppetdb
+    # track-hiera-lookups: true
 }
 
 # settings related to HTTPS client requests made by Puppet Server

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -53,9 +53,9 @@ jruby-puppet: {
     # specified).
     #use-legacy-auth-conf: true
 
-    # (optional) Whether or not to track hiera lookups during compilation; turning
+    # (optional) Whether or not to track lookups during compilation; turning
     # this on will send that information to puppetdb
-    # track-hiera-lookups: true
+    # track-lookups: true
 }
 
 # settings related to HTTPS client requests made by Puppet Server

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -126,7 +126,8 @@
                   http-client-connect-timeout-milliseconds
                   http-client-idle-timeout-milliseconds
                   http-client-metrics-enabled
-                  use-legacy-auth-conf]} config
+                  use-legacy-auth-conf
+                  track-hiera-lookups]} config
           scripting-container (:scripting-container jruby-instance)]
 
       (.runScriptlet scripting-container "require 'puppet/server/master'")
@@ -143,6 +144,7 @@
             (.put "metric_registry" (metrics/get-metrics-registry metrics-service :puppetserver))
             (.put "server_id" (metrics/get-server-id metrics-service))))
         (doto puppetserver-config
+          (.put "track_hiera_lookups" track-hiera-lookups)
           (.put "profiler" profiler)
           (.put "environment_registry" env-registry)
           (.put "http_connect_timeout_milliseconds" http-client-connect-timeout-milliseconds)
@@ -169,7 +171,7 @@
 
 (schema/defn extract-puppet-config
   [config :- {schema/Keyword schema/Any}]
-  (select-keys config (keys jruby-puppet-schemas/JRubyPuppetConfig)))
+  (select-keys config (map schema/explicit-schema-key (keys jruby-puppet-schemas/JRubyPuppetConfig))))
 
 (schema/defn extract-http-config
   "The config is allowed to be nil because the http-client section isn't

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -127,7 +127,7 @@
                   http-client-idle-timeout-milliseconds
                   http-client-metrics-enabled
                   use-legacy-auth-conf
-                  track-hiera-lookups]} config
+                  track-lookups]} config
           scripting-container (:scripting-container jruby-instance)]
 
       (.runScriptlet scripting-container "require 'puppet/server/master'")
@@ -144,7 +144,7 @@
             (.put "metric_registry" (metrics/get-metrics-registry metrics-service :puppetserver))
             (.put "server_id" (metrics/get-server-id metrics-service))))
         (doto puppetserver-config
-          (.put "track_hiera_lookups" track-hiera-lookups)
+          (.put "track_lookups" track-lookups)
           (.put "profiler" profiler)
           (.put "environment_registry" env-registry)
           (.put "http_connect_timeout_milliseconds" http-client-connect-timeout-milliseconds)

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -25,6 +25,9 @@
     * :master-log-dir - path to the puppetmaster's log dir;
         if not specified, will use the puppet default.
 
+    * :track-hiera-lookups - a boolean to turn on tracking hiera lookups during compilation;
+        if not specified, no tracking is enabled.
+
     * :http-client-ssl-protocols - A list of legal SSL protocols that may be used
         when https client requests are made.
 
@@ -53,6 +56,7 @@
    :master-var-dir (schema/maybe schema/Str)
    :master-run-dir (schema/maybe schema/Str)
    :master-log-dir (schema/maybe schema/Str)
+   (schema/optional-key :track-hiera-lookups) schema/Bool
    :http-client-ssl-protocols [schema/Str]
    :http-client-cipher-suites [schema/Str]
    :http-client-connect-timeout-milliseconds schema/Int

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -25,7 +25,7 @@
     * :master-log-dir - path to the puppetmaster's log dir;
         if not specified, will use the puppet default.
 
-    * :track-hiera-lookups - a boolean to turn on tracking hiera lookups during compilation;
+    * :track-lookups - a boolean to turn on tracking hiera lookups during compilation;
         if not specified, no tracking is enabled.
 
     * :http-client-ssl-protocols - A list of legal SSL protocols that may be used
@@ -56,7 +56,7 @@
    :master-var-dir (schema/maybe schema/Str)
    :master-run-dir (schema/maybe schema/Str)
    :master-log-dir (schema/maybe schema/Str)
-   (schema/optional-key :track-hiera-lookups) schema/Bool
+   (schema/optional-key :track-lookups) schema/Bool
    :http-client-ssl-protocols [schema/Str]
    :http-client-cipher-suites [schema/Str]
    :http-client-connect-timeout-milliseconds schema/Int

--- a/src/ruby/puppetserver-lib/puppet/server/key_recorder.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/key_recorder.rb
@@ -1,0 +1,12 @@
+require 'puppet/server'
+require 'puppet/pops/lookup/key_recorder'
+
+class Puppet::Server::KeyRecorder < Puppet::Pops::Lookup::KeyRecorder
+  def initialize
+    @lookups = Hash.new(0)
+  end
+
+  def record(key)
+    @lookups[key] += 1
+  end
+end

--- a/src/ruby/puppetserver-lib/puppet/server/key_recorder.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/key_recorder.rb
@@ -2,6 +2,8 @@ require 'puppet/server'
 require 'puppet/pops/lookup/key_recorder'
 
 class Puppet::Server::KeyRecorder < Puppet::Pops::Lookup::KeyRecorder
+  attr_accessor :lookups
+
   def initialize
     @lookups = Hash.new(0)
   end

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -32,7 +32,7 @@ class Puppet::Server::Master
   def initialize(puppet_config, puppet_server_config)
     # There is a setting that is routed from the puppetserver.conf to
     # configure whether or not to track hiera lookups.
-    @track_hiera_lookups = puppet_server_config.delete('track_hiera_lookups')
+    @track_lookups = puppet_server_config.delete('track_lookups')
     Puppet::Server::Config.initialize_puppet_server(puppet_server_config)
     Puppet::Server::PuppetConfig.initialize_puppet(puppet_config)
     # Tell Puppet's network layer which routes we are willing handle - which is
@@ -83,7 +83,7 @@ class Puppet::Server::Master
   end
 
   def create_recorder
-    @track_hiera_lookups ? Puppet::Server::KeyRecorder.new : Puppet::Pops::Lookup::KeyRecorder.singleton
+    @track_lookups ? Puppet::Server::KeyRecorder.new : Puppet::Pops::Lookup::KeyRecorder.singleton
   end
 
   def getClassInfoForEnvironment(env)

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -12,6 +12,7 @@ require 'puppet/server/network/http/handler'
 require 'puppet/server/compiler'
 require 'puppet/server/ast_compiler'
 require 'puppet/server/key_recorder'
+require 'puppet/pops/lookup/key_recorder'
 
 require 'java'
 
@@ -29,6 +30,9 @@ class Puppet::Server::Master
   include Puppet::Server::Network::HTTP::Handler
 
   def initialize(puppet_config, puppet_server_config)
+    # There is a setting that is routed from the puppetserver.conf to
+    # configure whether or not to track hiera lookups.
+    @track_hiera_lookups = puppet_server_config.delete('track_hiera_lookups')
     Puppet::Server::Config.initialize_puppet_server(puppet_server_config)
     Puppet::Server::PuppetConfig.initialize_puppet(puppet_config)
     # Tell Puppet's network layer which routes we are willing handle - which is
@@ -45,7 +49,7 @@ class Puppet::Server::Master
 
   def handleRequest(request)
     response = {}
-    Puppet.override(lookup_key_recorder: Puppet::Server::KeyRecorder.new) do
+    Puppet.override(lookup_key_recorder: create_recorder) do
       process(request, response)
       # 'process' returns only the status -
       # `response` now contains all of the response data
@@ -69,13 +73,17 @@ class Puppet::Server::Master
   end
 
   def compileCatalog(request_data)
-    Puppet.override(lookup_key_recorder: Puppet::Server::KeyRecorder.new) do
+    Puppet.override(lookup_key_recorder: create_recorder) do
       @catalog_compiler.compile(convert_java_args_to_ruby(request_data))
     end
   end
 
   def compileAST(compile_options)
     Puppet::Server::ASTCompiler.compile(convert_java_args_to_ruby(compile_options))
+  end
+
+  def create_recorder
+    @track_hiera_lookups ? Puppet::Server::KeyRecorder.new : Puppet::Pops::Lookup::KeyRecorder.singleton
   end
 
   def getClassInfoForEnvironment(env)


### PR DESCRIPTION
This PR introduces a new lookup_key_recorder to track hiera lookups, as well as a new setting in the jruby-puppet configuration to turn aforementioned key_recorder on or off. 