### PR TITLE
(SERVER-2726) Implement thread aware Puppetserver settings

### DIFF
--- a/ext/thread_test/environments/funky/manifests/init.pp
+++ b/ext/thread_test/environments/funky/manifests/init.pp
@@ -2,6 +2,8 @@ notify {'hello': }
 
 notify { threader::doit(): }
 
+notify { threader::futurist(): }
+
 notify { oldschool(): }
 
 include threader::params_class

--- a/ext/thread_test/environments/funky/modules/threader/lib/puppet/functions/threader/futurist.rb
+++ b/ext/thread_test/environments/funky/modules/threader/lib/puppet/functions/threader/futurist.rb
@@ -1,0 +1,9 @@
+Puppet::Functions.create_function(:'threader::futurist') do
+  dispatch :futurist do
+  end
+
+  def futurist
+    Puppet[:future_features] = true
+    "The funky future is #{Puppet[:future_features]}"
+  end
+end

--- a/ext/thread_test/environments/production/manifests/init.pp
+++ b/ext/thread_test/environments/production/manifests/init.pp
@@ -2,6 +2,8 @@ notify { 'hello': }
 
 notify { threader::doit(): }
 
+notify { threader::futurist(): }
+
 notify { oldschool(): }
 
 include threader::params_class

--- a/ext/thread_test/environments/production/modules/threader/lib/puppet/functions/threader/futurist.rb
+++ b/ext/thread_test/environments/production/modules/threader/lib/puppet/functions/threader/futurist.rb
@@ -1,0 +1,8 @@
+Puppet::Functions.create_function(:'threader::futurist') do
+  dispatch :futurist do
+  end
+
+  def futurist
+    "The production future is #{Puppet[:future_features]}"
+  end
+end

--- a/ext/thread_test/test.rb
+++ b/ext/thread_test/test.rb
@@ -32,6 +32,8 @@ class CatalogOneTester < CatalogTester
   def verify(result)
     expect(result).to include('name' => @catalog)
     expect(result).to include('environment' => @environment)
+    # future_features turned off in futurist function
+    expect(result['resources']).to include(a_hash_including('title' => 'The production future is false'))
     # v4 function
     expect(result['resources']).to include(a_hash_including('title' => 'do it'))
     # v3 function
@@ -51,6 +53,8 @@ class CatalogTwoTester < CatalogTester
   def verify(result)
     expect(result).to include('name' => @catalog)
     expect(result).to include('environment' => @environment)
+    # future_features turned on in futurist function
+    expect(result['resources']).to include(a_hash_including('title' => 'The funky future is true'))
     # v4 function
     expect(result['resources']).to include(a_hash_including('title' => 'Always on the one'))
     # v3 function

--- a/spec/puppet-server-lib/puppet/jvm/certificate_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/certificate_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::Server::Certificate do
   end
 
   it 'should return Puppet white-listed extensions' do
-    Puppet::Server::PuppetConfig.initialize_puppet({})
+    Puppet::Server::PuppetConfig.initialize_puppet(puppet_config: {})
     exts = agent_certificate.custom_extensions
 
     expect(exts.find { |ext|

--- a/spec/puppet-server-lib/puppet/jvm/logging_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/logging_spec.rb
@@ -6,7 +6,7 @@ require 'puppet/server/logging'
 describe Puppet::Server::Logging do
   context 'when setting the log level' do
     before :each do
-      Puppet::Server::PuppetConfig.initialize_puppet({})
+      Puppet::Server::PuppetConfig.initialize_puppet(puppet_config: {})
     end
 
     it 'correctly filters messages' do

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -41,4 +41,19 @@ describe 'Puppet::Server::Master' do
       expect(Puppet::Util::Profiler.current.length).to eq(1)
     end
   end
+
+  context "multithreaded" do
+    before do
+     @old_settings = Puppet.settings
+    end
+
+    after do
+      Puppet.replace_settings_object(@old_settings)
+    end
+
+    it 'creates a new Puppet::Server::Settings class for settings' do
+      Puppet::Server::Master.new({}, {'multithreaded' => true})
+      expect(Puppet.settings).to be_a_kind_of(Puppet::Server::Settings)
+    end
+  end
 end

--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -11,7 +11,7 @@ describe 'Puppet::Server::PuppetConfig' do
 
       before :each do
         expect(Puppet::Server::Logger).to receive(:get_logger).and_return(logger)
-        Puppet::Server::PuppetConfig.initialize_puppet({})
+        Puppet::Server::PuppetConfig.initialize_puppet(puppet_config: {})
       end
 
       it "the puppet log level (Puppet[:log_level]) is set from logback" do
@@ -26,7 +26,7 @@ describe 'Puppet::Server::PuppetConfig' do
 
   context "When puppet has had settings initialized" do
     before :each do
-      Puppet::Server::PuppetConfig.initialize_puppet({})
+      Puppet::Server::PuppetConfig.initialize_puppet(puppet_config: {})
     end
 
     describe '(PUP-5482) Puppet[:always_retry_plugins]' do
@@ -54,7 +54,7 @@ describe 'Puppet::Server::PuppetConfig' do
   # PUP-6060 / SERVER-1819
   subject { Puppet::Node.indirection.cache_class }
   it 'honors the Puppet[:node_cache_terminus] setting' do
-    Puppet::Server::PuppetConfig.initialize_puppet({ :node_cache_terminus => "plain" })
+    Puppet::Server::PuppetConfig.initialize_puppet(puppet_config: { :node_cache_terminus => "plain" })
     expect(subject).to eq(:plain)
   end
 end

--- a/spec/puppet-server-lib/puppet/jvm/settings_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/settings_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+require 'puppet/server/settings'
+
+describe 'Puppet::Server::Settings' do
+
+  before :each do
+    @old_settings = Puppet.settings
+    Puppet.replace_settings_object(Puppet::Settings.new)
+    Puppet.initialize_default_settings!(Puppet.settings)
+
+
+    @new_max_errors = Puppet[:max_errors] + 10
+    puppet_config = {max_errors: @new_max_errors.to_s}
+    Puppet::Server::PuppetConfig.initialize_puppet(puppet_config: puppet_config)
+
+    Puppet.replace_settings_object(Puppet::Server::Settings.new(global_settings: Puppet.settings,
+                                                                puppet_config: puppet_config))
+  end
+
+  after :each do
+    Puppet.replace_settings_object(@old_settings)
+  end
+
+  it 'settings configured prior to replacement are kept in new threads' do
+    thread = Thread.new do
+      expect(Puppet[:max_errors]).to be(@new_max_errors)
+    end
+    thread.join
+  end
+
+  it 'does not write settings to the global config when set in threads' do
+    thread = Thread.new do
+      Puppet[:max_errors] = 0
+    end
+    thread.join
+    expect(Puppet[:max_errors]).to be(@new_max_errors)
+  end
+end

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -12,7 +12,7 @@ require 'puppet/server/network/http/handler'
 require 'puppet/server/compiler'
 require 'puppet/server/ast_compiler'
 require 'puppet/server/key_recorder'
-
+require 'puppet/server/settings'
 require 'java'
 
 ##
@@ -32,8 +32,9 @@ class Puppet::Server::Master
     # There is a setting that is routed from the puppetserver.conf to
     # configure whether or not to track hiera lookups.
     @track_lookups = puppet_server_config.delete('track_lookups')
+    multithreaded = puppet_server_config.delete('multithreaded')
     Puppet::Server::Config.initialize_puppet_server(puppet_server_config)
-    Puppet::Server::PuppetConfig.initialize_puppet(puppet_config)
+    Puppet::Server::PuppetConfig.initialize_puppet(puppet_config: puppet_config)
     # Tell Puppet's network layer which routes we are willing handle - which is
     # the master routes, not the CA routes.
     master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/")
@@ -44,6 +45,11 @@ class Puppet::Server::Master
     @env_loader = Puppet.lookup(:environments)
     @transports_loader = Puppet::Util::Autoload.new(self, "puppet/transport/schema")
     @catalog_compiler = Puppet::Server::Compiler.new
+
+    if multithreaded
+      Puppet.replace_settings_object(Puppet::Server::Settings.new(global_settings: Puppet.settings,
+                                                                  puppet_config: puppet_config))
+    end
   end
 
   def handleRequest(request)
@@ -69,6 +75,8 @@ class Puppet::Server::Master
         body_to_return,
         response[:content_type],
         response["X-Puppet-Version"])
+  ensure
+    Puppet.settings.clear_local_settings if Puppet.settings.is_a?(Puppet::Server::Settings)
   end
 
   def compileCatalog(request_data)

--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -44,7 +44,7 @@ class Puppet::Server::PuppetConfig
       Puppet[:always_retry_plugins] = false
     end
 
-    app_defaults = Puppet::Settings.app_defaults_for_run_mode(master_run_mode.call).
+    app_defaults = Puppet::Settings.app_defaults_for_run_mode(Puppet::Util::RunMode[:master]).
         merge({:name => "master",
                :facts_terminus => 'yaml'})
     Puppet.settings.initialize_app_defaults(app_defaults)
@@ -65,7 +65,7 @@ class Puppet::Server::PuppetConfig
                                require_config: true,
                                push_settings_globally: true)
 
-    Puppet::ApplicationSupport.push_application_context(master_run_mode.call)
+    Puppet::ApplicationSupport.push_application_context(Puppet::Util::RunMode[:master])
 
     # Puppet's https machinery expects to find an object at
     # `Puppet.lookup(:ssl_context)` which it will then use as an input
@@ -109,7 +109,4 @@ class Puppet::Server::PuppetConfig
     @@oid_defns
   end
 
-  def self.master_run_mode
-    proc { Puppet::Util::RunMode[:master] }
-  end
 end

--- a/src/ruby/puppetserver-lib/puppet/server/settings.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/settings.rb
@@ -2,8 +2,8 @@ require 'puppet/server/puppet_config'
 
 class Puppet::Server::Settings
 
-  # @param global_settings[Puppet::Settings] The puppet settings that all threads will spawn from
-  # @param puppet_config[Hash]
+  # @param global_settings[Puppet::Settings] read-only puppet settings shared globally
+  # @param puppet_config[Hash] the setting options to use for new thread-local settings
   def initialize(global_settings:, puppet_config:)
     @global_settings = global_settings
     @local_settings = Puppet::ThreadLocal.new

--- a/src/ruby/puppetserver-lib/puppet/server/settings.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/settings.rb
@@ -1,0 +1,52 @@
+require 'puppet/server/puppet_config'
+
+class Puppet::Server::Settings
+
+  # @param global_settings[Puppet::Settings] The puppet settings that all threads will spawn from
+  # @param puppet_config[Hash]
+  def initialize(global_settings:, puppet_config:)
+    @global_settings = global_settings
+    @local_settings = Puppet::ThreadLocal.new
+    @puppet_config = puppet_config
+  end
+
+  def method_missing(method, *args, &block)
+    current_settings.send(method, *args, &block)
+  end
+
+  def clear_local_settings
+    @local_settings.value = nil
+  end
+
+  # This method populates the local_settings value, so that any reading of
+  # settings will read from @local_settings.value instead of the @global_settings.
+  # This should never happen on the parent thread, but on threads spawned
+  # from the parent during compilation.
+  def generate_new_local_settings
+    @local_settings.value = Puppet::Settings.new
+    Puppet.initialize_default_settings!(@local_settings.value)
+    Puppet::Server::PuppetConfig.initialize_puppet_settings(puppet_config: @puppet_config,
+                                                            require_config: true,
+                                                            push_settings_globally: false)
+  end
+
+  def local_settings?
+    !@local_settings.value.nil?
+  end
+
+  def current_settings
+    local_settings? ? @local_settings.value : @global_settings
+  end
+
+  def [](key)
+    current_settings[key]
+  end
+
+  def []=(key, value)
+    if !local_settings?
+      generate_new_local_settings
+    end
+    @local_settings.value[key] = value
+  end
+
+end


### PR DESCRIPTION
This implementation of a Puppetserver puppet settings class wraps
the original Puppet::Settings and generates new Puppet::Settings
as necessary per compilation. If, over the course of a compilation,
the settings are modified, there will be a new ThreadLocal settings
object that will be used for the duration of that compilation.
Those modified settings will not persist after the request has
been handled.