### PR TITLE
(SERVER-2591) Update CA CLI gem to 1.7.0

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.6.0
+puppetserver-ca 1.7.0


### PR DESCRIPTION
This update will display a certificate or CSR's authorization extensions
when they are available from the API (Puppet Server 6.10.0+).