### PR TITLE
(maint) Update Puppet Agent version for 5.x compat job

### DIFF
--- a/acceptance/suites/pre_suite/puppet5_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet5_compat/70_install_puppet.rb
@@ -15,7 +15,7 @@ nonmaster_agents.each { |agent|
 
 step "Install Legacy Puppet Agents."
 
-default_puppet_version = '5.5.0'
+default_puppet_version = '5.5.19'
 puppet_version = ENV['PUPPET_LEGACY_VERSION']
 if not puppet_version
   logger.info "PUPPET_LEGACY_VERSION is not set!"


### PR DESCRIPTION
We recently removed some of the older versions of the puppet5 stream
from our internal repos, so this commit updates us to the latest of that
stream to test against.