### PR TITLE
(DOCS) Release notes for Puppet Server 6.10.0

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -18,7 +18,7 @@ Released 14 April 2020
 
 - The `GET /certificate_status` endpoint now returns certificate or CSR's authorization extensions. [SERVER-2718](https://tickets.puppetlabs.com/browse/SERVER-2718)
 
-- Puppet's "ppRegCertExt" arc has been extended with OID "1.3.6.1.4.1.34380.1.1.26" and the short name "pp_owner". This OID is meant to help users in cloud environments, and the short name will be displayed when using the `puppetserver ca` cli tool.
+- Puppet's `ppRegCertExt` arc has been extended with OID `1.3.6.1.4.1.34380.1.1.26` and the short name `pp_owner`. This OID is meant to help users in cloud environments. The short name will be displayed when using the `puppetserver ca` cli tool.
 
 ### Resolved issues
 
@@ -26,9 +26,7 @@ Released 14 April 2020
 
 ### Known issues 
 
-- An update to JRuby 9.2.11.1 has caused a change in defaults when installing gems with the `puppetserver gem` command. It attempts to install documentation by default, but this will not work. To avoid this bug, pass `--no-document` when installing gems. [SERVER-2758](https://tickets.puppetlabs.com/browse/SERVER-2758).
-
-- Part of the `$LOAD_PATH` for Puppet Server is no longer valid when being passed to `File.expand_path`. This will cause Rubygems' `Gem.list_files()` and calls to `Dir.glob()` where the invalid portion of the $LOAD_PATH is passed as the `base:` parameter to fail. This causes features that depend on this functionality (like RDoc, the tool Rubygems uses to install documentation) to fail.
+- An update to JRuby 9.2.11.1 has caused a change in defaults when installing gems with the `puppetserver gem` command. It attempts to install documentation by default, but this will not work. To avoid this bug, pass `--no-document` when installing gems. This is caused by an inability to use the `classpath:/puppetserver-lib` portion of the `$LOAD_PATH` as a parameter to `Gem.list_files` or `Dir.glob`, which Rdoc relies on to install documentation. [SERVER-2758](https://tickets.puppetlabs.com/browse/SERVER-2758).
 
 ## Puppet Server 6.9.2
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -18,7 +18,7 @@ Released 14 April 2020
 
 - The `GET /certificate_status` endpoint now returns certificate or CSR's authorization extensions. [SERVER-2718](https://tickets.puppetlabs.com/browse/SERVER-2718)
 
-- Puppet's `ppRegCertExt` arc has been extended with OID `1.3.6.1.4.1.34380.1.1.26` and the short name `pp_owner`. This OID is meant to help users in cloud environments. The short name will be displayed when using the `puppetserver ca` cli tool.
+- Puppet's `ppRegCertExt` arc has been extended with OID `1.3.6.1.4.1.34380.1.1.26` and the short name `pp_owner`. This OID is meant to help users in cloud environments. The short name will be displayed when using the `puppetserver ca` CLI tool.
 
 ### Resolved issues
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -10,6 +10,14 @@ canonical: "/puppetserver/latest/release_notes.html"
 [puppetserver.conf]: ./config_file_puppetserver.markdown
 [product.conf]: ./config_file_product.markdown
 
+## Puppet Server 6.10.0
+
+Released 3 April 2020
+
+### Known issue 
+
+An update to JRuby 9.2.11.1 has caused a change in defaults when installing gems with the `puppetserver gem` command. It attempts to install documentation by default, but this will not work. To avoid this bug, pass `--no-document` when installing gems.
+
 ## Puppet Server 6.9.2
 
 Released 19 March 2020

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -18,6 +18,8 @@ Released 14 April 2020
 
 - The `GET /certificate_status` endpoint now returns certificate or CSR's authorization extensions. [SERVER-2718](https://tickets.puppetlabs.com/browse/SERVER-2718)
 
+- Puppet's "ppRegCertExt" arc has been extended with OID "1.3.6.1.4.1.34380.1.1.26" and the short name "pp_owner". This OID is meant to help users in cloud environments, and the short name will be displayed when using the `puppetserver ca` cli tool.
+
 ### Resolved issues
 
 - Using a precision number to truncate a string in Puppet's `sprintf` function no longer interpolates extra characters.[SERVER-2660](https://tickets.puppetlabs.com/browse/SERVER-2660).
@@ -25,6 +27,8 @@ Released 14 April 2020
 ### Known issues 
 
 - An update to JRuby 9.2.11.1 has caused a change in defaults when installing gems with the `puppetserver gem` command. It attempts to install documentation by default, but this will not work. To avoid this bug, pass `--no-document` when installing gems. [SERVER-2758](https://tickets.puppetlabs.com/browse/SERVER-2758).
+
+- Part of the `$LOAD_PATH` for Puppet Server is no longer valid when being passed to `File.expand_path`. This will cause Rubygems' `Gem.list_files()` and calls to `Dir.glob()` where the invalid portion of the $LOAD_PATH is passed as the `base:` parameter to fail. This causes features that depend on this functionality (like RDoc, the tool Rubygems uses to install documentation) to fail.
 
 ## Puppet Server 6.9.2
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -12,11 +12,21 @@ canonical: "/puppetserver/latest/release_notes.html"
 
 ## Puppet Server 6.10.0
 
-Released 3 April 2020
+Released 7 April 2020
 
-### Known issue 
+### New features
 
-An update to JRuby 9.2.11.1 has caused a change in defaults when installing gems with the `puppetserver gem` command. It attempts to install documentation by default, but this will not work. To avoid this bug, pass `--no-document` when installing gems.
+- The `GET /certificate_status` endpoint now returns certificate or CSR's authorization extensions. [SERVER-2718](https://tickets.puppetlabs.com/browse/SERVER-2718)
+
+### Resolved issues
+
+- Using a precision number to truncate a string in Puppet's `sprintf` function no longer interpolates extra characters.[SERVER-2660](https://tickets.puppetlabs.com/browse/SERVER-2660).
+
+### Known issues 
+
+- An update to JRuby 9.2.11.1 has caused a change in defaults when installing gems with the `puppetserver gem` command. It attempts to install documentation by default, but this will not work. To avoid this bug, pass `--no-document` when installing gems. [SERVER-2758](https://tickets.puppetlabs.com/browse/SERVER-2758).
+
+
 
 ## Puppet Server 6.9.2
 
@@ -24,7 +34,7 @@ Released 19 March 2020
 
 ### Resolved issue 
 
-To prevent information exposure as a result of [CVE-2020-7943](https://puppet.com/security/cve/CVE-2020-7943), the `/metrics/v1` endpoints are disabled by default, and access to the `/metrics/v2` endpoints are restricted to localhost.
+- To prevent information exposure as a result of [CVE-2020-7943](https://puppet.com/security/cve/CVE-2020-7943), the `/metrics/v1` endpoints are disabled by default, and access to the `/metrics/v2` endpoints are restricted to localhost.
 
 ## Puppet Server 6.9.1
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -12,7 +12,7 @@ canonical: "/puppetserver/latest/release_notes.html"
 
 ## Puppet Server 6.10.0
 
-Released 7 April 2020
+Released 9 April 2020
 
 ### New features
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -26,8 +26,6 @@ Released 9 April 2020
 
 - An update to JRuby 9.2.11.1 has caused a change in defaults when installing gems with the `puppetserver gem` command. It attempts to install documentation by default, but this will not work. To avoid this bug, pass `--no-document` when installing gems. [SERVER-2758](https://tickets.puppetlabs.com/browse/SERVER-2758).
 
-
-
 ## Puppet Server 6.9.2
 
 Released 19 March 2020

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -12,7 +12,7 @@ canonical: "/puppetserver/latest/release_notes.html"
 
 ## Puppet Server 6.10.0
 
-Released 9 April 2020
+Released 14 April 2020
 
 ### New features
 


### PR DESCRIPTION
This commit contains a known issue for Puppet Server 6.10.0, as part of an emergency PE release. 