### PR TITLE
(maint) Only build a release build if it makes sense

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,12 @@ on:
 
 jobs:
   build-and-publish:
+    env:
+      PUPPERWARE_ANALYTICS_STREAM: production
+      IS_LATEST: true
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
     runs-on: ubuntu-latest
 
     steps:
@@ -16,22 +22,33 @@ jobs:
         with:
           ruby-version: 2.6.x
       - run: gem install bundler
-      - name: Lint container
-        working-directory: docker
-        run: |
-          make lint
       - name: Build container
-        env:
-          PUPPERWARE_ANALYTICS_STREAM: production
-          IS_LATEST: true
         working-directory: docker
-        run: make build test
+        run: make lint build test
       - name: Publish container
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          IS_LATEST: true
         working-directory: docker
         run: |
           docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
           make publish
+      - name: Build release container
+        env:
+          IS_RELEASE: true
+        working-directory: docker
+        run: |
+          make prep
+          if [ $? -eq 0 ]; then
+            make lint build test
+          else
+            echo "Skipping release container building and testing"
+          fi
+      - name: Publish release container
+        env:
+          IS_RELEASE: true
+        working-directory: docker
+        run: |
+          make prep
+          if [ $? -eq 0 ]; then
+            make publish
+          else
+            echo "Skipping release container publishing"
+          fi

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -12,6 +12,18 @@ PUPPERWARE_ANALYTICS_STREAM ?= dev
 
 ifeq ($(IS_RELEASE),true)
 	VERSION ?= $(shell echo $(git_describe) | sed 's/-.*//')
+	# to work around failures that occur between when the repo is tagged and when the package
+	# is actually shipped, see if this version exists in dujour
+	PUBLISHED_VERSION ?= $(shell curl --silent 'https://updates.puppetlabs.com/?product=puppetserver&version=$(VERSION)' | jq '."version"' | tr -d '"')
+	# For our containers built from packages, we want those to be built once then never changed
+	# so check to see if that container already exists on dockerhub
+	CONTAINER_EXISTS = $(shell DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $(NAMESPACE)/puppetserver:$(VERSION) > /dev/null 2>&1; echo $$?)
+ifneq ($(CONTAINER_EXISTS),0)
+	SKIP_BUILD ?= true
+else ifneq ($(VERSION),$(PUBLISHED_VERSION))
+	SKIP_BUILD ?= true
+endif
+
 	LATEST_VERSION ?= latest
 	dockerfile := release.Dockerfile
 	dockerfile_context := puppetserver
@@ -25,6 +37,10 @@ endif
 prep:
 	@git fetch --unshallow ||:
 	@git fetch origin 'refs/tags/*:refs/tags/*'
+ifeq ($(SKIP_BUILD),true)
+	@echo "SKIP_BUILD is true, exiting with 1"
+	@exit 1
+endif
 
 lint:
 ifeq ($(hadolint_available),0)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -18,7 +18,7 @@ ifeq ($(IS_RELEASE),true)
 	# For our containers built from packages, we want those to be built once then never changed
 	# so check to see if that container already exists on dockerhub
 	CONTAINER_EXISTS = $(shell DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $(NAMESPACE)/puppetserver:$(VERSION) > /dev/null 2>&1; echo $$?)
-ifneq ($(CONTAINER_EXISTS),0)
+ifeq ($(CONTAINER_EXISTS),0)
 	SKIP_BUILD ?= true
 else ifneq ($(VERSION),$(PUBLISHED_VERSION))
 	SKIP_BUILD ?= true

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,6 +5,7 @@ build_date := $(shell date -u +%FT%T)
 hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
 hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL3028 --ignore DL4000 --ignore DL4001
 hadolint_container := hadolint/hadolint:latest
+
 export BUNDLE_PATH = $(PWD)/.bundle/gems
 export BUNDLE_BIN = $(PWD)/.bundle/bin
 export GEMFILE = $(PWD)/Gemfile
@@ -12,9 +13,10 @@ PUPPERWARE_ANALYTICS_STREAM ?= dev
 
 ifeq ($(IS_RELEASE),true)
 	VERSION ?= $(shell echo $(git_describe) | sed 's/-.*//')
+	PRODUCT ?= puppetserver
 	# to work around failures that occur between when the repo is tagged and when the package
 	# is actually shipped, see if this version exists in dujour
-	PUBLISHED_VERSION ?= $(shell curl --silent 'https://updates.puppetlabs.com/?product=puppetserver&version=$(VERSION)' | jq '."version"' | tr -d '"')
+	PUBLISHED_VERSION ?= $(shell curl --silent 'https://updates.puppetlabs.com/?product=$(PRODUCT)&version=$(VERSION)' | jq '."version"' | tr -d '"')
 	# For our containers built from packages, we want those to be built once then never changed
 	# so check to see if that container already exists on dockerhub
 	CONTAINER_EXISTS = $(shell DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $(NAMESPACE)/puppetserver:$(VERSION) > /dev/null 2>&1; echo $$?)


### PR DESCRIPTION
In our pipelines configuration, we always want to try to make a release build so that we don't have to kick that off manually. But we also only want to build and publish a release build if it doesn't already exists.

This adds some safeguards so we don't try to build the release build yet if it hasn't been published and updated in dujour, and also so that we only build and publish the release build if we haven't already pushed that tag.

Blocked on #2188 

TODO
- [ ] is it worthwhile to build and test the release package on azure? Thoughts @Iristyle ?