### PR TITLE
(SERVER-2423) Add facter.jar to system classpath from cli

### DIFF
--- a/resources/ext/cli_defaults/cli-defaults.sh.erb
+++ b/resources/ext/cli_defaults/cli-defaults.sh.erb
@@ -4,4 +4,4 @@ if [ -n "$JRUBY_JAR" ]; then
   echo "Warning: the JRUBY_JAR setting is no longer needed and will be ignored." 1>&2
 fi
 
-CLASSPATH="${CLASSPATH}:/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/jars/*"
+CLASSPATH="${CLASSPATH}:/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter.jar:/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/jars/*"

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -2,7 +2,6 @@
   (:require [clojure.tools.logging :as log]
             [me.raynes.fs :as fs]
             [schema.core :as schema]
-            [puppetlabs.kitchensink.classpath :as ks-classpath]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-puppet-schemas]
             [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
@@ -93,28 +92,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
-(def facter-jar
-  "Well-known name of the facter jar file"
-  "facter.jar")
-
 (def MetricsInfo
   {:metric-registry MetricRegistry
    :server-id schema/Str})
-
-(schema/defn ^:always-validate
-  add-facter-jar-to-system-classloader!
-  "Searches the ruby load path for a file whose name matches that of the
-  facter jar file.  The first one found is added to the system classloader's
-  classpath.  If no match is found, an info message is written to the log
-  but no failure is returned"
-  [ruby-load-path :- [schema/Str] ]
-  (if-let [facter-jar (first
-                       (filter fs/exists?
-                               (map #(fs/file % facter-jar) ruby-load-path)))]
-    (do
-      (log/debug (i18n/trs "Adding facter jar to classpath from: {0}" facter-jar))
-      (ks-classpath/add-classpath facter-jar))
-    (log/info (i18n/trs "Facter jar not found in ruby load path"))))
 
 (schema/defn get-initialize-pool-instance-fn :- IFn
   [config :- jruby-puppet-schemas/JRubyPuppetConfig

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -33,7 +33,6 @@
                         (partial shutdown-on-error (tk-services/service-id this))
                         true
                         metrics-service)
-          _ (core/add-facter-jar-to-system-classloader! (:ruby-load-path jruby-config))
           pool-context (create-pool jruby-config)]
       (log/info (i18n/trs "JRuby version info: {0}"
                           jruby-core/jruby-version-info))


### PR DESCRIPTION
When we moved to supporting native Facter we began optionally
adding the facter.jar in clojure at runtime if it was available.

This is because Java only allows a native library to be loaded once per
JVM and attempting to load the library from different classloaders will
cause an error.

This approach was possible because the application classloader was a
global, mutable object.

See SERVER-718 & FACT-965 for the original work and rationale.

In Java 9+, the global classloaders are no longer mutable so the
classloader that the clojure code adds the facter.jar to is never seen
by any JRuby instance. This causes starting Puppet Server with more than
one JRuby instance, or reloading Puppet Server with only one JRuby
instance, or whenever Puppet Server tries to refresh the one JRuby
instance because of max-requests-per-instance, to fail with an
UnsatisfiedLinkError because the second JRuby instance will have a
different classloader than the first one.

Now that Puppet Server requires versions of the AIO agent that only
bring in native Facter and its jar, we no longer need the optional
loading of native Facter's jar.

Since we can now rely on facter.jar being available we can simply add
it to the classpath when invoking Java, which is the only way to put it
in the global classloader in Java 9+.

Notes:
  - In dev environments we still load Ruby Facter from a submodule and
    do not use native Facter or the service scripts we change in this
    patch.
  - Some Java implementations may warn if there's a classpath entry
    that does not exist - if we move the facter.jar w/o updating our
    classpath invocation. However, OpenJDK versions 8 & 11 (those
    available on my test machine of RHEL8) do not warn on non-existent
    classpath entries.
  - Because we no longer search the ruby load path for the facter.jar if
    it moves and our classpath invocation isn't changed loading Facter
    will fail, and Puppet Server will no longer start. _Unless_ the jar
    is moved to `/opt/puppetlabs/server/data/puppetserver/jars/` where
    we encourage users to put their own additional jars, or it is
    vendored w/in the uberjar `puppet-server-release.jar`.