### PR TITLE
(maint) Push context changes globally during Server init

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -49,7 +49,7 @@ class Puppet::Server::PuppetConfig
     # in a completely different way.
     #
     # See `Puppet::Network::HttpPool.connection`
-    Puppet.push_context({ssl_context: :unused})
+    Puppet.push_context_global({ssl_context: :unused})
 
     Puppet.settings.use :main, :master, :ssl, :metrics
 


### PR DESCRIPTION
Puppet @ a1153bf3b created a method to update the default
Puppet::Context that all request threads see. We need to put in a dummy
value for the :ssl_context in the Puppet::Context during Server init to
function properly in FIPS installs.

This updates us to take advantage of that global update method, fixing a
regression in FIPS functionality.