### PR TITLE
(maint) Restructure Travis container scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,18 +26,14 @@ jobs:
       rvm: 2.5.5
       env:
         - DOCKER_COMPOSE_VERSION=1.25.0-rc2
-      script:
-        - |
-          set -ex
-          sudo rm /usr/local/bin/docker-compose
-          curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
-          cd docker
-          make lint
-          make build
-          make test
-          set +x
+      before_install: |
+        OS_ARCH=$(uname --machine)
+        sudo rm /usr/local/bin/docker-compose
+        curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-${OS_ARCH} > docker-compose
+        chmod +x docker-compose
+        sudo mv docker-compose /usr/local/bin
+      before_script: cd $TRAVIS_BUILD_DIR/docker && make lint build
+      script: cd $TRAVIS_BUILD_DIR/docker && make test
 
 notifications:
   email: false


### PR DESCRIPTION
 - Segregate into:

   before_install - for setting up tools like compose
   before_script - for linting / building
   script - for testing

 - This allows for better timings of these individual sequences in
   the Travis UI (for comparison with other build strategies later)