### PR TITLE
(PUP-10364) Add pp_owner ppRegCertExt OID

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -226,6 +226,7 @@
    :pp_cloudplatform    "1.3.6.1.4.1.34380.1.1.23"
    :pp_apptier          "1.3.6.1.4.1.34380.1.1.24"
    :pp_hostname         "1.3.6.1.4.1.34380.1.1.25"
+   :pp_owner            "1.3.6.1.4.1.34380.1.1.26"
    :pp_authorization    "1.3.6.1.4.1.34380.1.3.1"
    :pp_auth_role        "1.3.6.1.4.1.34380.1.3.13"
    :pp_cli_auth         cli-auth-oid})


### PR DESCRIPTION
In Puppet-as-a-Service use cases it is common for individual nodes to be
owned by various different tenant, or customer, teams. None of the
registered ppRegCertExt OIDs we currently provide cleanly allow generic
specification of an owner in this context.

Provide a new OID, pp_owner, which generically fits this use case.