### PR TITLE
(maint) Scoping for Docker ARGs is not intuitive

### DIFF
--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -2,6 +2,7 @@ ARG vcs_ref
 ARG build_date
 ARG version="6.0.0"
 ARG namespace="puppet"
+
 FROM ubuntu:18.04 as build
 
 ENV LANG="en_US.UTF-8"
@@ -30,7 +31,10 @@ RUN lein clean && \
     mv /puppetserver/output/deb/bionic/*/*.deb /puppetserver.deb
 
 FROM "$namespace"/puppetserver-base:"$version"
-
+ARG vcs_ref
+ARG build_date
+ARG version
+ARG namespace
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppetserver/release.Dockerfile
+++ b/docker/puppetserver/release.Dockerfile
@@ -1,8 +1,10 @@
-ARG vcs_ref
-ARG build_date
 ARG version="6.0.0"
 ARG namespace="puppet"
 FROM "$namespace"/puppetserver-base:"$version"
+ARG vcs_ref
+ARG build_date
+ARG version
+ARG namespace
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppetserver/release.Dockerfile
+++ b/docker/puppetserver/release.Dockerfile
@@ -22,7 +22,7 @@ RUN wget https://apt.puppetlabs.com/puppet6-release-"$UBUNTU_CODENAME".deb && \
     dpkg -i puppet6-release-"$UBUNTU_CODENAME".deb && \
     rm puppet6-release-"$UBUNTU_CODENAME".deb && \
     apt-get update && \
-    apt-get install --no-install-recommends -y puppetserver="$version"-1"$UBUNTU_CODENAME" && \
+    apt-get install --no-install-recommends -y puppetserver="$version"-1"$UBUNTU_CODENAME" puppetdb-termini && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     gem install --no-rdoc --no-ri r10k && \

--- a/docker/puppetserver/release.Dockerfile
+++ b/docker/puppetserver/release.Dockerfile
@@ -28,10 +28,12 @@ RUN wget https://apt.puppetlabs.com/puppet6-release-"$UBUNTU_CODENAME".deb && \
     gem install --no-rdoc --no-ri r10k && \
     puppet config set autosign true --section master && \
     cp -pr /etc/puppetlabs/puppet /var/tmp && \
+    cp -pr /opt/puppetlabs/server/data/puppetserver /var/tmp && \
     rm -rf /var/tmp/puppet/ssl
 
 COPY puppetserver /etc/default/puppetserver
 COPY logback.xml request-logging.xml /etc/puppetlabs/puppetserver/
 COPY puppetserver.conf /etc/puppetlabs/puppetserver/conf.d/
+COPY puppetdb.conf /var/tmp/puppet/
 
 COPY release.Dockerfile /


### PR DESCRIPTION
For multi-stage builds, setting `ARG`s before the `FROM` makes their
scope global, but you still need to have an `ARG foo` line in each build
step to use the global `ARG foo`.

For single-stage builds, it doesn't make sense to define `ARG`s before
the `FROM` except for `ARG`s used in the `FROM`, since global scope
doesn't really help with only one stage.