### PR TITLE
(MAINT) Generalize .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,4 @@
-docker/puppetserver/*               text  eol=lf
-docker/puppetserver-standalone/*    text  eol=lf
-docker/puppetserver-standalone/docker-entrypoint.d/*    text  eol=lf
+docker/**                           text  eol=lf
 resources/ext/build-scripts/*       text  eol=lf
 resources/ext/cli_defaults/*        text  eol=lf
 resources/ext/cli/*                 text  eol=lf


### PR DESCRIPTION
So it's easier to maintain by not listing out all the subdirectories
underneath docker/.