### PR TITLE
(SERVER-2724) Add missing `ipaddress6` fact to v4 catalog endpoint

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -230,22 +230,28 @@ module Puppet
 
         # And then add the server name and IP
         { 'servername' => 'fqdn',
-          'serverip' => 'ipaddress'
+          'serverip' => 'ipaddress',
+          'serverip6' => 'ipaddress6'
         }.each do |var, fact|
-          if value = Facter.value(fact)
+          value = Facter.value(fact)
+          if value
             @server_facts[var] = value
-          else
-            Puppet.warning "Could not retrieve fact #{fact}"
           end
         end
 
         if @server_facts['servername'].nil?
           host = Facter.value(:hostname)
-          if domain = Facter.value(:domain)
+          if host.nil?
+            Puppet.warning _("Could not retrieve fact servername")
+          elsif domain = Facter.value(:domain)
             @server_facts['servername'] = [host, domain].join('.')
           else
             @server_facts['servername'] = host
           end
+        end
+
+        if @server_facts['serverip'].nil? && @server_facts['serverip6'].nil?
+          Puppet.warning _("Could not retrieve either serverip or serverip6 fact")
         end
       end
     end


### PR DESCRIPTION
This fact was added to the `server_facts` hash in puppet as part of PUP-5109,
so this commit ensures parity.