### PR TITLE
(maint) Update clj-parent to 4.2.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.2.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.6"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -60,6 +60,7 @@
                  [puppetlabs/trapperkeeper-metrics]
                  [puppetlabs/trapperkeeper-scheduler]
                  [puppetlabs/trapperkeeper-status]
+                 [puppetlabs/trapperkeeper-filesystem-watcher]
                  [puppetlabs/kitchensink]
                  [puppetlabs/ssl-utils]
                  [puppetlabs/ring-middleware]


### PR DESCRIPTION
This update includes changes to Jetty cipher suites, an update of
jackson-xml to fix some CVEs, and an update for tk-filesystem-watcher to
improve error handling.

This commit also adds tk-filesystem-watcher as an explicit dependency,
rather than relying on its coming in transitively through tk-jetty9.