### PR TITLE
(SERVER-2684) Take up new jruby-utils

### DIFF
--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -87,6 +87,10 @@ jruby-puppet: {
     # (optional) Whether or not to track lookups during compilation; turning
     # this on will send that information to puppetdb
     # track-lookups: true
+
+    # For testing running requests through a single JRuby instance. DO NOT ENABLE unless
+    # explicitly testing this functionality.
+    # multithreaded: true
 }
 
 # Settings related to HTTP client requests made by Puppet Server.

--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -87,10 +87,6 @@ jruby-puppet: {
     # (optional) Whether or not to track lookups during compilation; turning
     # this on will send that information to puppetdb
     # track-lookups: true
-
-    # For testing running requests through a single JRuby instance. DO NOT ENABLE unless
-    # explicitly testing this functionality.
-    # multithreaded: true
 }
 
 # Settings related to HTTP client requests made by Puppet Server.

--- a/ext/thread_test/puppetserver.conf
+++ b/ext/thread_test/puppetserver.conf
@@ -71,7 +71,7 @@ jruby-puppet: {
     master-log-dir: ${HOME}"/.puppetlabs/var/log"
 
     # (optional) maximum number of JRuby instances to allow
-    max-active-instances: 1
+    max-active-instances: 2
 
     # (optional) Authorize access to Puppet master endpoints via rules
     # specified in the legacy Puppet auth.conf file (if true) or via rules

--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
                  ;; send their logs to logstash, so we include it in the jar.
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils]
+                 [puppetlabs/jruby-utils "3.0.0"]
                  [puppetlabs/clj-shell-utils]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-webserver-jetty9]

--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -47,14 +47,6 @@
      jruby-puppet jruby-service {:request (dissoc request :ssl-client-cert)}
      (handler (assoc request :jruby-instance jruby-puppet)))))
 
-(defn wrap-with-multithreaded-jruby-instance
-  "Middleware that makes the provided jruby instance available in the request as
-  `:jruby-instance`. When using this handler, the provided JRuby instance will be
-  shared with other requests."
-  [handler jruby-instance]
-  (fn [request]
-    (handler (assoc request :jruby-instance (:jruby-puppet jruby-instance)))))
-
 (schema/defn ^:always-validate
   wrap-with-request-queue-limit :- IFn
   "Middleware fn that short-circuits incoming requests with a 503 'Service

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -178,12 +178,6 @@
    [this]
    (:pool-context (tk-services/service-context this)))
 
-  (borrow-instance
-    [this reason]
-    (let [pool-context (:pool-context (tk-services/service-context this))
-          event-callbacks (jruby-core/get-event-callbacks pool-context)]
-      (jruby-core/borrow-from-pool pool-context reason event-callbacks)))
-
   (register-event-handler
     [this callback-fn]
     (let [pool-context (:pool-context (tk-services/service-context this))]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -124,10 +124,6 @@
     [this]
     "Return a thread dump for each JRuby instance registered to the pool.")
 
-  (borrow-instance
-    [this reason]
-    "Borrow a JRuby instance from the pool directly. For use with multithreaded Puppet.")
-
   (get-pool-context
     [this]
     "Get the pool context out of the service context.")

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -282,11 +282,3 @@
   (-> (jruby-request-handler config current-code-id)
       (jruby-request/wrap-with-jruby-instance jruby-service)
       jruby-request/wrap-with-error-handling))
-
-(defn build-multithreaded-request-handler
-  "Build the request handler fn for JRuby requests, when
-  using a multithreaded Puppet architecture."
-  [jruby-instance config current-code-id]
-  (-> (jruby-request-handler config current-code-id)
-      (jruby-request/wrap-with-multithreaded-jruby-instance jruby-instance)
-      jruby-request/wrap-with-error-handling))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
@@ -12,28 +12,19 @@
   [[:PuppetServerConfigService get-config]
    [:ConfigService get-in-config]
    [:VersionedCodeService current-code-id]
-   [:JRubyPuppetService borrow-instance]
+   [:JRubyPuppetService]
    [:JRubyMetricsService]]
   (init [this context]
     (let [config (get-config)
           max-queued-requests (get-in-config [:jruby-puppet :max-queued-requests] 0)
           max-retry-delay (get-in-config [:jruby-puppet :max-retry-delay] 1800)
-          multithreaded (get-in-config [:jruby-puppet :multithreaded] false)
           jruby-service (tk-services/get-service this :JRubyPuppetService)
-          ;; Is there a better thing to pass as the "reason" here?
-          jruby-instance (if multithreaded (borrow-instance "puppet") nil)
           metrics-service (tk-services/get-service this :JRubyMetricsService)
-          handler-settings (request-handler-core/config->request-handler-settings
-                             config)
-          request-handler (if multithreaded
-                            (request-handler-core/build-multithreaded-request-handler
-                              jruby-instance
-                              handler-settings
-                              current-code-id)
-                            (request-handler-core/build-request-handler
-                              jruby-service
-                              handler-settings
-                              current-code-id))]
+          request-handler (request-handler-core/build-request-handler
+                            jruby-service
+                            (request-handler-core/config->request-handler-settings
+                              config)
+                            current-code-id)]
       (when (contains? (:master config) :allow-header-cert-info)
         (if (true? (get-in config [:jruby-puppet :use-legacy-auth-conf]))
           (log/warn (format "%s %s"
@@ -48,8 +39,7 @@
                                           metrics-service
                                           max-queued-requests
                                           max-retry-delay)
-                                        request-handler)
-                     :jruby-instance jruby-instance)))
+                                        request-handler))))
 
   (handle-request
     [this request]

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -97,7 +97,7 @@
 (deftest environment-classes-test
   (testing "environment_classes query"
     (with-redefs [jruby-core/borrow-from-pool-with-timeout (fn [_ _ _] {:jruby-puppet (Object.)})
-                  jruby-core/return-to-pool (fn [_ _ _] #())]
+                  jruby-core/return-to-pool (fn [_ _ _ _] #())]
       (let [jruby-service (reify jruby/JRubyPuppetService
                             (get-pool-context [_] (jruby-pool-manager-core/create-pool-context
                                                    (jruby-core/initialize-config {:gem-home "bar"
@@ -343,7 +343,7 @@
 (deftest all-tasks-response-test
   (testing "all-tasks query"
     (with-redefs [jruby-core/borrow-from-pool-with-timeout (fn [_ _ _] {:jruby-puppet (Object.)})
-                  jruby-core/return-to-pool (fn [_ _ _] #())]
+                  jruby-core/return-to-pool (fn [_ _ _ _] #())]
       (let [jruby-service (reify jruby/JRubyPuppetService
                             (get-pool-context [_] (jruby-pool-manager-core/create-pool-context
                                                    (jruby-core/initialize-config {:gem-home "bar"
@@ -393,7 +393,7 @@
 
 (deftest compile-endpoint
   (with-redefs [jruby-core/borrow-from-pool-with-timeout (fn [_ _ _] {:jruby-puppet (Object.)})
-                jruby-core/return-to-pool (fn [_ _ _] #())]
+                jruby-core/return-to-pool (fn [_ _ _ _] #())]
     (let [jruby-service (reify jruby/JRubyPuppetService
                           (get-pool-context [_] (jruby-pool-manager-core/create-pool-context
                                                  (jruby-core/initialize-config {:gem-home "bar"
@@ -417,7 +417,7 @@
 
 (deftest v4-routes-test
   (with-redefs [jruby-core/borrow-from-pool-with-timeout (fn [_ _ _] {:jruby-puppet (Object.)})
-                jruby-core/return-to-pool (fn [_ _ _] #())]
+                jruby-core/return-to-pool (fn [_ _ _ _] #())]
     (let [jruby-service (reify jruby/JRubyPuppetService
                           (get-pool-context [_] (jruby-pool-manager-core/create-pool-context
                                                  (jruby-core/initialize-config {:gem-home "bar"

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -385,7 +385,7 @@
            (with-redefs [core/as-jruby-request (fn [_ _]
                                                  (ringutils/throw-bad-request!
                                                   bad-message))
-                         jruby-core/return-to-pool (fn [_ _ _] #())]
+                         jruby-core/return-to-pool (fn [_ _ _ _] #())]
              (with-redefs [jruby-core/borrow-from-pool-with-timeout (fn [_ _ _] {})]
                (let [request-handler (core/build-request-handler dummy-service {} (constantly nil))
                      response (request-handler {:body (StringReader. "blah")})]


### PR DESCRIPTION
This reverts the interim implementation of the `multithreaded` mode, replacing it with the new JRuby reference pool.