### PR TITLE
(SERVER-2649) Merge branch '6.3.x' into 'master'

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -100,6 +100,42 @@ Released 19 April 2019
 
 - This release adds a new API endpoint to `/puppet/v3/environment_transports`. This endpoint lists all of the available network transports from modules and is for use with the Agentless Catalog Executor. [SERVER-2467](https://tickets.puppetlabs.com/browse/SERVER-2467)
 
+## Puppet Server 6.3.2
+
+Released 15 October 2019
+
+### New features
+
+Puppet Server's CA API now synchronizes write access to the CRL, so that each revoke request updates the CRL in succession, instead of concurrently. This prevents corruption of the CRL due to competing requests.
+
+This does _not_ affect the `puppet cert` command. If you use `puppet cert revoke` at the same time as a revocation request via the API, the CRL is updated simultaneously and could be corrupted.
+
+To minimize this risk, use the `puppetserver ca` command line tool -- which uses the CA API -- whenever possible. [SERVER-2641](https://tickets.puppetlabs.com/browse/SERVER-2641)
+
+### Bug fixes
+
+- The Puppet Server CA CLI now correctly uses hex serial numbers for certs. [SERVER-2603](https://tickets.puppetlabs.com/browse/SERVER-2603)
+
+- The `puppetserver ca import` command now initializes an empty CRL for the intermediate CA if one is not provided in the `crl-chain` file. [SERVER-2522](https://tickets.puppetlabs.com/browse/SERVER-2552)
+
+- You can now specify a `--certname` flag with the `puppetserver ca list` command, which will limit the output to information about the requested cert, and log an error if the requested cert does not exist in any form. [SERVER-2589](https://tickets.puppetlabs.com/browse/SERVER-2589)
+
+- Timing metrics associated with borrowing a JRuby instance now include why that JRuby instance was borrowed and access logs now include the time spent in JRuby. [SERVER-1975](https://tickets.puppetlabs.com/browse/SERVER-1975) & [SERVER-2198](https://tickets.puppetlabs.com/browse/SERVER-2198) respectively.
+
+## Puppet Server 6.3.1
+
+Released 16 July 2019
+
+### Bug fixes
+
+- In this release, performance in puppetserver commands is improved. Running `puppetserver gem`, `puppetserver irb`, and other Puppet Server CLI commands are 15-30 percent faster to start up. Service starting and reloading should see similar improvements, along with some marginal improvements to top-end performance, especially in environments with limited sources of entropy.
+
+- Building Puppet Server outside our network is now slightly easier.
+
+- Prior to this release, an unnecessary and deprecated version of Facter was shipped in the `puppetserver` package. This has been removed.
+
+- Cert and CRL bundles no longer need to be in any specific order. By default, the leaf instances still come first, descending to the root, which are last. [SERVER-2465](https://tickets.puppetlabs.com/browse/SERVER-2465)
+
 
 ## Puppet Server 6.3.0
 


### PR DESCRIPTION
```
Conflicts:
  - acceptance/config/beaker/options.rb
  - documentation/release_notes.markdown
  - project.clj

Resolved project.clj & acceptance to prefer our changes as usual. Pulled
in the release notes for 6.3.2 and backfilled the relase notes for
6.3.1.
```