### PR TITLE
(SERVER-2763) Pass no-document flag when installing gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -159,8 +159,7 @@ namespace :spec do
       ## Line 2 programmatically runs 'gem install bundler' via the gem command that comes with JRuby
       gem_install_bundler = <<-CMD
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-      #{LEIN_PATH} run -m org.jruby.Main \
-      -e 'load "META-INF/jruby.home/bin/gem"' install -i '#{TEST_GEMS_DIR}' bundler -v '< 2' --no-document --source '#{GEM_SOURCE}'
+      #{LEIN_PATH} gem install -i '#{TEST_GEMS_DIR}' bundler -v '< 2' --no-document --source '#{GEM_SOURCE}'
       CMD
       sh gem_install_bundler
 

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -11,7 +11,7 @@ gems = {'nokogiri' => '1.6.7', 'excon' => '0.45.4'}
 
 additional_gem_source = ENV['GEM_SOURCE']
 # define command lines
-gem_install = "#{cli} gem install --minimal-deps --force"
+gem_install = "#{cli} gem install --minimal-deps --force --no-document"
 if additional_gem_source
   gem_install += " --clear-sources --source #{additional_gem_source}"
 end


### PR DESCRIPTION
This is a workaround to get our pipelines unblocked. Ultimately we would
like to revert this and have the test still pass.