### PR TITLE
(maint) Remove stages from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,19 @@ services:
 script:
   - ./ext/travisci/test.sh
   - $TRAVIS_BUILD_DIR/ext/travisci/secscan.sh "$TRAVIS_BUILD_DIR/src/clj" "clj"
-matrix:
+jobs:
   include:
-    - stage: puppetserver tests on JDK11 w/o FIPS
-      jdk: openjdk11
-    - stage: puppetserver tests on JDK8 w/o FIPS
+    - stage: puppetserver tests
+      name: "Java 8 w/o FIPS"
       jdk: openjdk8
-    - stage: puppetserver tests on JDK11 w/ FIPS
-      jdk: openjdk11
-      env:
-        - ADDITIONAL_LEIN_ARGS="with-profile +fips"
-    - stage: puppetserver tests on JDK8 w/ FIPS
-      jdk: openjdk8
-      env:
-        - ADDITIONAL_LEIN_ARGS="with-profile +fips"
+    - jdk: openjdk11
+      name: "Java 11 w/o FIPS"
+    - jdk: openjdk8
+      env: ADDITIONAL_LEIN_ARGS="with-profile +fips"
+      name: "Java 8 w/ FIPS"
+    - jdk: openjdk11
+      env: ADDITIONAL_LEIN_ARGS="with-profile +fips"
+      name: "Java 11 w/ FIPS"
     - stage: puppetserver container tests
       language: ruby
       rvm: 2.5.5


### PR DESCRIPTION
In Travis, stages run in sequence. A recent update made each of our
puppetserver cells (jdk8 x jdk11 x FIPS x no-FIPS) run sequentially,
rather than in parallel. This remedies that.