### PR TITLE
(maint) Remove timeouts on Docker service waiters

### DIFF
--- a/docker/spec/puppetserver_spec.rb
+++ b/docker/spec/puppetserver_spec.rb
@@ -24,7 +24,7 @@ describe 'puppetserver container' do
   end
 
   it 'should start puppetserver successfully' do
-    expect(wait_on_service_health('puppet', 180)).to eq ('healthy')
+    expect(wait_on_service_health('puppet')).to eq ('healthy')
   end
 
   it 'should be able to run a puppet agent against the puppetserver' do
@@ -32,7 +32,7 @@ describe 'puppetserver container' do
   end
 
   it 'should be able to start a compile master' do
-    expect(wait_on_service_health('compiler', 180)).to eq ('healthy')
+    expect(wait_on_service_health('compiler')).to eq ('healthy')
   end
 
   it 'should be able to run an agent against the compile master' do


### PR DESCRIPTION
 - The upstream method now uses the healtcheck definition inside the
   Dockerfile to automatically determine the appropriate timeout