### PR TITLE
(DOC-4223) Document removal of the Puppet Server developer dashboard

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -63,6 +63,10 @@ This release contains new features.
 - The `puppetserver ca` tool now respects the `server_list` setting in `puppet.conf` for those users that have created their own high availability configuration using that feature. [SERVER-2392](https://tickets.puppetlabs.com/browse/SERVER-2392) 
 - The EZBake configs now allow you to specify `JAVA_ARGS_CLI`, which is used when using `puppetserver` subcommands to configure Java differently from what is needed for the service. This was used by the CLI before, but as an environment variable only, not as an EZBake config option. [SERVER-2399](https://tickets.puppetlabs.com/browse/SERVER-2399)
 
+### Removals 
+
+- The developer dashboard has been removed.
+
 ## Puppet Server 5.3.6
 
 Released 23 October 2018.


### PR DESCRIPTION
This commit documents the removal of the developer dashboard in the release notes for Server 5.3.7. https://tickets.puppetlabs.com/browse/DOC-4223