### PR TITLE
(maint) Use puppet6 release repos for PuppetDB

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -10,15 +10,9 @@ teardown do
   on(master, "rm -f #{sitepp}")
 end
 
-# Install the SNAPSHOT with the necessary modifications to the
-# puppetdb terminus; once PuppetDB has tagged and released, revert
-# this commit and update the `install_puppetlabs_release_repo_on`
-# to use 'puppet6'
-
-# step 'Install Puppet Release Repo' do
-#   install_puppetlabs_release_repo_on(master, 'puppet5')
-# end
-install_puppetlabs_dev_repo master, 'puppetdb', "6.4.1.SNAPSHOT.2019.08.13T0822"
+step 'Install Puppet Release Repo' do
+  install_puppetlabs_release_repo_on(master, 'puppet6')
+end
 
 step 'Install PuppetDB module' do
   on(master, puppet('module install puppetlabs-puppetdb'))


### PR DESCRIPTION
Now that the changes we need for Hiera lookup data collection have been
released in PDB, this commit updates our tests to use the puppet6
release repos, which will pull in the latest released version of PDB in
that stream.