### PR TITLE
shut down jruby executors

### DIFF
--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  *
  * This interface is a bridge between the clojure/Java code and the ruby class
- * `JRubyPuppet`.  (defined in `src/ruby/puppetserver-lib/jruby_puppet.rb`.)
+ * `JRubyPuppet`.  (defined in `src/ruby/puppetserver-lib/puppet/server/master.rb`.)
  * The ruby class uses some JRuby magic that causes it to "implement" the Java
  * interface.
  *

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -14,6 +14,7 @@ require 'puppet/server/ast_compiler'
 require 'puppet/server/key_recorder'
 require 'puppet/server/settings'
 require 'java'
+require 'timeout'
 
 ##
 ## This class is a bridge between the puppet ruby code and the java interface
@@ -149,6 +150,10 @@ class Puppet::Server::Master
 
   def terminate
     Puppet::Server::Config.terminate_puppet_server
+    # executor shutdown can be removed after puppetserver upgrades to a version of jruby
+    # following merge of https://github.com/jruby/jruby/pull/6127
+    executor = Timeout.to_java.getInternalVariable('__executor__')
+    executor.shutdown
   end
 
    # @return [Array, nil] an array of hashes describing tasks


### PR DESCRIPTION
JRuby executors are not shutting down, causing a build-up of JRuby worker threads.  A [patch for JRuby](https://github.com/jruby/jruby/pull/6127) has been submitted but until merged and puppetserver updated to use the new version this change will explicitly shut down the worker threads.