### PR TITLE
(docs) explain docs redirect

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,7 @@
+# Puppet Server documentation
+
+If you were redirected while trying to reach the Puppet Server docs at puppet.com/docs/puppetserver, the version you were trying to reach is no longer maintained.
+
+For the most recent Puppet Server docs, see [puppet.com/docs/puppetserver/latest](puppet.com/docs/puppetserver/latest). For a list of the current maintained versions of open source Puppet and its components, see the most recent [Puppet version](puppet.com/docs/puppet/latest/about_agent.html) information. For a list of supported Puppet Enterprise versions, see the [Puppet Enterprise lifecycle](https://puppet.com/misc/puppet-enterprise-lifecycle).
+
+If you need docs for an older version of Puppet Server, you may be able to find it by switching to the relevant branch of this repository.


### PR DESCRIPTION
Adding a README to explain to users why they might have been redirected here, and how they can find what they really need.