### PR TITLE
(MAINT) Add java tmpdir to CLI commands

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -109,7 +109,8 @@
                        :build-type "foss"
                        :java-args ~(str "-Xms2g -Xmx2g "
                                      "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger")
-                       :create-dirs ["/opt/puppetlabs/server/data/puppetserver/jars"]
+                       :create-dirs ["/opt/puppetlabs/server/data/puppetserver/jars",
+                                     "/opt/puppetlabs/server/apps/puppetserver/tmp"]
                        :repo-target "puppet5"
                        :nonfinal-repo-target "puppet5-nightly"
                        :bootstrap-source :services-d

--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -14,7 +14,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
+"${JAVA_BIN}" $TMPPATH $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/irb.erb
+++ b/resources/ext/cli/irb.erb
@@ -12,7 +12,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
+"${JAVA_BIN}" $TMPPATH $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.irb \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/ruby.erb
+++ b/resources/ext/cli/ruby.erb
@@ -12,7 +12,7 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
-"${JAVA_BIN}" $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
+"${JAVA_BIN}" $TMPPATH $JAVA_ARGS_CLI -Djava.security.egd=file:/dev/urandom \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.ruby \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli_defaults/cli-defaults.sh.erb
+++ b/resources/ext/cli_defaults/cli-defaults.sh.erb
@@ -8,3 +8,4 @@ if [ ! -e "$JRUBY_JAR" ]; then
 fi
 
 CLASSPATH="${CLASSPATH}:${JRUBY_JAR}:/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/jars/*"
+TMPPATH="-Djava.io.tmpdir=/opt/puppetlabs/server/apps/<%= EZBake::Config[:real_name] %>/tmp"


### PR DESCRIPTION
Prior to this commit, running any of the CLI commands
when /tmp is mounted as noexec would result in
difficult to parse error messages.

After this commit, we configure java to use a tmpdir
within our control so that the settings on /tmp
don't matter.