### PR TITLE
(maint) Configure more like pe puppetserver

### DIFF
--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -51,6 +51,8 @@ ENV CONSUL_ENABLED=false
 ENV CONSUL_HOSTNAME=consul
 ENV CONSUL_PORT=8500
 ENV NETWORK_INTERFACE=eth0
+ENV SSLDIR /etc/puppetlabs/puppet/ssl
+ENV CERTNAME puppet
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -52,6 +52,8 @@ ENV CONSUL_HOSTNAME=consul
 ENV CONSUL_PORT=8500
 ENV NETWORK_INTERFACE=eth0
 ENV SSLDIR /etc/puppetlabs/puppet/ssl
+# TODO: stup this volume
+# ENV SSLDIR /opt/puppetlabs/server/data/puppetserver/certs
 ENV CERTNAME puppet
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
@@ -86,6 +88,8 @@ COPY docker/puppetserver-standalone/puppetserver /etc/default/puppetserver
 COPY docker/puppetserver-standalone/logback.xml /etc/puppetlabs/puppetserver/
 COPY docker/puppetserver-standalone/request-logging.xml /etc/puppetlabs/puppetserver/
 COPY docker/puppetserver-standalone/puppetserver.conf /etc/puppetlabs/puppetserver/conf.d/
+# TODO: we'll need to copy in a puppet.conf like pe-puppetserver that configures SSLDIR and log locations
+# TODO: and a script like https://github.com/puppetlabs/pe-puppetserver/blob/968696ddaa1fc5cf2c16a89faae9b9dff497feb2/docker/pe-puppetserver/docker-entrypoint.d/10-ca.sh
 
 RUN puppet config set autosign true --section master && \
     cp -pr /etc/puppetlabs/puppet /var/tmp && \
@@ -104,5 +108,15 @@ CMD ["foreground"]
 COPY docker/puppetserver-standalone/healthcheck.sh /
 RUN chmod +x /healthcheck.sh
 HEALTHCHECK --interval=10s --timeout=15s --retries=12 --start-period=4m CMD ["/healthcheck.sh"]
+
+# TODO: setup volumes like pe-puppetserver
+# VOLUME definitions are always at end of Dockerfile to address an LCOW bug
+# https://github.com/moby/moby/issues/39892
+# the puppetserver data directory which contains pe_repo packages under packages
+# VOLUME /opt/puppetlabs/server/data/puppetserver
+# VOLUME /opt/puppetlabs/server/data/packages
+# users should volume map in their id-control_repo.rsa
+# VOLUME /etc/puppetlabs/puppetserver/ssh
+
 
 COPY docker/puppetserver-standalone/Dockerfile /

--- a/docker/puppetserver-standalone/healthcheck.sh
+++ b/docker/puppetserver-standalone/healthcheck.sh
@@ -1,18 +1,13 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -x
 set -e
 
-certname=$(ls /etc/puppetlabs/puppet/ssl/certs | grep --invert-match ca.pem) && \
-hostname=$(basename $certname .pem) && \
-hostprivkey=/etc/puppetlabs/puppet/ssl/private_keys/$certname && \
-hostcert=/etc/puppetlabs/puppet/ssl/certs/$certname && \
-localcacert=/etc/puppetlabs/puppet/ssl/certs/ca.pem && \
 curl --fail \
---resolve "${hostname}:${PUPPET_MASTERPORT}:127.0.0.1" \
---cert   $hostcert \
---key    $hostprivkey \
---cacert $localcacert \
-"https://${hostname}:${PUPPET_MASTERPORT}/status/v1/simple" \
-|  grep -q '^running$' \
-|| exit 1
+    --resolve "${HOSTNAME}:${PUPPET_MASTERPORT}:127.0.0.1" \
+    --cert    "${SSLDIR}/certs/${CERTNAME}.pem" \
+    --key     "${SSLDIR}/private_keys/${CERTNAME}.pem" \
+    --cacert  "${SSLDIR}/certs/ca.pem" \
+    "https://${HOSTNAME}:${PUPPET_MASTERPORT}/status/v1/simple" \
+    |  grep -q '^running$' \
+    || exit 1

--- a/docker/puppetserver-standalone/puppetserver.conf
+++ b/docker/puppetserver-standalone/puppetserver.conf
@@ -42,11 +42,13 @@ jruby-puppet: {
 
     # (optional) path to puppet log dir; if not specified, will use
     # /var/log/puppetlabs/puppetserver
+    # TOOD: this should be configured as /opt/puppetlabs/server/data/puppetserver/logs
+    # TODO: make sure all /var/log/puppetlabs have been replaced
     master-log-dir: /var/log/puppetlabs/puppetserver
 
     # (optional) maximum number of JRuby instances to allow
     max-active-instances: ${PUPPETSERVER_MAX_ACTIVE_INSTANCES}
-    
+
     # (optional) number of HTTP requests a given JRuby instance will handle in its lifetime
     max-requests-per-instance: ${PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE}
 


### PR DESCRIPTION
Store things in puppetserver at the same place as pe-puppetserver so upgrades are easy peasy


There's a ton more work to do here