### PR TITLE
Allow executables in Docker entrypoint; avoid chmod; fix run ordering

### DIFF
--- a/docker/puppetserver-base/docker-entrypoint.sh
+++ b/docker/puppetserver-base/docker-entrypoint.sh
@@ -2,20 +2,32 @@
 
 set -e
 
-chmod +x /docker-entrypoint.d/*.sh
-# sync prevents aufs from sometimes returning EBUSY if you exec right after a chmod
+# Execute all executables in a given directory in numeric order
+function execute_executables() {
+  source="${1}"
+  find "${source}" \
+       -type f     \
+       -executable |
+    sort -n        |
+    xargs -i /bin/sh -c 'echo "Running {}"; {}'
+}
+
+# mark non-executable entrypoint files as executable
+find /docker-entrypoint.d/ -not -perm -u+x -exec chmod +x {} \+
+# sync prevents aufs from sometimes returning EBUSY if you exec right after a
+# chmod
 sync
-for f in /docker-entrypoint.d/*.sh; do
-    echo "Running $f"
-    "$f"
-done
+execute_executables /docker-entrypoint.d
 
 if [ -d /docker-custom-entrypoint.d/ ]; then
-    find /docker-custom-entrypoint.d/ -type f -name "*.sh" \
-        -exec chmod +x {} \;
-    sync
-    find /docker-custom-entrypoint.d/ -type f -name "*.sh" \
-        -exec echo Running {} \; -exec {} \;
+  find /docker-custom-entrypoint.d/ \
+       -type f                      \
+       -name '*.sh'                 \
+       -not -perm -u+x              \
+        -exec chmod +x {} \+
+  sync
+
+  execute_executables /docker-custom-entrypoint.d
 fi
 
 exec /opt/puppetlabs/bin/puppetserver "$@"


### PR DESCRIPTION
Because the script is run with `set -e` executing `chmod` on a read-only file
will make the script exit. With these changes `chmod` is only run for files that
end with `.sh` and that are not already executable.

As `find` doesn't guarantee any particular ordering `sort` has been added to the
execute pipelines to ensure that executables are run in correct (numeric) order.