### PR TITLE
(SERVER-2722) Add ppAuthCertExt to custom_extensions

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/certificate.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/certificate.rb
@@ -45,7 +45,8 @@ class Puppet::Server::Certificate < Puppet::SSL::Certificate
     else
       valid_oids = exts.select do |ext|
         subtree_of?(get_name_from_oid('ppRegCertExt'), ext['oid']) or
-            subtree_of?(get_name_from_oid('ppPrivCertExt'), ext['oid'])
+            subtree_of?(get_name_from_oid('ppPrivCertExt'), ext['oid']) or
+            subtree_of?(get_name_from_oid('ppAuthCertExt'), ext['oid'])
       end
 
       valid_oids.collect do |ext|


### PR DESCRIPTION
Related: https://github.com/puppetlabs/puppet/pull/7922

PUP-6258 introduced the new oid ppAuthCertExt, but this new OID was
never added to the custom_extensions method. This commit adds the
missing OID and ensures that it can be accessed