### PR TITLE
(maint) Allow using Puppet code prior to 0f370f0fb

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/key_recorder.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/key_recorder.rb
@@ -1,5 +1,27 @@
 require 'puppet/server'
-require 'puppet/pops/lookup/key_recorder'
+
+# Puppet::Pops::Lookup::KeyRecorder was added in Puppet 6.8 with
+# this "null" behavior. If running with agent code < 6.8 define our
+# own null recorder.
+begin
+  require 'puppet/pops/lookup/key_recorder'
+rescue LoadError
+  module Puppet
+    module Pops
+      module Lookup
+        class KeyRecorder
+
+          def self.singleton
+            @recorder ||= new
+          end
+
+          def record(key)
+          end
+        end
+      end
+    end
+  end
+end
 
 class Puppet::Server::KeyRecorder < Puppet::Pops::Lookup::KeyRecorder
   attr_accessor :lookups

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -12,7 +12,6 @@ require 'puppet/server/network/http/handler'
 require 'puppet/server/compiler'
 require 'puppet/server/ast_compiler'
 require 'puppet/server/key_recorder'
-require 'puppet/pops/lookup/key_recorder'
 
 require 'java'
 


### PR DESCRIPTION
It isn't recommended and few do it, but we should generally allow
running agents and masters of similar versions, as it at least makes
upgrade scenarios easier for our users and git bisects and code
promotions easier on us.