### PR TITLE
6.6 release

### DIFF
--- a/acceptance/config/beaker/options.rb
+++ b/acceptance/config/beaker/options.rb
@@ -11,4 +11,4 @@
  "puppetserver-confdir"=>"/etc/puppetlabs/puppetserver/conf.d",
  "puppetserver-config"=>
   "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
- :puppet_build_version=>"dd1d68d9fcfefde1b8497301bd0748f71a66b750"}
+ :puppet_build_version=>"2e5ae62b8c9376273cda3744d6d4ffa2d060d67f"}

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -8,9 +8,23 @@ canonical: "/puppetserver/latest/install_from_packages.html"
 
 ## System Requirements
 
-Puppet Server is configured to use 2 GB of RAM by default. If you'd like to just play around with an installation on a Virtual Machine, this much memory is not necessary. To change the memory allocation, see [Memory Allocation](#memory-allocation).
+Puppet Server is configured to use 2 GB of RAM by default. If you're just testing an installation on a Virtual Machine, this much memory is not necessary. To change the memory allocation, see [Memory Allocation](#memory-allocation).
 
 > If you're also using PuppetDB, check its [requirements](https://puppet.com/docs/puppetdb/latest/index.html#system-requirements).
+
+## Java support
+
+Puppet Server versions are tested against the following versions of Java:
+
+| Puppet Server  | Java  |
+|---|---|
+| 2.x  | 7, 8  |
+| 5.x  | 8  |
+| 6.0-6.5  | 8, 11 (experimental)  |
+| 6.6 and later  | 8, 11  |
+
+
+Some Java versions may work with other Puppet Server versions, but we do not test or support those cases. Community submitted patches for support greater than Java 11 are welcome. Both Java 8 and 11 are considered long-term support versions and are planned to be supported by upstream maintainers until 2022 or later.
 
 ## Platforms with Packages
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -10,6 +10,32 @@ canonical: "/puppetserver/latest/release_notes.html"
 [puppetserver.conf]: ./config_file_puppetserver.markdown
 [product.conf]: ./config_file_product.markdown
 
+## Puppet Server 6.6.0
+
+Released 17 September 2019
+
+### New features
+
+- Puppet Server no longer hardcodes Java's egd parameter. Users may manage the value via JAVA_ARGS or JAVA_ARGS_CLI in the defaults file. [SERVER-2602](https://tickets.puppetlabs.com/browse/SERVER-2602)
+
+- RedHat 7 FIPS mode packages are now available for `puppetserver`. [SERVER-2555](https://tickets.puppetlabs.com/browse/SERVER-2555)
+
+- Puppet Server now lists plan content from your modules, just as it does task content. [SERVER-2543](https://tickets.puppetlabs.com/browse/SERVER-2543)
+
+- You can now enable sending a list of all the Hiera keys looked up during compile to PuppetDB, via the `jruby-puppet.track-lookups` setting in `puppetserver.conf`. This is currently only used by CD4PE. [SERVER-2538](https://tickets.puppetlabs.com/browse/SERVER-2538)
+
+-Added the `/puppet-admin-api/v1/jruby-pool/thread-dump` endpoint, which returns a thread dump of running JRuby instances, if `jruby.management.enabled` has been set to `true` in the JVM running Puppet Server. See [Admin API: JRuby Pool](./admin-api/v1/jruby-pool.markdown#get-puppet-admin-apiv1jruby-poolthread-dump) for details. [SERVER-2193](https://tickets.puppetlabs.com/browse/SERVER-2193)
+
+- Puppet Server now runs with JRuby 9.2.8.0. [SERVER-2388](https://tickets.puppetlabs.com/browse/SERVER-2588)
+ 
+- The `puppetserver ca import` command now initializes an empty CRL for the intermediate CA if one is not provided in the `crl-chain` file. [SERVER-2522](https://tickets.puppetlabs.com/browse/SERVER-2552)
+
+### Resolved issues
+
+- Puppet Server can now be reloaded and run with multiple JRuby instances when running under Java 11. [SERVER-2423](https://tickets.puppetlabs.com/browse/SERVER-2423)
+
+-Puppet Server's CA can now handle keys in the PKCS#8 format, which is required when running in FIPS mode. [SERVER-2019](https://tickets.puppetlabs.com/browse/SERVER-2019)
+
 ## Puppet Server 6.5.0
 
 Released 22 July 2019
@@ -52,19 +78,6 @@ Released 19 April 2019
 
 - This release adds a new API endpoint to `/puppet/v3/environment_transports`. This endpoint lists all of the available network transports from modules and is for use with the Agentless Catalog Executor. [SERVER-2467](https://tickets.puppetlabs.com/browse/SERVER-2467)
 
-## Puppet Server 6.3.1
-
-Released 16 July 2019
-
-### Bug fixes
-
-- In this release, performance in puppetserver commands is improved. Running `puppetserver gem`, `puppetserver irb`, and other Puppet Server CLI commands are 15-30 percent faster to start up. Service starting and reloading should see similar improvements, along with some marginal improvements to top-end performance, especially in environments with limited sources of entropy.
-
-- Building Puppet Server outside our network is now slightly easier.
-
-- Prior to this release, an unnecessary and deprecated version of Facter was shipped in the `puppetserver` package. This has been removed.
-
-- Cert and CRL bundles no longer need to be in any specific order. By default, the leaf instances still come first, descending to the root, which are last. [SERVER-2465](https://tickets.puppetlabs.com/browse/SERVER-2465)
 
 ## Puppet Server 6.3.0
 

--- a/documentation/services_master_puppetserver.markdown
+++ b/documentation/services_master_puppetserver.markdown
@@ -11,7 +11,7 @@ canonical: "/puppetserver/latest/services_master_puppetserver.html"
 
 Puppet is configured in an agent-master architecture, in which a master node controls configuration information for a fleet of managed agent nodes. Puppet Server performs the role of the master node. Puppet Server is a Ruby and Clojure application that runs on the Java Virtual Machine (JVM) and provides the same services as the classic Puppet master application. It mostly does this by running the existing Puppet master code in several JRuby interpreters, but it replaces some parts of the classic application with new services written in Clojure.
 
-This page describes the generic requirements and run environment for Puppet Server; for practical instructions, see the docs for [installing](./install_from_packages.markdown) and [configuring](./configuration.markdown) it. For details about invoking the `puppet master` command, see [the `puppet master` man page](https://puppet.com/docs/puppet/latest/man/master.html).
+This page describes the generic requirements and run environment for Puppet Server; for practical instructions, see the docs for [installing](./install_from_packages.markdown) and [configuring](./configuration.markdown) it.
 
 ## Supported Platforms
 
@@ -19,7 +19,7 @@ Puppet provides Puppet Server packages for Red Hat Enterprise Linux, RHEL-derive
 
 If we don't provide a package for your system, you can run Puppet Server from source on any POSIX server with JDK 1.7 or later. See [Running from Source](./dev_running_from_source.markdown) for more details.
 
-Note that Puppet Server is versioned separately from Puppet itself. Puppet Server 1.0 is compatible with Puppet 3.7.3 and later, but will not be compatible with Puppet 4.0; there will be a separate Puppet Server release to coincide with the next major version of Puppet.
+Note that Puppet Server is versioned separately from Puppet itself. Major Puppet Server releases are compatible with the same major Puppet release, such as Puppet 6.x and Puppet Server 6.x, but might have different minor or patch versions, such as Puppet 6.9 and Puppet Server 6.6. For a list of the maintained versions of Puppet, Puppet Server, and Puppet DB, see [Puppet releases and lifecycles](https://puppet.com/docs/puppet/latest/about_agent.html).
 
 ## Controlling the Service
 
@@ -57,7 +57,7 @@ for more information on these APIs.
 
 Signing and revoking certificates over the network is disallowed by default; you can use the [`auth.conf`](./config_file_auth.html) file to let specific certificate owners issue commands.
 
-The CA service uses .pem files in the standard Puppet [`ssldir`](https://puppet.com/docs/puppet/latest/dirs_ssldir.html) to store credentials. You can use the standard `puppetserver ca` command to interact with these credentials, including listing, signing, and revoking certificates.
+The CA service uses ``.pem` files in the standard Puppet [`ssldir`](https://puppet.com/docs/puppet/latest/dirs_ssldir.html) to store credentials. You can use the standard `puppetserver ca` command to interact with these credentials, including listing, signing, and revoking certificates.
 
 ### Admin API Service
 
@@ -76,9 +76,7 @@ Most of Puppet Server's work — compiling catalogs, receiving reports, etc. —
 
 Because we don't use the system Ruby, you can't use the system `gem` command to install Ruby Gems for use by the Puppet master. Instead, Puppet Server includes a separate `puppetserver gem` command for installing any libraries that your Puppet extensions might require. See [the "Using Ruby Gems" page](./gems.markdown) for details.
 
-Additionally, if you need to test or debug code that will be used by Puppet Server, we include `puppetserver ruby` and `puppetserver irb` commands that will execute Ruby code in a JRuby environment.
-
-> **Note:** In Puppet Server 2.7.1, you can set custom arguments to be passed into the Java process for the `puppetserver ruby` command via the new `JAVA_ARGS_CLI` environment variable, either temporarily on the command line or persistently by adding it to the sysconfig/default file (typically located at `/etc/sysconfig/puppetserver` or `/etc/defaults/puppetserver`). The `JAVA_ARGS_CLI` environment variable also controls the arguments used when running the `puppetserver gem` and `puppetserver irb` [subcommands](./subcommands.markdown). See the [Server 2.7.1 release notes](https://docs.puppet.com/puppetserver/2.7/release_notes.html) for details.
+Additionally, if you need to test or debug code that will be used by Puppet Server, we include `puppetserver ruby` and `puppetserver irb` commands that execute Ruby code in a JRuby environment.
 
 To handle parallel requests from agent nodes, Puppet Server maintains several separate JRuby interpreters, all independently running Puppet's application code, and distributes agent requests among them. Today, agent requests are distributed more or less randomly, without regard to their environment; this may change in the future.
 
@@ -122,13 +120,13 @@ By default, Puppet Server handles SSL termination automatically.
 
 In network configurations that require external SSL termination (e.g. with a hardware load balancer), you'll need to configure a few other things. See the [External SSL Termination](./external_ssl_termination.markdown) page for details. In summary, you'll need to:
 
-* Configure Puppet Server to use HTTP instead of HTTPS
-* Configure Puppet Server to accept SSL information via insecure HTTP headers
-* Secure your network so that Puppet Server **cannot** be directly reached by **any** untrusted clients
+* Configure Puppet Server to use HTTP instead of HTTPS.
+* Configure Puppet Server to accept SSL information via insecure HTTP headers.
+* Secure your network so that Puppet Server **cannot** be directly reached by **any** untrusted clients.
 * Configure your SSL terminating proxy to set the following HTTP headers:
-    * `X-Client-Verify` (mandatory)
-    * `X-Client-DN` (mandatory for client-verified requests)
-    * `X-Client-Cert` (optional; required for [trusted facts](https://puppet.com/docs/puppet/latest/lang_facts_and_builtin_vars.html))
+    * `X-Client-Verify` (mandatory).
+    * `X-Client-DN` (mandatory for client-verified requests).
+    * `X-Client-Cert` (optional; required for [trusted facts](https://puppet.com/docs/puppet/latest/lang_facts_and_builtin_vars.html)).
 
 ## Configuring Puppet Server
 
@@ -140,11 +138,8 @@ Puppet Server's `conf.d` directory contains:
 * `webserver.conf` and `web-routes.conf`: Web server configuration settings.
 * `puppetserver.conf`: Settings for Puppet Server itself, including the JRuby interpreter and the administrative API.
 * `auth.conf`: Authentication rules for Puppet Server endpoints.
-* `master.conf` ([deprecated][]): Settings for the Puppet master functionality of Puppet Server.
 * `ca.conf`: Settings for the Certificate Authority service.
 
 For detailed information about Puppet Server settings and the `conf.d` directory, refer to the [Configuration](./configuration.markdown) page.
-
-While Puppet Server can use Puppet's [`auth.conf`](https://puppet.com/docs/puppet/latest/config_file_auth.html) for access control, this method is deprecated in favor of a new authentication system introduced in Puppet Server 2.2 and configured through its own [`auth.conf`](./config_file_auth.markdown) file.
 
 As mentioned above, Puppet Server also uses Puppet's usual config files, including most of the settings in [`puppet.conf`](https://puppet.com/docs/puppet/latest/config_file_main.html). However, Puppet Server treats some `puppet.conf` settings differently, and you should be aware of [these differences](./puppet_conf_setting_diffs.markdown).

--- a/documentation/services_master_puppetserver.markdown
+++ b/documentation/services_master_puppetserver.markdown
@@ -57,7 +57,7 @@ for more information on these APIs.
 
 Signing and revoking certificates over the network is disallowed by default; you can use the [`auth.conf`](./config_file_auth.html) file to let specific certificate owners issue commands.
 
-The CA service uses ``.pem` files in the standard Puppet [`ssldir`](https://puppet.com/docs/puppet/latest/dirs_ssldir.html) to store credentials. You can use the standard `puppetserver ca` command to interact with these credentials, including listing, signing, and revoking certificates.
+The CA service uses `.pem` files in the standard Puppet [`ssldir`](https://puppet.com/docs/puppet/latest/dirs_ssldir.html) to store credentials. You can use the standard `puppetserver ca` command to interact with these credentials, including listing, signing, and revoking certificates.
 
 ### Admin API Service
 
@@ -75,6 +75,8 @@ Right now, the main administrative task is forcing expiration of all environment
 Most of Puppet Server's work — compiling catalogs, receiving reports, etc. — is still done by Ruby code. But instead of using the operating system's MRI Ruby runtime, Puppet Server runs Puppet in JRuby, an implementation of the Ruby interpreter that runs on the JVM.
 
 Because we don't use the system Ruby, you can't use the system `gem` command to install Ruby Gems for use by the Puppet master. Instead, Puppet Server includes a separate `puppetserver gem` command for installing any libraries that your Puppet extensions might require. See [the "Using Ruby Gems" page](./gems.markdown) for details.
+
+> **Note:** To set custom arguments to be passed into the Java process for the `puppetserver ruby` command with the `JAVA_ARGS_CLI` environment variable, either temporarily on the command line or persistently by adding it to the sysconfig/default file (typically located at `/etc/sysconfig/puppetserver` or `/etc/defaults/puppetserver`). The `JAVA_ARGS_CLI` environment variable also controls the arguments used when running the `puppetserver gem` and `puppetserver irb` [subcommands](./subcommands.markdown).
 
 Additionally, if you need to test or debug code that will be used by Puppet Server, we include `puppetserver ruby` and `puppetserver irb` commands that execute Ruby code in a JRuby environment.
 


### PR DESCRIPTION
Release notes for 6.6, and a couple of file changes. 

I removed some info from pages, so please review those carefully and let me know if I removed something I shouldn't have. 

I removed:

out-of-stream release notes
outdated info on services_master_puppetserver.markdown 
outdated info on install_from_packages.markdown