### PR TITLE
(maint) Remove default `set -e ` for gh actions shell

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           IS_RELEASE: true
         working-directory: docker
+        shell: bash {0}
         run: |
           make prep
           if [ $? -eq 0 ]; then
@@ -45,6 +46,7 @@ jobs:
         env:
           IS_RELEASE: true
         working-directory: docker
+        shell: bash {0}
         run: |
           make prep
           if [ $? -eq 0 ]; then


### PR DESCRIPTION
Skipped release build without failing the job at https://github.com/puppetlabs/puppetserver/runs/550391873?check_suite_focus=true