### PR TITLE
[Docker container] Add 2 missing directories to fix permissions for

### DIFF
--- a/docker/puppetserver-standalone/docker-entrypoint.d/30-set-permissions.sh
+++ b/docker/puppetserver-standalone/docker-entrypoint.d/30-set-permissions.sh
@@ -2,3 +2,5 @@
 
 chown -R puppet:puppet /etc/puppetlabs/puppet/
 chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver/
+chown -R puppet:puppet /etc/puppetlabs/puppetserver/
+chown -R puppet:puppet /var/log/puppetlabs/puppetserver/


### PR DESCRIPTION
Following directories are owned by `puppet` user in container. If UID/GID is changed, those directories permissions must be updated too.