### PR TITLE
[dnm] (SERVER-2616) Do not force closed client connections

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/http_client.rb
@@ -94,8 +94,6 @@ class Puppet::Server::HttpClient
       headers["Authorization"] = authorization
     end
 
-    # Ensure multiple requests are not made on the same connection
-    headers["Connection"] = "close"
     request_options = RequestOptions.new(build_url(url))
     if options[:metric_id]
       request_options.set_metric_id(options[:metric_id])

--- a/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -319,20 +319,6 @@ jruby-config :- jruby-schemas/JRubyConfig
               (is (= client1 client2)))))))))
 
 (deftest connections-closed
-  (testing "connection header always set to close on get"
-    (logutils/with-test-logging
-      (jetty9/with-test-webserver ring-app-connection-closed port
-        (with-scripting-container sc
-          (with-http-client sc port {:use-ssl false}
-            (is (= "The Connection header has value close"
-                   (.runScriptlet sc "$c.get('/', {}).body"))))))))
-  (testing "connection header always set to close on post"
-    (logutils/with-test-logging
-      (jetty9/with-test-webserver ring-app-connection-closed port
-        (with-scripting-container sc
-          (with-http-client sc port {:use-ssl false}
-            (is (= "The Connection header has value close"
-                   (.runScriptlet sc "$c.post('/', 'foo', {}).body"))))))))
   (testing "client's terminate function closes the client"
     (logutils/with-test-logging
       (jetty9/with-test-webserver ring-app-connection-closed port


### PR DESCRIPTION
When Server's http client wrapper was initially written Puppet's client
forced all of its connections closed, however, it was very shortly later
re-written to stop doing that w/o issue (see
puppet@789e00bb8255548dbad71ba1462a16afec624cc8).