### PR TITLE
(SERVER-2722) Add ppAuthCertExt to custom_extensions

### DIFF
--- a/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/custom_trusted_oid_mapping.yaml
+++ b/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/custom_trusted_oid_mapping.yaml
@@ -6,3 +6,6 @@ oid_mapping:
   1.3.6.1.4.1.34380.1.2.3:
     shortname: 'short'
     longname: 'A Very Long Name'
+  1.3.6.1.4.1.34380.1.3.39:
+    shortname: 'pp_auth_doodad'
+    longname: 'PP Auth Doodad Long Name'

--- a/src/ruby/puppetserver-lib/puppet/server/certificate.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/certificate.rb
@@ -45,7 +45,8 @@ class Puppet::Server::Certificate < Puppet::SSL::Certificate
     else
       valid_oids = exts.select do |ext|
         subtree_of?(get_name_from_oid('ppRegCertExt'), ext['oid']) or
-            subtree_of?(get_name_from_oid('ppPrivCertExt'), ext['oid'])
+            subtree_of?(get_name_from_oid('ppPrivCertExt'), ext['oid']) or
+            subtree_of?(get_name_from_oid('ppAuthCertExt'), ext['oid'])
       end
 
       valid_oids.collect do |ext|

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -307,7 +307,7 @@
       app
       {}
       (let [catalog (testutils/get-catalog)]
-        (is (= "{sf => Burning Finger, short => 22}"
+        (is (= "{pp_auth_doodad => true, sf => Burning Finger, short => 22}"
                (get-in (first (filter #(= (get % "title") "trusted_hash")
                                       (get catalog "resources")))
                        ["parameters" "message"])))))))


### PR DESCRIPTION
PUP-6258 introduced the new oid ppAuthCertExt, but this new OID was
never added to the custom_extensions method. This commit adds the
missing OID and ensures that it can be accessed