### PR TITLE
(maint) Update clj-parent to 4.2.11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.2.8"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.11"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit updates some ambiguous type specifications that were causing
problems on Java 11.