### PR TITLE
(RE-13304) Switch to using beaker subcommands

### DIFF
--- a/acceptance/scripts/generic/testrun.sh
+++ b/acceptance/scripts/generic/testrun.sh
@@ -14,7 +14,7 @@ export BEAKER_HELPER="${BEAKER_HELPER:-acceptance/lib/helper.rb}"
 bundle install --path vendor/bundle
 
 #TODO: Someday, when our Rakefile is refactored, this section will go away
-BEAKER="bundle exec beaker --debug"
+BEAKER="bundle exec beaker init --debug"
 BEAKER="$BEAKER --type aio"
 BEAKER="$BEAKER --keyfile $BEAKER_KEYFILE"
 BEAKER="$BEAKER --helper $BEAKER_HELPER"
@@ -61,12 +61,15 @@ case $1 in
 
   # run it with the old options.
   BEAKER="$BEAKER --pre-suite $BEAKER_PRESUITE"
-  BEAKER="$BEAKER --config $BEAKER_CONFIG"
+  BEAKER="$BEAKER --hosts $BEAKER_CONFIG"
   BEAKER="$BEAKER --pre-suite $BEAKER_PRESUITE"
   BEAKER="$BEAKER --tests $BEAKER_TESTSUITE"
   BEAKER="$BEAKER --preserve-hosts onfail"
   BEAKER="$BEAKER --debug --timeout 360"
    $BEAKER
+
   ;;
 esac
 
+bundle exec beaker provision
+bundle exec beaker exec


### PR DESCRIPTION
This commit updates our test scripts to use beaker subcomands, so we can
take advantage of some setup that occurs in the beaker helpers when
using `beaker provision`.