### PR TITLE
(maint) Update Docker healthcheck

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -57,6 +57,7 @@ endif
 
 test: prep
 	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE
+	@bundle update
 	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/puppetserver-standalone:$(version) \
 		bundle exec --gemfile $$GEMFILE \
 		rspec --options puppetserver-standalone/.rspec spec

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -101,6 +101,6 @@ CMD ["foreground"]
 
 COPY docker/puppetserver-standalone/healthcheck.sh /
 RUN chmod +x /healthcheck.sh
-HEALTHCHECK --interval=5s --timeout=5s --retries=12 --start-period=120s CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=10s --timeout=15s --retries=12 --start-period=4m CMD ["/healthcheck.sh"]
 
 COPY docker/puppetserver-standalone/Dockerfile /

--- a/docker/spec/puppetserver_spec.rb
+++ b/docker/spec/puppetserver_spec.rb
@@ -1,28 +1,22 @@
 require 'rspec/core'
-require 'open3'
 require 'pupperware/spec_helper'
+include Pupperware::SpecHelpers
 
-describe 'puppetserver container' do
-  include Pupperware::SpecHelpers
-
-  before(:all) do
-    run_command('docker pull puppet/puppet-agent-ubuntu:latest')
-    require_test_image
-    status = docker_compose('version')[:status]
-    if status.exitstatus != 0
-      fail "`docker-compose` must be installed and available in your PATH"
-    end
-
+RSpec.configure do |c|
+  c.before(:suite) do
+    require_test_image()
     teardown_cluster()
-
+    run_command('docker pull puppet/puppet-agent-ubuntu:latest')
     docker_compose_up()
   end
 
-  after(:all) do
-    emit_logs()
+  c.after(:suite) do
+    emit_logs
     teardown_cluster()
   end
+end
 
+describe 'puppetserver container' do
   it 'should be able to run a puppet agent against the puppetserver' do
     expect(run_agent('puppet-agent.test', 'puppetserver_test', masterport: '8141')).to eq(0)
   end

--- a/docker/spec/puppetserver_spec.rb
+++ b/docker/spec/puppetserver_spec.rb
@@ -23,16 +23,8 @@ describe 'puppetserver container' do
     teardown_cluster()
   end
 
-  it 'should start puppetserver successfully' do
-    expect(wait_on_service_health('puppet')).to eq ('healthy')
-  end
-
   it 'should be able to run a puppet agent against the puppetserver' do
     expect(run_agent('puppet-agent.test', 'puppetserver_test', masterport: '8141')).to eq(0)
-  end
-
-  it 'should be able to start a compile master' do
-    expect(wait_on_service_health('compiler')).to eq ('healthy')
   end
 
   it 'should be able to run an agent against the compile master' do


### PR DESCRIPTION
This is partly about making puppetserver / pe-puppetserver containers similar, but more about configuring a more reasonable healthcheck in addition to:

- Need a bundle update to be able to pull the pupperware spec_helper
   (this primarily impacts local dev)

- Latest spec helpers include a new wait_on_stack_healthy that is
   automatically called by docker_compose_up

   Any explicit calls to wait on specific services are no longer
   necessary

 - Follow similar patterns set by other suites like pe-puppetserver
   for the sake of consistency

 - It's no longer necessary to follow a check for the docker-compose
   binary

 - Under LCOW, this container sometimes doesn't start in a 240s
   initial time window.

   Increase the initial failing healthcheck period to 4m from 2m and
   increase the retries so that the container is tested for 2m rather
   than 1m -- allowing for a maximum startup time of 6m instead of 3m

 - Note that under LCOW we're also seeing failures like the following
   in specs:

   encountered an error during CreateProcess: failure in a Windows system call: Unspecified error (0x80004005)
   [Event Detail: failed to run runc create/exec call for container 61b42887868d25d43e41f5bb9fb50315de0b8de8236969e0e20a90862f641dfe: exit status 1 Stack Trace:
     github.com/Microsoft/opengcs/service/gcs/runtime/runc.(*container).startProcess
     ...

   Other containers don't appear to have this problem, and they have
   larger intervals specified between healthcheck calls.

   The hope is that by spacing these out further, that other related
   problems disappear