### PR TITLE
(maint) Update healthcheck timings to max 3 mins

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -96,6 +96,6 @@ CMD ["foreground"]
 
 COPY docker/puppetserver-standalone/healthcheck.sh /
 RUN chmod +x /healthcheck.sh
-HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=5s --timeout=5s --retries=12 --start-period=120s CMD ["/healthcheck.sh"]
 
 COPY docker/puppetserver-standalone/Dockerfile /


### PR DESCRIPTION
 - Ignore problems in the first 2 minutes for bootstrapping, then allow
   an additional minute to pass before marking unhealthy