### PR TITLE
(SERVER-2727) Use Facter NG as our facter submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "ruby/puppet"]
 	path = ruby/puppet
 	url = https://github.com/puppetlabs/puppet.git
-[submodule "ruby/facter"]
-	path = ruby/facter
-	url = https://github.com/puppetlabs/facter.git
 [submodule "ruby/hiera"]
 	path = ruby/hiera
 	url = https://github.com/puppetlabs/hiera.git
 [submodule "ruby/resource_api"]
 	path = ruby/resource_api
 	url = https://github.com/puppetlabs/puppet-resource_api.git
+[submodule "ruby/facter"]
+	path = ruby/facter
+	url = https://github.com/puppetlabs/facter-ng.git

--- a/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 require 'puppet/server/compiler'
 
+def set_facts(fact_hash)
+  fact_hash.each do |key, value|
+    allow(Facter).to receive(:value).with(key).and_return(value)
+  end
+end
+
 describe Puppet::Server::Compiler do
   let(:compiler) { Puppet::Server::Compiler.new }
 
@@ -55,6 +61,11 @@ describe Puppet::Server::Compiler do
     end
 
     it 'the node has pe_serverversion fact set when PE' do
+      set_facts({
+        'fqdn'       => "my.server.com",
+        'ipaddress'  => "my.ip.address",
+        'ipaddress6' => nil
+        })
       allow(File).to receive(:readable?).with(pe_version_file).and_return(true)
       allow(File).to receive(:zero?).with(pe_version_file).and_return(false)
       allow(File).to receive(:read).with(pe_version_file).and_return('2019.3.0')


### PR DESCRIPTION
We have been rewriting Facter from C++ back into Ruby, so puppetserver
can finally take up a new Facter version for testing and repl workflows.
This commit updates our facter submodule to point at the new version.