### PR TITLE
(maint) Improve Dockerfile organization

### DIFF
--- a/docker/puppetserver-base/Dockerfile
+++ b/docker/puppetserver-base/Dockerfile
@@ -6,29 +6,29 @@ ARG version="6.0.0"
 # Used by entrypoint to submit metrics to Google Analytics.
 # Published images should use "production" for this build_arg.
 ARG pupperware_analytics_stream="dev"
-ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream"
-ENV PUPPERWARE_ANALYTICS_TRACKING_ID="UA-132486246-4"
-ENV PUPPERWARE_ANALYTICS_APP_NAME="puppetserver"
-ENV PUPPERWARE_ANALYTICS_ENABLED=false
 
-ENV PUPPET_SERVER_VERSION="$version"
-ENV DUMB_INIT_VERSION="1.2.1"
-ENV UBUNTU_CODENAME="bionic"
-ENV PUPPETSERVER_JAVA_ARGS="-Xms512m -Xmx512m"
-ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
-ENV PUPPET_MASTERPORT=8140
-ENV PUPPETSERVER_MAX_ACTIVE_INSTANCES=1
-ENV PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE=0
-ENV CA_ENABLED=true
-ENV CA_ALLOW_SUBJECT_ALT_NAMES=false
-ENV CONSUL_ENABLED=false
-ENV CONSUL_HOSTNAME=consul
-ENV CONSUL_PORT=8500
-ENV NETWORK_INTERFACE=eth0
-ENV USE_PUPPETDB=true
-ENV PUPPET_STORECONFIGS_BACKEND="puppetdb"
-ENV PUPPET_STORECONFIGS=true
-ENV PUPPET_REPORTS="puppetdb"
+ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream" \
+    PUPPERWARE_ANALYTICS_TRACKING_ID="UA-132486246-4" \
+    PUPPERWARE_ANALYTICS_APP_NAME="puppetserver" \
+    PUPPERWARE_ANALYTICS_ENABLED=false \
+    PUPPET_SERVER_VERSION="$version" \
+    DUMB_INIT_VERSION="1.2.1" \
+    UBUNTU_CODENAME="bionic" \
+    PUPPETSERVER_JAVA_ARGS="-Xms512m -Xmx512m" \
+    PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH \
+    PUPPET_MASTERPORT=8140 \
+    PUPPETSERVER_MAX_ACTIVE_INSTANCES=1 \
+    PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE=0 \
+    CA_ENABLED=true \
+    CA_ALLOW_SUBJECT_ALT_NAMES=false \
+    CONSUL_ENABLED=false \
+    CONSUL_HOSTNAME=consul \
+    CONSUL_PORT=8500 \
+    NETWORK_INTERFACE=eth0 \
+    USE_PUPPETDB=true \
+    PUPPET_STORECONFIGS_BACKEND="puppetdb" \
+    PUPPET_STORECONFIGS=true \
+    PUPPET_REPORTS="puppetdb"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
@@ -42,7 +42,11 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
-RUN apt-get update && \
+COPY docker-entrypoint.sh healthcheck.sh /
+COPY docker-entrypoint.d /docker-entrypoint.d
+
+RUN chmod +x /docker-entrypoint.sh /healthcheck.sh && \
+    apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates git && \
     wget https://github.com/Yelp/dumb-init/releases/download/v"$DUMB_INIT_VERSION"/dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
     dpkg -i dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
@@ -50,17 +54,11 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
-COPY docker-entrypoint.d /docker-entrypoint.d
-
 EXPOSE 8140
 
 ENTRYPOINT ["dumb-init", "/docker-entrypoint.sh"]
 CMD ["foreground"]
 
-COPY healthcheck.sh /
-RUN chmod +x /healthcheck.sh
 HEALTHCHECK --interval=10s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]
 
 COPY Dockerfile /

--- a/docker/puppetserver-base/Dockerfile
+++ b/docker/puppetserver-base/Dockerfile
@@ -7,11 +7,18 @@ ARG version="6.0.0"
 # Published images should use "production" for this build_arg.
 ARG pupperware_analytics_stream="dev"
 
-ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream" \
-    PUPPERWARE_ANALYTICS_TRACKING_ID="UA-132486246-4" \
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/puppetserver" \
+      org.label-schema.name="Puppet Server Base Image" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+ENV PUPPERWARE_ANALYTICS_TRACKING_ID="UA-132486246-4" \
     PUPPERWARE_ANALYTICS_APP_NAME="puppetserver" \
     PUPPERWARE_ANALYTICS_ENABLED=false \
-    PUPPET_SERVER_VERSION="$version" \
     DUMB_INIT_VERSION="1.2.1" \
     UBUNTU_CODENAME="bionic" \
     PUPPETSERVER_JAVA_ARGS="-Xms512m -Xmx512m" \
@@ -30,20 +37,23 @@ ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream" \
     PUPPET_STORECONFIGS=true \
     PUPPET_REPORTS="puppetdb"
 
-LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
-      org.label-schema.vendor="Puppet" \
-      org.label-schema.url="https://github.com/puppetlabs/puppetserver" \
-      org.label-schema.name="Puppet Server Base Image" \
-      org.label-schema.license="Apache-2.0" \
-      org.label-schema.version="$PUPPET_SERVER_VERSION" \
-      org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver" \
-      org.label-schema.vcs-ref="$vcs_ref" \
-      org.label-schema.build-date="$build_date" \
-      org.label-schema.schema-version="1.0" \
-      org.label-schema.dockerfile="/Dockerfile"
+EXPOSE 8140
+
+ENTRYPOINT ["dumb-init", "/docker-entrypoint.sh"]
+CMD ["foreground"]
 
 COPY docker-entrypoint.sh healthcheck.sh /
 COPY docker-entrypoint.d /docker-entrypoint.d
+HEALTHCHECK --interval=10s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]
+
+# dynamic LABELs and ENV vars placed lower for the sake of Docker layer caching
+# these are specific to analytics
+ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream" \
+    PUPPET_SERVER_VERSION="$version"
+
+LABEL org.label-schema.version="$version" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date"
 
 RUN chmod +x /docker-entrypoint.sh /healthcheck.sh && \
     apt-get update && \
@@ -53,12 +63,5 @@ RUN chmod +x /docker-entrypoint.sh /healthcheck.sh && \
     rm dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-EXPOSE 8140
-
-ENTRYPOINT ["dumb-init", "/docker-entrypoint.sh"]
-CMD ["foreground"]
-
-HEALTHCHECK --interval=10s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]
 
 COPY Dockerfile /

--- a/docker/puppetserver-base/Dockerfile
+++ b/docker/puppetserver-base/Dockerfile
@@ -64,4 +64,4 @@ RUN chmod +x /docker-entrypoint.sh /healthcheck.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY Dockerfile /
+COPY Dockerfile /base.Dockerfile

--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -35,16 +35,16 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.url="https://github.com/puppetlabs/puppetserver" \
       org.label-schema.name="Puppet Server (from source)" \
       org.label-schema.license="Apache-2.0" \
-      org.label-schema.version="$PUPPET_SERVER_VERSION" \
       org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver" \
-      org.label-schema.vcs-ref="$vcs_ref" \
-      org.label-schema.build-date="$build_date" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
 COPY --from=build /puppetserver.deb /puppetserver.deb
 
-
+# dynamic LABELs placed lower for the sake of Docker layer caching
+LABEL org.label-schema.version="$version" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date"
 
 RUN wget http://nightlies.puppet.com/apt/puppet6-nightly-release-"$UBUNTU_CODENAME".deb && \
     dpkg -i puppet6-nightly-release-"$UBUNTU_CODENAME".deb && \

--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -22,9 +22,10 @@ RUN apt-get update && \
 
 COPY . /puppetserver
 WORKDIR /puppetserver
-RUN lein clean && lein install
-RUN EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true COW=base-bionic-amd64.cow MOCK='' GEM_SOURCE=https://rubygems.org lein with-profile ezbake ezbake local-build
-RUN mv /puppetserver/output/deb/bionic/*/*.deb /puppetserver.deb
+RUN lein clean && \
+    lein install && \
+    EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true COW=base-bionic-amd64.cow MOCK='' GEM_SOURCE=https://rubygems.org lein with-profile ezbake ezbake local-build && \
+    mv /puppetserver/output/deb/bionic/*/*.deb /puppetserver.deb
 
 FROM "$namespace"/puppetserver-base:"$version"
 
@@ -52,17 +53,17 @@ RUN wget http://nightlies.puppet.com/apt/puppet6-nightly-release-"$UBUNTU_CODENA
     apt-get install --no-install-recommends -y /puppetserver.deb puppetdb-termini && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    gem install --no-rdoc --no-ri r10k
-
-COPY docker/puppetserver/puppetserver /etc/default/puppetserver
-COPY docker/puppetserver/logback.xml /etc/puppetlabs/puppetserver/
-COPY docker/puppetserver/request-logging.xml /etc/puppetlabs/puppetserver/
-COPY docker/puppetserver/puppetserver.conf /etc/puppetlabs/puppetserver/conf.d/
-COPY docker/puppetserver/puppetdb.conf /etc/puppetlabs/puppet/
-
-RUN puppet config set autosign true --section master && \
+    gem install --no-rdoc --no-ri r10k && \
+    puppet config set autosign true --section master && \
     cp -pr /etc/puppetlabs/puppet /var/tmp && \
     cp -pr /opt/puppetlabs/server/data/puppetserver /var/tmp && \
     rm -rf /var/tmp/puppet/ssl
+
+COPY docker/puppetserver/puppetserver /etc/default/puppetserver
+COPY docker/puppetserver/logback.xml \
+     docker/puppetserver/request-logging.xml \
+     /etc/puppetlabs/puppetserver/
+COPY docker/puppetserver/puppetserver.conf /etc/puppetlabs/puppetserver/conf.d/
+COPY docker/puppetserver/puppetdb.conf /etc/puppetlabs/puppet/
 
 COPY docker/puppetserver/Dockerfile /

--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -1,3 +1,5 @@
+ARG vcs_ref
+ARG build_date
 ARG version="6.0.0"
 ARG namespace="puppet"
 FROM ubuntu:18.04 as build

--- a/docker/puppetserver/release.Dockerfile
+++ b/docker/puppetserver/release.Dockerfile
@@ -7,7 +7,7 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.url="https://github.com/puppetlabs/puppetserver" \
       org.label-schema.name="Puppet Server" \
       org.label-schema.license="Apache-2.0" \
-      org.label-schema.version="$PUPPET_SERVER_VERSION" \
+      org.label-schema.version="$version" \
       org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver" \
       org.label-schema.vcs-ref="$vcs_ref" \
       org.label-schema.build-date="$build_date" \
@@ -18,7 +18,7 @@ RUN wget https://apt.puppetlabs.com/puppet6-release-"$UBUNTU_CODENAME".deb && \
     dpkg -i puppet6-release-"$UBUNTU_CODENAME".deb && \
     rm puppet6-release-"$UBUNTU_CODENAME".deb && \
     apt-get update && \
-    apt-get install --no-install-recommends -y puppetserver="$PUPPET_SERVER_VERSION"-1"$UBUNTU_CODENAME" && \
+    apt-get install --no-install-recommends -y puppetserver="$version"-1"$UBUNTU_CODENAME" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     gem install --no-rdoc --no-ri r10k && \

--- a/docker/puppetserver/release.Dockerfile
+++ b/docker/puppetserver/release.Dockerfile
@@ -21,15 +21,13 @@ RUN wget https://apt.puppetlabs.com/puppet6-release-"$UBUNTU_CODENAME".deb && \
     apt-get install --no-install-recommends -y puppetserver="$PUPPET_SERVER_VERSION"-1"$UBUNTU_CODENAME" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    gem install --no-rdoc --no-ri r10k
-
-COPY puppetserver /etc/default/puppetserver
-COPY logback.xml /etc/puppetlabs/puppetserver/
-COPY request-logging.xml /etc/puppetlabs/puppetserver/
-COPY puppetserver.conf /etc/puppetlabs/puppetserver/conf.d/
-
-RUN puppet config set autosign true --section master && \
+    gem install --no-rdoc --no-ri r10k && \
+    puppet config set autosign true --section master && \
     cp -pr /etc/puppetlabs/puppet /var/tmp && \
     rm -rf /var/tmp/puppet/ssl
+
+COPY puppetserver /etc/default/puppetserver
+COPY logback.xml request-logging.xml /etc/puppetlabs/puppetserver/
+COPY puppetserver.conf /etc/puppetlabs/puppetserver/conf.d/
 
 COPY release.Dockerfile /

--- a/docker/puppetserver/release.Dockerfile
+++ b/docker/puppetserver/release.Dockerfile
@@ -1,3 +1,5 @@
+ARG vcs_ref
+ARG build_date
 ARG version="6.0.0"
 ARG namespace="puppet"
 FROM "$namespace"/puppetserver-base:"$version"


### PR DESCRIPTION
- Reduce Dockerfile build steps
- Improve ability to cache build steps
- Make sure resulting images have all metadata correctly (including `build_date` and `vcs_ref`) 
- Ensure all constituent `Dockerfile` source files are copied into image (base Dockerfile and derivatives)