### PR TITLE
(maint) Remove unnecessary travis cells

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,13 @@ script:
 jobs:
   include:
     - stage: puppetserver tests
-      name: "Java 8 w/o FIPS"
+      name: "Java 8"
       jdk: openjdk8
     - jdk: openjdk11
-      name: "Java 11 w/o FIPS"
-    - jdk: openjdk8
-      env: ADDITIONAL_LEIN_ARGS="with-profile fips"
-      name: "Java 8 w/ FIPS"
+      name: "Java 11"
     - jdk: openjdk11
       env: ADDITIONAL_LEIN_ARGS="with-profile fips"
       name: "Java 11 w/ FIPS"
-    - jdk: openjdk8
-      env: MULTITHREADED=true
-      name: "Java 8 w/ multithreaded"
     - jdk: openjdk11
       env: MULTITHREADED=true
       name: "Java 11 w/ multithreaded"


### PR DESCRIPTION
We no longer maintain a PE stream that ships FIPS with Java 8 and we
don't believe the multithreaded work should vary based on Java 8 vs 11.
Consequently, we believe we can improve our velocity by removing those
two cells.