### PR TITLE
Merge 6.3.x -> master

### DIFF
--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -64,6 +64,7 @@ Puppet provides official packages that install Puppet Server 6.0 and all of its 
 * Red Hat Enterprise Linux 7
 * Debian 8 (Jessie)
 * Debian 9 (Stretch)
+* Debian 10 (Buster)
 * Ubuntu 18.04 (Bionic) - enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu), which contains packages necessary for Puppet Server.
 * Ubuntu 16.04 (Xenial)
 * SLES 12 SP1


### PR DESCRIPTION
Conflicts were resolved by maintaining the state of the current branch, except
for the documentation changes for installing from packages.