### PR TITLE
(SERVER-2193) Add thread-dump endpoint to admin API

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.1.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -169,6 +169,12 @@
           {:keys [pool-context]} service-context]
      (jruby-core/flush-pool! pool-context)))
 
+  (get-jruby-thread-dump
+   [this]
+   (let [service-context (tk-services/service-context this)
+         {:keys [pool-context]} service-context]
+     (jruby-core/get-jruby-thread-dump pool-context)))
+
   (get-pool-context
    [this]
    (:pool-context (tk-services/service-context this)))

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -120,6 +120,10 @@
     [this]
     "Flush all the current JRuby instances and repopulate the pool.")
 
+  (get-jruby-thread-dump
+    [this]
+    "Return a thread dump for each JRuby instance registered to the pool.")
+
   (borrow-instance
     [this reason]
     "Borrow a JRuby instance from the pool directly. For use with multithreaded Puppet.")


### PR DESCRIPTION
This commit adds a `jruby-pool/thread-dump` endpoint to the admin API.
This endpoint can be used to retrieve a backtrace from each JRuby
interpreter registered to the pool when `-Djruby.management.enabled=true`
has been set in JAVA_ARGS.