### PR TITLE
(SERVER-2681) Fix `borrow-timeout-test` for multithreaded mode

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
                  ;; send their logs to logstash, so we include it in the jar.
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-utils "3.0.1"]
+                 [puppetlabs/jruby-utils "3.0.2"]
                  [puppetlabs/clj-shell-utils]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-webserver-jetty9]

--- a/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
@@ -2,6 +2,7 @@
   (:require [schema.core :as schema]
             [puppetlabs.metrics :as metrics]
             [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
@@ -366,7 +367,7 @@
    free-instances-fn :- IFn
    registry :- MetricRegistry]
   {:num-jrubies (metrics/register registry (metrics/host-metric-name hostname "jruby.num-jrubies")
-                  (metrics/gauge max-active-instances))
+                  (if jruby-puppet-core/multithreaded? (metrics/gauge 1) (metrics/gauge max-active-instances)))
    :requested-count (.counter registry (metrics/host-metric-name hostname "jruby.request-count"))
    ;; See the comments on `jruby-metrics-service/schedule-metrics-sampler!` for
    ;; an explanation of how we're using these histograms.

--- a/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
@@ -203,19 +203,6 @@
    :current-metrics-values IFn
    :jruby-service (schema/protocol jruby-protocol/JRubyPuppetService)})
 
-(defn expected-values-atom
-  []
-  (let [num-jrubies (if jruby-puppet-core/multithreaded? 1 2)]
-    (atom {:num-jrubies num-jrubies
-           :num-free-jrubies num-jrubies
-           :requested-count 0
-           :borrow-count 0
-           :borrow-timeout-count 0
-           :borrow-retry-count 0
-           :return-count 0
-           :current-requested-instances 0
-           :current-borrowed-instances 0})))
-
 (schema/defn ^:always-validate build-test-env :- TestEnvironment
   [sampling-scheduled? :- Atom
    coordinator :- (schema/protocol coordinator/TaskCoordinator)
@@ -228,11 +215,20 @@
                                                    jruby-metrics-service)
         jruby-service (tk-app/get-service app :JRubyPuppetService)
         sample-metrics! #(jruby-metrics-core/sample-jruby-metrics! jruby-service metrics)
+        expected-num-jrubies (if jruby-puppet-core/multithreaded? 1 2)
 
         ;; an atom to track the expected values for the basic metrics, so
         ;; that we don't have to keep track of the latest counts by hand
         ;; in all of the tests
-        expected-values-atom (expected-values-atom)
+        expected-values-atom (atom {:num-jrubies expected-num-jrubies
+                                    :num-free-jrubies expected-num-jrubies
+                                    :requested-count 0
+                                    :borrow-count 0
+                                    :borrow-timeout-count 0
+                                    :borrow-retry-count 0
+                                    :return-count 0
+                                    :current-requested-instances 0
+                                    :current-borrowed-instances 0})
 
         ;; convenience functions to use for comparing current metrics
         ;; values with expected values.


### PR DESCRIPTION
This commit updates the expected values in the metrics service tests to be
conditional on whether we are running with multithreaded turned on or not.
There is only ever 1 JRuby instance in multithreaded mode, so this ensures that
tests reflect that.