### PR TITLE
(SERVER-2611) Update to clj-parent 4.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.0.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.1.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -51,8 +51,7 @@
                  ;; send their logs to logstash, so we include it in the jar.
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "2.1.2"]
-
+                 [puppetlabs/jruby-utils]
                  [puppetlabs/clj-shell-utils]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-webserver-jetty9]


### PR DESCRIPTION
This version of clj-parent starts managing the jruby-utils library. The
version we are using now updates JRuby to 2.9.8.0.