### PR TITLE
(maint) Remove jira-ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ end
 
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 gem 'rake', :group => [:development, :test]
-gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'


### PR DESCRIPTION
The jira-ruby gem used to be used for generating tickets via a rake
task, but the only tickets we autogenerate now come from a centralized
repo of tasks, so we don't need this dep anymore. This commit removes
it, following an update to it that started limiting the Ruby versions
with which it can be installed.