### PR TITLE
(SERVER-2660) Update jruby to 9.2.11.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "6.9.3-SNAPSHOT")
+(def ps-version "6.10.0-SNAPSHOT")
 (def jruby-utils-version "3.1.1")
 
 (defn deploy-info

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def ps-version "6.9.3-SNAPSHOT")
-(def jruby-utils-version "3.1.0")
+(def jruby-utils-version "3.1.1")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This update fixes a `sprintf` buffer bug.