### PR TITLE
(MAINT) Remove --fail-fast

### DIFF
--- a/docker/puppetserver/.rspec
+++ b/docker/puppetserver/.rspec
@@ -1,4 +1,3 @@
 --format RspecJunitFormatter
 --out puppetserver/TEST-rspec.xml
 --format documentation
---fail-fast


### PR DESCRIPTION
We already fail fast if there's an error in :before blocks, and we'd
prefer to run all tests if it gets out of the :before block, so we
actually don't want --fail-fast.