### PR TITLE
(maint) Update healthcheck timeouts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,36 +35,42 @@ steps:
     bundle config --local path $gempath
     bundle install --with test
   displayName: Fetch Dependencies
+  timeoutInMinutes: 1
   name: fetch_deps
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Write-HostDiagnostics
   displayName: Diagnostic Host Information
+  timeoutInMinutes: 2
   name: hostinfo
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Lint-Dockerfile -Name $ENV:CONTAINER_NAME2 -Ignore ($ENV:LINT_IGNORES -split ' ')
   displayName: Lint $(CONTAINER_NAME2) Dockerfile
+  timeoutInMinutes: 1
   name: lint_standalone_dockerfile
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Lint-Dockerfile -Name $ENV:CONTAINER_NAME -Ignore ($ENV:LINT_IGNORES -split ' ')
   displayName: Lint $(CONTAINER_NAME) Dockerfile
+  timeoutInMinutes: 1
   name: lint_dockerfile
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Build-Container -Name $ENV:CONTAINER_NAME2 -Namespace $ENV:NAMESPACE -PathOrUri $ENV:CONTAINER_BUILD_PATH2 -AdditionalOptions ($ENV:BUILD_OPTIONS -split ' ')
   displayName: Build $(CONTAINER_NAME2) Container
+  timeoutInMinutes: 20
   name: build_standalone_container
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -Pull $false -AdditionalOptions ($ENV:BUILD_OPTIONS -split ' ')
   displayName: Build $(CONTAINER_NAME) Container
+  timeoutInMinutes: 5
   name: build_container
 
 - powershell: |
@@ -77,6 +83,7 @@ steps:
     . "$(bundle show pupperware)/ci/build.ps1"
     Invoke-ContainerTest -Name $ENV:CONTAINER_NAME2 -Namespace $ENV:NAMESPACE -Options $ENV:CONTAINER_NAME2/.rspec
   displayName: Test $(CONTAINER_NAME2)
+  timeoutInMinutes: 10
   name: test_standalone_container
 
 - task: PublishTestResults@2
@@ -90,6 +97,7 @@ steps:
     . "$(bundle show pupperware)/ci/build.ps1"
     Invoke-ContainerTest -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -Options $ENV:CONTAINER_NAME/.rspec
   displayName: Test $(CONTAINER_NAME)
+  timeoutInMinutes: 10
   name: test_container
 
 - task: PublishTestResults@2
@@ -104,5 +112,5 @@ steps:
     Clear-BuildState -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE
     Clear-BuildState -Name $ENV:CONTAINER_NAME2 -Namespace $ENV:NAMESPACE
   displayName: Container Cleanup
-  timeoutInMinutes: 3
+  timeoutInMinutes: 4
   condition: always()

--- a/docker/puppetserver-standalone/Dockerfile
+++ b/docker/puppetserver-standalone/Dockerfile
@@ -101,6 +101,6 @@ CMD ["foreground"]
 
 COPY docker/puppetserver-standalone/healthcheck.sh /
 RUN chmod +x /healthcheck.sh
-HEALTHCHECK --interval=10s --timeout=15s --retries=12 --start-period=4m CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=10s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]
 
 COPY docker/puppetserver-standalone/Dockerfile /


### PR DESCRIPTION
- Set reasonable upper bounds for various stages in Azure to abort
  jobs quickly when Docker misbehaves

- Based on timings of trhe open source stack under LCOW, this container
  typically starts in about 200s. Give the healthcheck an additional
  100s buffer, allowing it to take up to 5m to be healthy, rather than 6m