### PR TITLE
(maint) Exclude :multithreaded-only tests by default

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -215,7 +215,8 @@
              :ci {:plugins [[lein-pprint "1.1.1"]
                             [lein-exec "0.3.7"]]}}
 
-  :test-selectors {:integration :integration
+  :test-selectors {:default (complement :multithreaded-only)
+                   :integration :integration
                    :unit (complement :integration)
                    :multithreaded (complement :single-threaded-only)
                    :singlethreaded (complement :multithreaded-only)}


### PR DESCRIPTION
This commit updates the default test filter to exclude tests that are
tagged with `:multithreaded-only`, since those tests require the
`MULTITHREAED` env var to be set in order to work correctly.