### PR TITLE
(maint) Migrate container builds from pipelines to GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Docker test and publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+      - name: Lint container
+        working-directory: docker
+        run: |
+          make lint
+      - name: Build container
+        env:
+          PUPPERWARE_ANALYTICS_STREAM: production
+          IS_LATEST: true
+        working-directory: docker
+        run: |
+          gem install bundler
+          make build test
+      - name: Publish container
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          IS_LATEST: true
+        working-directory: docker
+        run: |
+          docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+          make publish

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.6.x
+      - run: gem install bundler
       - name: Lint container
         working-directory: docker
         run: |
@@ -24,9 +25,7 @@ jobs:
           PUPPERWARE_ANALYTICS_STREAM: production
           IS_LATEST: true
         working-directory: docker
-        run: |
-          gem install bundler
-          make build test
+        run: make build test
       - name: Publish container
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -77,15 +77,15 @@ push-readme:
 	@docker pull sheogorath/readme-to-dockerhub
 	@docker run --rm \
 		-v $(PWD)/puppetserver-standalone/README.md:/data/README.md \
-		-e DOCKERHUB_USERNAME="$(DISTELLI_DOCKER_USERNAME)" \
-		-e DOCKERHUB_PASSWORD="$(DISTELLI_DOCKER_PW)" \
+		-e DOCKERHUB_USERNAME="$(DOCKERHUB_USERNAME)" \
+		-e DOCKERHUB_PASSWORD="$(DOCKERHUB_PASSWORD)" \
 		-e DOCKERHUB_REPO_PREFIX=puppet \
 		-e DOCKERHUB_REPO_NAME=puppetserver-standalone \
 		sheogorath/readme-to-dockerhub
 	@docker run --rm \
 		-v $(PWD)/puppetserver/README.md:/data/README.md \
-		-e DOCKERHUB_USERNAME="$(DISTELLI_DOCKER_USERNAME)" \
-		-e DOCKERHUB_PASSWORD="$(DISTELLI_DOCKER_PW)" \
+		-e DOCKERHUB_USERNAME="$(DOCKERHUB_USERNAME)" \
+		-e DOCKERHUB_PASSWORD="$(DOCKERHUB_PASSWORD)" \
 		-e DOCKERHUB_REPO_PREFIX=puppet \
 		-e DOCKERHUB_REPO_NAME=puppetserver \
 		sheogorath/readme-to-dockerhub

--- a/docker/distelli-manifest.yml
+++ b/docker/distelli-manifest.yml
@@ -1,9 +1,0 @@
-pe-and-platform/puppetserver:
-  PreBuild:
-    - make lint
-  Build:
-    - make build PUPPERWARE_ANALYTICS_STREAM=production
-    - make test
-  AfterBuildSuccess:
-    - docker login -u "$DISTELLI_DOCKER_USERNAME" -p "$DISTELLI_DOCKER_PW" "$DISTELLI_DOCKER_ENDPOINT"
-    - make publish


### PR DESCRIPTION
Pipelines is EOL Jan 31, so we need to migrate to something else. This
adds a github action to lint, build, test, and publish containers on
pushes to the master branch.

Pipelines auto-builds have been disabled and necessary secrets have been
added to the puppetserver github repo.