### PR TITLE
(PE-27515) Allow sign requests to specify ttl

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -243,9 +243,14 @@
               (malformed
                 (i18n/tru "State {0} invalid; Must specify desired state of ''signed'' or ''revoked'' for host {1}."
                   (name desired-state) subject))
-              ; this is the happy path. we have a body, it's parsable json,
-              ; and the desired_state field is one of (signed revoked)
-              [false {::json-body json-body}])
+              (let [cert-ttl (:cert_ttl json-body)]
+                (if (and cert-ttl (schema/check schema/Int cert-ttl))
+                     (malformed
+                      (i18n/tru "cert_ttl specified for host {0} must be an integer, not \"{1}\"" subject cert-ttl))
+                     ; this is the happy path. we have a body, it's parsable json,
+                     ; and the desired_state field is one of (signed revoked), and
+                     ; it potentially has a valid cert_ttl field
+                     [false {::json-body json-body}])))
             (malformed (i18n/tru "Missing required parameter \"desired_state\"")))
           (malformed (i18n/tru "Request body is not JSON.")))
         (malformed (i18n/tru "Empty request body.")))))

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -102,6 +102,12 @@
   [context]
   (keyword (get-in context [::json-body :desired_state])))
 
+(defn merge-request-settings
+  [settings context]
+  (if-let [cert-ttl (get-in context [::json-body :cert_ttl])]
+    (assoc settings :ca-ttl cert-ttl)
+    settings))
+
 (defn invalid-state-requested?
   [context]
   (when (= :put (get-in context [:request :request-method]))
@@ -263,7 +269,10 @@
   (fn [context]
     (let [desired-state (get-desired-state context)]
       (locking crl-write-serializer
-        (ca/set-certificate-status! settings subject desired-state)))))
+       (ca/set-certificate-status!
+        (merge-request-settings settings context)
+        subject
+        desired-state)))))
 
 (defresource certificate-statuses
   [settings]

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -582,6 +582,15 @@
             (is (= 400 (:status response)))
             (is (= (:body response) "Request body is not JSON."))))
 
+        (testing "invalid cert_ttl value results in a 400"
+          (let [request  {:uri "/v1/certificate_status/test-agent"
+                          :request-method :put
+                          :body (body-stream "{\"desired_state\":\"signed\",\"cert_ttl\":\"astring\"}")}
+                response (test-app request)]
+            (is (= 400 (:status response)))
+            (is (= (:body response)
+                   "cert_ttl specified for host test-agent must be an integer, not \"astring\""))))
+
         (testing "invalid cert status results in a 400"
           (let [request  {:uri "/v1/certificate_status/test-agent"
                           :request-method :put


### PR DESCRIPTION
This change adds in the additional optional key `cert_ttl` for the
`certificate_status` endpoint that will override the `ca-ttl` CA
setting.