### PR TITLE
(SERVER-2630) Turn off puppet i18n when using multithreaded jruby

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.2.6"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.7"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -202,7 +202,7 @@
       (update-in [:master-run-dir] #(or % default-master-run-dir))
       (update-in [:master-log-dir] #(or % default-master-log-dir))
       (update-in [:max-requests-per-instance] #(or % 0))
-      (update-in [:disable-i18n] #(or % multithreaded))
+      (assoc :disable-i18n multithreaded)
       (update-in [:use-legacy-auth-conf] #(if (some? %) % false))
       (dissoc :environment-class-cache-enabled)))
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -28,8 +28,8 @@
     * :track-lookups - a boolean to turn on tracking hiera lookups during compilation;
         if not specified, no tracking is enabled.
 
-    * :disable_i18n - a boolean to pass to Puppet to control whether or not to translate;
-        if not specified, uses Puppet's own default.
+    * :disable-i18n - a boolean to pass to Puppet to control whether or not to translate;
+        if not specified or false, the flag is not passed to Puppet's initialization.
 
     * :http-client-ssl-protocols - A list of legal SSL protocols that may be used
         when https client requests are made.

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -28,6 +28,9 @@
     * :track-lookups - a boolean to turn on tracking hiera lookups during compilation;
         if not specified, no tracking is enabled.
 
+    * :disable_i18n - a boolean to pass to Puppet to control whether or not to translate;
+        if not specified, uses Puppet's own default.
+
     * :http-client-ssl-protocols - A list of legal SSL protocols that may be used
         when https client requests are made.
 
@@ -57,6 +60,7 @@
    :master-run-dir (schema/maybe schema/Str)
    :master-log-dir (schema/maybe schema/Str)
    (schema/optional-key :track-lookups) schema/Bool
+   (schema/optional-key :disable-i18n) schema/Bool
    :http-client-ssl-protocols [schema/Str]
    :http-client-cipher-suites [schema/Str]
    :http-client-connect-timeout-milliseconds schema/Int

--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -15,9 +15,13 @@ class Puppet::Server::PuppetConfig
     #
     # `config` is a map whose keys are the names of the settings that we wish
     # to override, and whose values are the desired values for the settings.
+    # Key values that are not strings are omitted, allowing for keys in the
+    # HashMap from puppetserver to have true values.
     Puppet.initialize_settings(
         puppet_config.reduce([]) do |acc, entry|
-          acc << "--#{entry[0]}" << entry[1]
+          acc << "--#{entry[0]}"
+          acc << entry[1] if entry[1].kind_of?(String)
+          acc
         end
     )
     Puppet[:trace] = true

--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -15,7 +15,7 @@ class Puppet::Server::PuppetConfig
     #
     # `config` is a map whose keys are the names of the settings that we wish
     # to override, and whose values are the desired values for the settings.
-    # Key values that are not strings are omitted, allowing for keys in the
+    # Values that are not strings are omitted, allowing for keys in the
     # HashMap from puppetserver to have true values.
     Puppet.initialize_settings(
         puppet_config.reduce([]) do |acc, entry|

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -56,7 +56,7 @@
                        :connect-timeout-milliseconds 31415
                        :idle-timeout-milliseconds 42
                        :metrics-enabled false}
-          initialized-config (jruby-puppet-core/initialize-puppet-config http-config {})]
+          initialized-config (jruby-puppet-core/initialize-puppet-config http-config {} false)]
       (is (= ["some-suite"] (:http-client-cipher-suites initialized-config)))
       (is (= ["some-protocol"] (:http-client-ssl-protocols initialized-config)))
       (is (= 42 (:http-client-idle-timeout-milliseconds initialized-config)))
@@ -70,27 +70,29 @@
                                :master-log-dir "four"
                                :master-code-dir "five"
                                :use-legacy-auth-conf true}
-          initialized-config (jruby-puppet-core/initialize-puppet-config {} jruby-puppet-config)]
+          initialized-config (jruby-puppet-core/initialize-puppet-config {} jruby-puppet-config true)]
       (is (= "one" (:master-run-dir initialized-config)))
       (is (= "two" (:master-var-dir initialized-config)))
       (is (= "three" (:master-conf-dir initialized-config)))
       (is (= "four" (:master-log-dir initialized-config)))
       (is (= "five" (:master-code-dir initialized-config)))
+      (is (= true (:disable-i18n initialized-config)))
       (is (= true (:use-legacy-auth-conf initialized-config)))))
 
   (testing "jruby-puppet values are set to defaults if not provided"
-    (let [initialized-config (jruby-puppet-core/initialize-puppet-config {} {})]
+    (let [initialized-config (jruby-puppet-core/initialize-puppet-config {} {} false)]
       (is (= "/var/run/puppetlabs/puppetserver" (:master-run-dir initialized-config)))
       (is (= "/opt/puppetlabs/server/data/puppetserver" (:master-var-dir initialized-config)))
       (is (= "/etc/puppetlabs/puppet" (:master-conf-dir initialized-config)))
       (is (= "/var/log/puppetlabs/puppetserver" (:master-log-dir initialized-config)))
       (is (= "/etc/puppetlabs/code" (:master-code-dir initialized-config)))
       (is (= false (:use-legacy-auth-conf initialized-config)))
+      (is (= false (:disable-i18n initialized-config)))
       (is (= true (:http-client-metrics-enabled initialized-config))))))
 
 (deftest create-jruby-config-test
   (testing "provided values are not overriden"
-    (let [jruby-puppet-config (jruby-puppet-core/initialize-puppet-config {} {})
+    (let [jruby-puppet-config (jruby-puppet-core/initialize-puppet-config {} {} false)
           unitialized-jruby-config {:gem-home "/foo"
                                     :gem-path ["/foo" "/bar"]
                                     :compile-mode :jit
@@ -117,7 +119,7 @@
         (is (= 31415 (:max-borrows-per-instance initialized-jruby-config))))))
 
   (testing "defaults are used if no values provided"
-    (let [jruby-puppet-config (jruby-puppet-core/initialize-puppet-config {} {})
+    (let [jruby-puppet-config (jruby-puppet-core/initialize-puppet-config {} {} false)
           unitialized-jruby-config {:gem-home "/foo"}
           shutdown-fn (fn [] 42)
           initialized-jruby-config (jruby-puppet-core/create-jruby-config

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -154,7 +154,8 @@ create-mock-pool-instance :- JRubyInstance
                   :master-var-dir var-dir
                   :master-run-dir run-dir
                   :master-log-dir log-dir
-                  :use-legacy-auth-conf false})
+                  :use-legacy-auth-conf false}
+                 false)
                 (jruby-core/initialize-config {:ruby-load-path ruby-load-path
                                                :gem-home gem-home
                                                :gem-path gem-path}))


### PR DESCRIPTION
This change forces the puppet configuration to turn i18n off when in a
multithreaded jruby environment.