### PR TITLE
(SERVER-2718) Return authoriziation extensions with cert status response

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -526,8 +526,8 @@
       (or (false? (:authorization-required certificate-status-access-control))
           (not-empty certificate-status-whitelist))
       (log/warn (format "%s %s"
-               (i18n/trs "The ''client-whitelist'' and ''authorization-required'' settings in the ''certificate-authority.certificate-status'' section are deprecated and will be removed in a future release.")
-               (i18n/trs "Remove these settings and create an appropriate authorization rule in the /etc/puppetlabs/puppetserver/conf.d/auth.conf file.")))
+                  (i18n/trs "The ''client-whitelist'' and ''authorization-required'' settings in the ''certificate-authority.certificate-status'' section are deprecated and will be removed in a future release.")
+                  (i18n/trs "Remove these settings and create an appropriate authorization rule in the /etc/puppetlabs/puppetserver/conf.d/auth.conf file.")))
       (not (nil? certificate-status-whitelist))
       (log/warn (format "%s %s %s"
                         (i18n/trs "The ''client-whitelist'' and ''authorization-required'' settings in the ''certificate-authority.certificate-status'' section are deprecated and will be removed in a future release.")
@@ -1065,20 +1065,20 @@
     csr-stream :- InputStream]
    (autosign-csr? autosign subject csr-stream [] ""))
   ([autosign :- (schema/either schema/Str schema/Bool)
-   subject :- schema/Str
-   csr-stream :- InputStream
-   ruby-load-path :- [schema/Str]
-   gem-path :- schema/Str]
-  (if (ks/boolean? autosign)
-    autosign
-    (if (fs/exists? autosign)
-      (if (fs/executable? autosign)
-        (let [command-result (execute-autosign-command! autosign subject csr-stream ruby-load-path gem-path)]
-          (-> command-result
-              :exit-code
-              zero?))
-        (whitelist-matches? autosign subject))
-      false))))
+    subject :- schema/Str
+    csr-stream :- InputStream
+    ruby-load-path :- [schema/Str]
+    gem-path :- schema/Str]
+   (if (ks/boolean? autosign)
+     autosign
+     (if (fs/exists? autosign)
+       (if (fs/executable? autosign)
+         (let [command-result (execute-autosign-command! autosign subject csr-stream ruby-load-path gem-path)]
+           (-> command-result
+               :exit-code
+               zero?))
+         (whitelist-matches? autosign subject))
+       false))))
 
 (schema/defn create-agent-extensions :- (schema/pred utils/extension-list?)
   "Given a certificate signing request, generate a list of extensions that
@@ -1246,7 +1246,7 @@
                   subject csr-path)]
         (log/warn msg)
         {:outcome :not-found
-         :message msg }))))
+         :message msg}))))
 
 (schema/defn ^:always-validate
   get-certificate-revocation-list :- schema/Str
@@ -1292,22 +1292,22 @@
    new ones will not be generated. If only some are found
    (but others are missing), an exception is thrown."
   [settings :- CaSettings]
-    (ensure-directories-exist! settings)
-    (let [required-files (-> (settings->cadir-paths settings)
-                            (select-keys (required-ca-files (:enable-infra-crl settings)))
-                            (vals))]
-     (if (every? fs/exists? required-files)
-       (do
-         (log/info (i18n/trs "CA already initialized for SSL"))
-         (when (:enable-infra-crl settings)
-           (generate-infra-serials settings))
-         (when (:manage-internal-file-permissions settings)
-           (ensure-ca-file-perms! settings)))
-       (let [{found   true
-              missing false} (group-by fs/exists? required-files)]
-         (if (= required-files missing)
-           (generate-ssl-files! settings)
-           (throw (partial-state-error "CA" found missing)))))))
+  (ensure-directories-exist! settings)
+  (let [required-files (-> (settings->cadir-paths settings)
+                          (select-keys (required-ca-files (:enable-infra-crl settings)))
+                          (vals))]
+   (if (every? fs/exists? required-files)
+     (do
+       (log/info (i18n/trs "CA already initialized for SSL"))
+       (when (:enable-infra-crl settings)
+         (generate-infra-serials settings))
+       (when (:manage-internal-file-permissions settings)
+         (ensure-ca-file-perms! settings)))
+     (let [{found   true
+            missing false} (group-by fs/exists? required-files)]
+       (if (= required-files missing)
+         (generate-ssl-files! settings)
+         (throw (partial-state-error "CA" found missing)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; certificate_status endpoint

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -79,6 +79,7 @@
                        "DNS:localhost"
                        "DNS:puppet"
                        "DNS:puppet.vpn.puppetlabs.net"]
+   :authorization_extensions {}
    :fingerprint       "24:DC:A8:C5:1E:FE:DE:EE:D9:2C:D8:91:00:9E:4C:2E:1C:3E:A2:3D:E7:D1:4C:9F:0B:04:C7:7C:49:B0:12:F8"
    :fingerprints      {:SHA1    "A7:9B:45:46:8A:27:2A:85:60:E2:BF:AD:AA:4B:AB:DE:54:02:F7:76"
                        :SHA256  "24:DC:A8:C5:1E:FE:DE:EE:D9:2C:D8:91:00:9E:4C:2E:1C:3E:A2:3D:E7:D1:4C:9F:0B:04:C7:7C:49:B0:12:F8"
@@ -93,6 +94,7 @@
 (def test-agent-status
   {:dns_alt_names []
    :subject_alt_names []
+   :authorization_extensions {}
    :fingerprint   "36:94:27:47:EA:51:EE:7C:43:D2:EC:24:24:BB:85:CD:4A:D1:FB:BB:09:27:D9:61:59:D0:07:94:2B:2F:56:E3"
    :fingerprints  {:SHA1 "EB:3D:7B:9C:85:3E:56:7A:3E:9D:1B:C4:7A:21:5A:91:F5:00:4D:9D"
                    :SHA256 "36:94:27:47:EA:51:EE:7C:43:D2:EC:24:24:BB:85:CD:4A:D1:FB:BB:09:27:D9:61:59:D0:07:94:2B:2F:56:E3"
@@ -110,6 +112,7 @@
                        "DNS:Baz4"
                        "DNS:foo"
                        "DNS:revoked-agent"]
+   :authorization_extensions {}
    :fingerprint       "1C:D0:29:04:9B:49:F5:ED:AB:E9:85:CC:D9:6F:20:E1:7F:84:06:8A:1D:37:19:ED:EA:24:66:C6:6E:D4:6D:95"
    :fingerprints      {:SHA1    "38:56:67:FF:20:91:0E:85:C4:DF:CA:16:77:60:D2:BB:FB:DF:68:BB"
                        :SHA256  "1C:D0:29:04:9B:49:F5:ED:AB:E9:85:CC:D9:6F:20:E1:7F:84:06:8A:1D:37:19:ED:EA:24:66:C6:6E:D4:6D:95"


### PR DESCRIPTION
This adds a new field to the GET response for the
`certificate_status` endpoint, listing the authorization extensions
present on the cert or CSR being queried. This will be used to help
inform users of potentially risky extensions, so they can make an
informed decision about whether or not to sign a certificate.