### PR TITLE
(maint) Update clj-parent to 1.7.34

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.33"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.34"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This version of clj-parent was published to clojars, while the previous
version was an interal-only release.