### PR TITLE
(SERVER-2677) Make initial puppet run more resilient to CI Load

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -117,7 +117,16 @@ module PuppetServerExtensions
 
         hosts.each do |host|
           step "Agents: Run agent --test first time to gen CSR"
-          on host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0]
+          response = on(host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,1])
+          if response.exit_code == 1
+            if response.stdout.match?(/Certificate (.+) has not been signed yet/)
+              Beaker::Log.notify "Cert not signed, possibly due to CI load; running agent again"
+              sleep 3
+              on(host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0])
+            else
+              fail_test("Exit code of 1 with unexpected stdout:\n#{response.stdout}")
+            end
+          end
         end
 
       end


### PR DESCRIPTION
When first initializing ssl for an agent, there are sporadic issues
with the autosigning; the output in the puppet logs indicate that
the autosigning didn't work, and the cert is still not signed.

This change tries one more time after 3 seconds; hopefully, allowing
for more time will give the server the time it needs to sign the
certificate.