### PR TITLE
(SERVER-2680) Parameterize Clojure tests for multithreaded mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ jobs:
     - jdk: openjdk11
       env: ADDITIONAL_LEIN_ARGS="with-profile fips"
       name: "Java 11 w/ FIPS"
+    - jdk: openjdk8
+      env: MULTITHREADED=true
+      name: "Java 8 w/ multithreaded"
+    - jdk: openjdk11
+      env: MULTITHREADED=true
+      name: "Java 11 w/ multithreaded"
     - stage: puppetserver container tests
       language: ruby
       rvm: 2.5.5

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -6,6 +6,13 @@ echo "Total memory available: $(grep MemTotal /proc/meminfo | awk '{print $2}')"
 
 ./dev/install-test-gems.sh
 
-lein -U $ADDITIONAL_LEIN_ARGS test :all
+if [ "$MULTITHREADED" = "true" ]; then
+  filter=":multithreaded"
+else
+  filter=":singlethreaded"
+fi
+test_command="lein -U $ADDITIONAL_LEIN_ARGS test $filter"
+echo $test_command
+$test_command
 
 rake spec

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   { :url url
     :username :env/nexus_jenkins_username
     :password :env/nexus_jenkins_password
-    :sign-releases false })
+    :sign-releases false})
 
 (def heap-size-from-profile-clj
   (let [profile-clj (io/file (System/getenv "HOME") ".lein" "profiles.clj")]
@@ -146,8 +146,8 @@
                     ;; use core.async and need more than eight threads to run
                     ;; properly; this setting overrides the default value.  Without
                     ;; it the metrics tests will hang.
-                    :jvm-opts ["-Dclojure.core.async.pool-size=50"]
-                    }
+                    :jvm-opts ["-Dclojure.core.async.pool-size=50"]}
+
 
              :ezbake {:dependencies ^:replace [;; we need to explicitly pull in our parent project's
                                                ;; clojure version here, because without it, lein
@@ -216,7 +216,9 @@
                             [lein-exec "0.3.7"]]}}
 
   :test-selectors {:integration :integration
-                   :unit (complement :integration)}
+                   :unit (complement :integration)
+                   :multithreaded (complement :single-thread-only)
+                   :singlethreaded (complement :multithreaded-only)}
 
   :aliases {"gem" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.gem" "--config" "./dev/puppetserver.conf" "--"]
             "ruby" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.ruby" "--config" "./dev/puppetserver.conf" "--"]
@@ -236,5 +238,5 @@
   :uberjar-merge-with {"locales.clj"  [(comp read-string slurp)
                                        (fn [new prev]
                                          (if (map? prev) [new prev] (conj prev new)))
-                                       #(spit %1 (pr-str %2))]}
-  )
+                                       #(spit %1 (pr-str %2))]})
+

--- a/project.clj
+++ b/project.clj
@@ -217,7 +217,7 @@
 
   :test-selectors {:integration :integration
                    :unit (complement :integration)
-                   :multithreaded (complement :single-thread-only)
+                   :multithreaded (complement :single-threaded-only)
                    :singlethreaded (complement :multithreaded-only)}
 
   :aliases {"gem" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.gem" "--config" "./dev/puppetserver.conf" "--"]

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -1116,7 +1116,7 @@
                                       current-code-id-fn
                                       environment-class-cache-enabled
                                       wrap-with-jruby-queue-limit)
-                   clojure-request-wrapper )))
+                   clojure-request-wrapper)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Lifecycle Helper Functions

--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -39,6 +39,9 @@
 (def master-log-dir
   "./target/master-var/log")
 
+(def multithreaded
+  (= "true" (System/getenv "MULTITHREADED")))
+
 (defn load-dev-config-with-overrides
   [overrides]
   (let [tmp-conf (ks/temp-file "puppetserver" ".conf")]
@@ -50,6 +53,7 @@
         (assoc-in [:jruby-puppet :master-var-dir] master-var-dir)
         (assoc-in [:jruby-puppet :master-run-dir] master-run-dir)
         (assoc-in [:jruby-puppet :master-log-dir] master-log-dir)
+        (assoc-in [:jruby-puppet :multithreaded] multithreaded)
         (ks/deep-merge overrides))))
 
 (def services-from-dev-bootstrap

--- a/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
@@ -283,7 +283,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
 
-(deftest ^:metrics basic-metrics-test
+(deftest ^:metrics ^:single-threaded-only basic-metrics-test
   (with-metrics-test-env test-env default-test-config
     (let [{:keys [num-jrubies num-free-jrubies requested-count
                   requested-jrubies-histo borrow-count borrow-timeout-count
@@ -320,7 +320,7 @@
           (is (= expected-metrics (-> (current-jruby-status-metrics)
                                       (jruby-status-metric-counters)))))))))
 
-(deftest ^:metrics borrowed-instances-test
+(deftest ^:metrics ^:single-threaded-only borrowed-instances-test
   (with-metrics-test-env test-env default-test-config
     (let [{:keys [coordinator update-expected-values expected-metrics-values
                   current-metrics-values jruby-service]} test-env
@@ -403,7 +403,7 @@
                                  :current-borrowed-instances -1})
         (is (= (expected-metrics-values) (current-metrics-values)))))))
 
-(deftest ^:metrics requested-instances-test
+(deftest ^:metrics ^:single-threaded-only requested-instances-test
   (with-metrics-test-env test-env default-test-config
     (let [{:keys [coordinator update-expected-values expected-metrics-values
                   current-metrics-values jruby-service]} test-env
@@ -886,7 +886,7 @@
               (is (= 1 (.getCount timer))
                   (str "Timer has a accumulated a count for borrow reason: " timer-name)))))))))
 
-(deftest ^:metrics borrow-timeout-test
+(deftest ^:metrics ^:single-threaded-only borrow-timeout-test
   (with-metrics-test-env
     test-env
     (assoc-in default-test-config

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -149,7 +149,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
 
-(deftest ^:integration admin-api-flush-jruby-pool-test
+(deftest ^:integration ^:single-threaded-only admin-api-flush-jruby-pool-test
   (testing "Flushing the pool results in all new JRuby instances"
     (bootstrap/with-puppetserver-running
       app

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -61,7 +61,7 @@
 ;; not ideal, but we discussed it at length and agreed that the test has
 ;; value in terms of simulating an end user's experience, which could not
 ;; be achieved w/o some such assumptions, and thus is worth keeping.
-(deftest ^:integration environment-flush-integration-test
+(deftest ^:integration ^:single-threaded-only environment-flush-integration-test
   (testing "environments are flushed after marking expired"
     ;; This test is a bit complicated, so warrants some 'splainin.
     ;;

--- a/test/integration/puppetlabs/services/jruby/tasks_test.clj
+++ b/test/integration/puppetlabs/services/jruby/tasks_test.clj
@@ -140,8 +140,8 @@
         (testing "with the init task"
           (let [res (get-task-data "env1" "apache" "init")]
             (is (nil? (schema/check mc/TaskData res)))
-            (is (= "init.rb" (-> res :files first :name))
-            (is (re-matches #".*init\.rb" (-> res :files first :path))))))
+            (is (= "init.rb" (-> res :files first :name)))
+            (is (re-matches #".*init\.rb" (-> res :files first :path)))))
 
         (testing "with another named task"
           (let [res (get-task-data "env1" "apache" "install")]
@@ -265,7 +265,7 @@
                                                 :uri
                                                 {:path "/puppet/v3/file_content/tasks/apache/files.rb",
                                                  :params {:environment "production"}}}
-                                              {:filename "apache/lib/puppet/ruby_file.rb",
+                                               {:filename "apache/lib/puppet/ruby_file.rb",
                                                 :sha256
                                                 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                                                 :size_bytes 0,

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -37,6 +37,9 @@
 (def run-dir "./target/master-var/run")
 (def log-dir "./target/master-var/log")
 
+(def multithreaded
+  (= "true" (System/getenv "MULTITHREADED")))
+
 (def jruby-service-and-dependencies
   [jruby-puppet/jruby-puppet-pooled-service
    profiler/puppet-profiler-service
@@ -156,7 +159,8 @@ create-mock-pool-instance :- JRubyInstance
                  false)
                 (jruby-core/initialize-config {:ruby-load-path ruby-load-path
                                                :gem-home gem-home
-                                               :gem-path gem-path}))
+                                               :gem-path gem-path
+                                               :multithreaded multithreaded}))
          max-requests-per-instance (:max-borrows-per-instance combined-configs)
          updated-config (-> combined-configs
                             (assoc :max-requests-per-instance max-requests-per-instance)


### PR DESCRIPTION
This allows the puppetserver clojure tests to be run in multithreaded mode when the `MULTITHREADED` environment variable is set to `true`. Setting this var will update the test configs to toggle the `multithreaded` setting. The tests should then be run with `lein test :multithreaded` to ensure correct filtering, since some tests require different implementations between the two modes.