### PR TITLE
(SERVER-2724) set pe_serverversion in set_server_facts

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
@@ -28,6 +28,8 @@ describe Puppet::Server::Compiler do
 
     let(:node) { compiler.create_node(request_data) }
 
+    let(:pe_version_file) { '/opt/puppetlabs/server/pe_version' }
+
     before(:each) do
       Puppet::Node.indirection.terminus_class = :plain
     end
@@ -43,6 +45,19 @@ describe Puppet::Server::Compiler do
     it 'the node has server facts set' do
       expect(node.parameters).to include('serverversion' => Puppet.version.to_s)
       expect(node.server_facts).to include('serverversion' => Puppet.version.to_s)
+    end
+
+    it 'the node has no pe_serverversion fact set when FOSS' do
+      expect(node.parameters).not_to include('pe_serverversion')
+      expect(node.server_facts).not_to include('pe_serverversion')
+    end
+
+    it 'the node has pe_serverversion fact set when PE' do
+      allow(File).to receive(:readable?).with(pe_version_file).and_return(true)
+      allow(File).to receive(:zero?).with(pe_version_file).and_return(false)
+      allow(File).to receive(:read).with(pe_version_file).and_return('2019.3.0')
+      expect(node.parameters).to include('pe_serverversion' => '2019.3.0')
+      expect(node.server_facts).to include('pe_serverversion' => '2019.3.0')
     end
 
     context 'the classified node has a different environment' do

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -245,9 +245,7 @@ module Puppet
         # Add our server Puppet Enterprise version, if available.
         pe_version_file = '/opt/puppetlabs/server/pe_version'
         if File.readable?(pe_version_file) and !File.zero?(pe_version_file)
-          pe_version_data = File.read(pe_version_file).chomp
-          pe_serverversion = pe_version_data.match(/(\d+\.\d+\.\d+)/)
-          @server_facts['pe_serverversion'] = pe_serverversion[1] if pe_serverversion
+          @server_facts['pe_serverversion'] = File.read(pe_version_file).chomp
         end
 
         # Add our server version to the fact list

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -238,9 +238,17 @@ module Puppet
       # Initialize our server fact hash; we add these to each catalog, and they
       # won't change while we're running, so it's safe to cache the values.
       #
-      # This is lifted directly from Puppet::Indirector::Catalog::Compiler.
+      # See also set_server_facts in Puppet::Indirector::Catalog::Compiler in puppet.
       def set_server_facts
         @server_facts = {}
+
+        # Add our server Puppet Enterprise version, if available.
+        pe_version_file = '/opt/puppetlabs/server/pe_version'
+        if File.readable?(pe_version_file) and !File.zero?(pe_version_file)
+          pe_version_data = File.read(pe_version_file).chomp
+          pe_serverversion = pe_version_data.match(/(\d+\.\d+\.\d+)/)
+          @server_facts['pe_serverversion'] = pe_serverversion[1] if pe_serverversion
+        end
 
         # Add our server version to the fact list
         @server_facts['serverversion'] = Puppet.version.to_s


### PR DESCRIPTION
Set pe_serverversion in set_server_facts as per the same in puppet.
Document the other set_server_facts in puppet,
to reduce the chance of them being out of sync.