### PR TITLE
(MAINT) Group gem dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ steps:
     $gempath = Join-Path -Path (Get-Location) -ChildPath 'docker/.bundle/gems'
     bundle config --local gemfile $gemfile
     bundle config --local path $gempath
-    bundle install
+    bundle install --with test
   displayName: Fetch Dependencies
   name: fetch_deps
 

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,8 +1,11 @@
 source "https://rubygems.org"
 
-gem 'rspec'
-gem 'rspec_junit_formatter'
 gem 'pupperware',
     :git => 'https://github.com/puppetlabs/pupperware.git',
     :branch => 'master',
     :glob => 'gem/*.gemspec'
+
+group :test do
+    gem 'rspec'
+    gem 'rspec_junit_formatter'
+end

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -56,7 +56,7 @@ ifeq ($(IS_LATEST),true)
 endif
 
 test: prep
-	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE
+	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE --with test
 	@bundle update
 	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/puppetserver-standalone:$(version) \
 		bundle exec --gemfile $$GEMFILE \


### PR DESCRIPTION
Allows us to speed up calls to bundler by specifying groups to operate on.