### PR TITLE
(FM-8336) Capture and expose attribute ordering from transport schema

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -97,7 +97,16 @@ class Puppet::Server::Master
 
   def getTransportInfoForEnvironment(env)
     require 'puppet/resource_api/transport'
-    Puppet::ResourceApi::Transport.list_all_transports(env).values.map(&:definition)
+    Puppet::ResourceApi::Transport.list_all_transports(env).values.map do |transport|
+      definition = transport.definition
+      # Provide a default for connection_info_order based on the hash-key-insertion order, which is guaranteed by ruby to be preserved.
+      unless definition.has_key?(:connection_info_order)
+        definition = definition.merge(
+          connection_info_order: definition[:connection_info].keys
+        )
+      end
+      definition
+    end
   end
 
   def getModuleInfoForEnvironment(env)


### PR DESCRIPTION
When exposing attributes in the UI, they currently need to be alphabetised by their name, since the transmission through APIs does not preserve key order of the connection_info hash.

To facilitate showing attributes in the order defined by the module author, this change embeds the key-insertion order from the TypeDefinition into the API response.