### PR TITLE
(SERVER-2734) Update clj-parent to 4.3.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.3.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.3.2"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This update includes a tk-jetty update fixing an ambiguous type
inference when running with Java 11.