### PR TITLE
(maint) Preserve vendored gems at container build time

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -83,6 +83,7 @@ COPY docker/puppetserver-standalone/puppetserver.conf /etc/puppetlabs/puppetserv
 
 RUN puppet config set autosign true --section master && \
     cp -pr /etc/puppetlabs/puppet /var/tmp && \
+    cp -pr /opt/puppetlabs/server/data/puppetserver /var/tmp && \
     rm -rf /var/tmp/puppet/ssl
 
 COPY docker/puppetserver-standalone/docker-entrypoint.sh /

--- a/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
@@ -14,13 +14,13 @@ cd /
 
 # if the data dir is empty, copy over everything from build time
 if [ ! "$(ls -A /opt/puppetlabs/server/data/puppetserver)" ]; then
-  cp -a /var/tmp/puppetserver/* /opt/puppetlabs/server/data/puppetserver/
+  cp -R /var/tmp/puppetserver/* /opt/puppetlabs/server/data/puppetserver/
   # remove the tmp dir so we only run this on first runs of new containers
   rm -rf /var/tmp/puppetserver/vendored-jruby-gems
 elif [ -d /var/tmp/puppetserver/vendored-jruby-gems ]; then
   # clean up existing vendored gems
   rm -rf /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems
-  cp -a /var/tmp/puppetserver/vendored-jruby-gems /opt/puppetlabs/server/data/puppetserver/
+  cp -R /var/tmp/puppetserver/vendored-jruby-gems /opt/puppetlabs/server/data/puppetserver/
   # remove the tmp dir so we only run this on first runs of new containers
   rm -rf /var/tmp/puppetserver/vendored-jruby-gems
 fi

--- a/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
@@ -14,10 +14,13 @@ cd /
 
 # if the data dir is empty, copy over everything from build time
 if [ ! "$(ls -A /opt/puppetlabs/server/data/puppetserver)" ]; then
+  # https://github.com/moby/moby/issues/39892
+  echo "Loading new empty VOLUME with default /opt/puppetlabs/server/data/puppetserver content (LCOW moby 39892 workaround)"
   cp -R /var/tmp/puppetserver/* /opt/puppetlabs/server/data/puppetserver/
   # remove the tmp dir so we only run this on first runs of new containers
   rm -rf /var/tmp/puppetserver/vendored-jruby-gems
 elif [ -d /var/tmp/puppetserver/vendored-jruby-gems ]; then
+  echo "Upgrading /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"
   # clean up existing vendored gems
   rm -rf /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems
   cp -R /var/tmp/puppetserver/vendored-jruby-gems /opt/puppetlabs/server/data/puppetserver/

--- a/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
@@ -11,3 +11,11 @@ do
     test -f "$TEMPLATES/$f" && cp -np "$TEMPLATES/$f" .
 done
 cd /
+
+if [ -d /var/tmp/puppetserver/vendored-jruby-gems ]; then
+  # clean up existing vendored gems
+  rm -rf /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems
+  cp -a /var/tmp/puppetserver/vendored-jruby-gems /opt/puppetlabs/server/data/puppetserver/
+  # remove the tmp dir so we only run this on first runs of new containers
+  rm -rf /var/tmp/puppetserver/vendored-jruby-gems
+fi

--- a/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/20-use-templates-initially.sh
@@ -12,7 +12,12 @@ do
 done
 cd /
 
-if [ -d /var/tmp/puppetserver/vendored-jruby-gems ]; then
+# if the data dir is empty, copy over everything from build time
+if [ ! "$(ls -A /opt/puppetlabs/server/data/puppetserver)" ]; then
+  cp -a /var/tmp/puppetserver/* /opt/puppetlabs/server/data/puppetserver/
+  # remove the tmp dir so we only run this on first runs of new containers
+  rm -rf /var/tmp/puppetserver/vendored-jruby-gems
+elif [ -d /var/tmp/puppetserver/vendored-jruby-gems ]; then
   # clean up existing vendored gems
   rm -rf /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems
   cp -a /var/tmp/puppetserver/vendored-jruby-gems /opt/puppetlabs/server/data/puppetserver/


### PR DESCRIPTION
We've realized most of the data in
/opt/puppetlabs/server/data/puppetserver is runtime data that should be
preserved as a volume during container runs. However,
`vendored-jruby-gems` only ever contains files installed at package
build time. Ideally these will move out of the data directory, but in
the interim work around it using the existing /var/tmp + entrypoint
pattern we have.