### PR TITLE
(SERVER-2602) Stop setting egd in subcommands

### DIFF
--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -14,7 +14,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
+"${JAVA_BIN}" $JAVA_ARGS_CLI \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/irb.erb
+++ b/resources/ext/cli/irb.erb
@@ -12,7 +12,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
+"${JAVA_BIN}" $JAVA_ARGS_CLI \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.irb \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/ruby.erb
+++ b/resources/ext/cli/ruby.erb
@@ -12,7 +12,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
+"${JAVA_BIN}" $JAVA_ARGS_CLI \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.ruby \
     --config "${CONFIG}" -- "$@"


### PR DESCRIPTION
The performance of urandom vs the defaults anecdotally has been the
same. If users would like to manage the egd source explicitly they're
encouraged to do so via the JAVA_ARGS_CLI variable.