### PR TITLE
(maint) Use static addressing in Docker specs

### DIFF
--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 gem 'rspec'
 gem 'rspec_junit_formatter'
 gem 'pupperware',
-    :git => 'https://github.com/puppetlabs/pupperware.git',
-    :branch => 'master',
+    :git => 'https://github.com/Iristyle/pupperware.git',
+    :branch => 'allow-agent-extra-hosts',
     :glob => 'gem/*.gemspec'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,8 +15,11 @@ services:
       - PUPPET_STORECONFIGS=false
       - PUPPET_REPORTS=log
     dns_search: 'test'
+    extra_hosts:
+      - 'compiler.test:172.22.0.101'
     networks:
       puppetserver_test:
+        ipv4_address: 172.22.0.100
         aliases:
           - puppet.test
 
@@ -33,11 +36,17 @@ services:
       - PUPPET_STORECONFIGS=false
       - PUPPET_REPORTS=log
     dns_search: 'test'
+    extra_hosts:
+      - 'puppet.test:172.22.0.100'
     networks:
       puppetserver_test:
+        ipv4_address: 172.22.0.101
         aliases:
           - compiler.test
 
 networks:
   puppetserver_test:
     name: puppetserver_test
+    ipam:
+      config:
+        - subnet: 172.22.0.0/16

--- a/docker/spec/puppetserver_spec.rb
+++ b/docker/spec/puppetserver_spec.rb
@@ -36,7 +36,22 @@ describe 'puppetserver container' do
   end
 
   it 'should be able to run an agent against the compile master' do
-    expect(run_agent('compiler-agent.test', 'puppetserver_test', server: get_container_hostname(get_service_container('compiler')), ca: get_container_hostname(get_service_container('puppet')), ca_port: '8141')).to eq(0)
+    compiler_container = get_service_container('compiler')
+    compiler_hostname = get_container_hostname(compiler_container)
+    ca_container = get_service_container('puppet')
+    ca_hostname = get_container_hostname(ca_container)
+
+    expect(run_agent(
+      'compiler-agent.test',
+      'puppetserver_test',
+      extra_hosts: {
+        ca_hostname => get_container_ip(ca_container),
+        compiler_hostname => get_container_ip(compiler_container)
+      },
+      server: compiler_hostname,
+      ca: ca_hostname,
+      ca_port: '8141'
+    )).to eq(0)
   end
 
   it 'should have r10k available' do


### PR DESCRIPTION
 - We're still seeing failures with the DNS resolver in Docker related
   specs.

   Assign static addresses to the puppet infra, so that when agents
   connect they can have the values set directly in their /etc/hosts
   instead of relying on the flaky Docker DNS resolver.

   Failures are generally `getaddrinfo` failures in resolving
   `puppet.test` from the Ruby code in Puppet.

 - This requires an updated version of the shared spec helpers that
   allows passing an `extra_hosts` value to `run_agent`