### PR TITLE
(maint) Remove LCOW support / convert to WSL2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,9 +8,8 @@ pr:
     - '*'
 
 pool:
-  # self-hosted agent on Windows 10 1903 environment
-  # includes newer Docker engine with LCOW enabled, new build of LCOW image
-  # includes Ruby 2.5, Go 1.10, Node.js 10.10
+  # self-hosted agent on Windows 10 2004 / WSL2 environment
+  # includes Ruby 2.5
   name: Default
 
 variables:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,39 +3,26 @@ version: '3.5'
 services:
   puppet:
     hostname: puppet
-    domainname: test
     image: ${PUPPET_TEST_DOCKER_IMAGE:-puppet/puppetserver}
     expose:
       - 8141
     environment:
-      - PUPPETSERVER_HOSTNAME=puppet.test
+      - PUPPETSERVER_HOSTNAME=puppet
       - PUPPET_MASTERPORT=8141
       - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-false}
-      - DNS_ALT_NAMES=puppet,puppet.test,${DNS_ALT_NAMES:-}
       - USE_PUPPETDB=false
-    dns_search: 'test'
-    networks:
-      puppetserver_test:
-        aliases:
-          - puppet.test
 
   compiler:
     hostname: compiler
-    domainname: test
     image: ${PUPPET_TEST_DOCKER_IMAGE:-puppet/puppetserver}
     environment:
       - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-false}
-      - PUPPETSERVER_HOSTNAME=compiler.test
+      - PUPPETSERVER_HOSTNAME=compiler
       - CA_ENABLED=false
-      - CA_HOSTNAME=puppet.test
+      - CA_HOSTNAME=puppet
       - CA_MASTERPORT=8141
       - USE_PUPPETDB=false
-    dns_search: 'test'
-    networks:
-      puppetserver_test:
-        aliases:
-          - compiler.test
 
 networks:
-  puppetserver_test:
+  default:
     name: puppetserver_test

--- a/docker/puppetserver-base/docker-entrypoint.d/20-use-templates-initially.sh
+++ b/docker/puppetserver-base/docker-entrypoint.d/20-use-templates-initially.sh
@@ -12,14 +12,7 @@ do
 done
 cd /
 
-# if the data dir is empty, copy over everything from build time
-if [ ! "$(ls -A /opt/puppetlabs/server/data/puppetserver)" ]; then
-  # https://github.com/moby/moby/issues/39892
-  echo "Loading new empty VOLUME with default /opt/puppetlabs/server/data/puppetserver content (LCOW moby 39892 workaround)"
-  cp -R /var/tmp/puppetserver/* /opt/puppetlabs/server/data/puppetserver/
-  # remove the tmp dir so we only run this on first runs of new containers
-  rm -rf /var/tmp/puppetserver/vendored-jruby-gems
-elif [ -d /var/tmp/puppetserver/vendored-jruby-gems ]; then
+if [ -d /var/tmp/puppetserver/vendored-jruby-gems ]; then
   echo "Upgrading /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"
   # clean up existing vendored gems
   rm -rf /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems

--- a/docker/spec/puppetserver_spec.rb
+++ b/docker/spec/puppetserver_spec.rb
@@ -18,11 +18,11 @@ end
 
 describe 'puppetserver container' do
   it 'should be able to run a puppet agent against the puppetserver' do
-    expect(run_agent('puppet-agent.test', 'puppetserver_test', masterport: '8141')).to eq(0)
+    expect(run_agent('puppet-agent', 'puppetserver_test', masterport: '8141')).to eq(0)
   end
 
   it 'should be able to run an agent against the compile master' do
-    expect(run_agent('compiler-agent.test', 'puppetserver_test', server: get_container_hostname(get_service_container('compiler')), ca: get_container_hostname(get_service_container('puppet')), ca_port: '8141')).to eq(0)
+    expect(run_agent('compiler-agent', 'puppetserver_test', server: get_container_hostname(get_service_container('compiler')), ca: get_container_hostname(get_service_container('puppet')), ca_port: '8141')).to eq(0)
   end
 
   it 'should have r10k available' do


### PR DESCRIPTION
 - Remove having to add .test to the end of container names in compose
   due to DNS resolution bugs in LCOW
 - Remove any LCOW file system copy workarounds given WSL2 does
   not have these problems