### PR TITLE
(SERVER-2685) Bump jruby-utils to 3.0.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
                  ;; send their logs to logstash, so we include it in the jar.
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "3.0.0"]
+                 [puppetlabs/jruby-utils "3.0.1"]
                  [puppetlabs/clj-shell-utils]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-webserver-jetty9]

--- a/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
+++ b/src/clj/puppetlabs/services/puppet_admin/puppet_admin_core.clj
@@ -60,7 +60,7 @@
     ; 204 No Content on success
     {:status 204}
     ; If a lock timeout occurs return a 503 Service Unavailable
-    (catch [:kind :puppetlabs.services.jruby-pool-manager.impl.jruby-agents/jruby-lock-timeout] e
+    (catch [:kind :puppetlabs.services.jruby-pool-manager.impl.jruby-internal/jruby-lock-timeout] e
       (log/error (:msg e))
       (-> (rr/response (:msg e))
           (rr/status 503)


### PR DESCRIPTION
This includes the work for the `flush-timeout` setting in the JRuby ref pool.