### PR TITLE
(SERVER-2674) Update clj-parent to 4.2.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.2.7"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.8"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This update downgrades JRuby to 9.2.8.0 to avoid a bug in 9.2.9.0.