### PR TITLE
(PE-28877, PE-28941) Add option to compile-ast endpoint to load bolt types

### DIFF
--- a/documentation/puppet-api/v3/compile.markdown
+++ b/documentation/puppet-api/v3/compile.markdown
@@ -36,7 +36,8 @@ The request body must look like:
   "transaction_uuid": "<uuid string>",
   "job_id": "<id string>",
   "options": { "capture_logs": <true/false>,
-               "log_level": <one of debug/info/warning/err>}
+               "log_level": <one of debug/info/warning/err>
+               "compile_for_plan": <true/false> }
 }
 ```
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -53,7 +53,11 @@
 
     * :use-legacy-auth-conf - Whether to use the legacy core Puppet auth.conf
         (true) or trapperkeeper-authorization (false) to authorize requests
-        being made to core Puppet endpoints."
+        being made to core Puppet endpoints.
+
+    * :boltlib-path - Optional array containing path(s) to bolt modules. This path
+         will be prepended to AST compilation modulepath. This is required for
+         compiling AST that contains bolt types."
   {:master-conf-dir (schema/maybe schema/Str)
    :master-code-dir (schema/maybe schema/Str)
    :master-var-dir (schema/maybe schema/Str)
@@ -67,5 +71,6 @@
    :http-client-idle-timeout-milliseconds schema/Int
    :http-client-metrics-enabled schema/Bool
    :max-requests-per-instance schema/Int
-   :use-legacy-auth-conf schema/Bool})
+   :use-legacy-auth-conf schema/Bool
+   (schema/optional-key :boltlib-path) [schema/Str]})
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -85,8 +85,8 @@
    (.compileCatalog jruby-instance request-options))
 
   (compile-ast
-    [this jruby-instance compile-options]
-    (.compileAST jruby-instance compile-options))
+    [this jruby-instance compile-options boltlib-path]
+    (.compileAST jruby-instance compile-options boltlib-path))
 
   (get-environment-module-info
     [this jruby-instance env-name]

--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -45,7 +45,8 @@
                                                                    (throw (IllegalStateException.
                                                                             (i18n/trs "Versioned code not supported."))))
                                                                  (constantly nil)
-                                                                 false))
+                                                                 false
+                                                                 nil))
           master-route-handler (comidi/routes->handler master-routes)
           master-mount (master-core/get-master-mount
                         master-ns

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -122,6 +122,7 @@
                                            max-retry-delay))
                                        identity)
 
+         boltlib-path (get-in config [:jruby-puppet :boltlib-path])
          ring-app (comidi/routes
                    (core/construct-root-routes puppet-version
                                                use-legacy-auth-conf
@@ -131,7 +132,8 @@
                                                handle-request
                                                (get-auth-handler)
                                                wrap-with-jruby-queue-limit
-                                               environment-class-cache-enabled))
+                                               environment-class-cache-enabled
+                                               boltlib-path))
          routes (comidi/context path ring-app)
          route-metadata (comidi/route-metadata routes)
          comidi-handler (comidi/routes->handler routes)

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -89,7 +89,7 @@
     "Compile the catalog for a given certname")
 
   (compile-ast
-    [this jruby-instance compile-options]
+    [this jruby-instance compile-options boltlib-path]
     "Compiles arbitrary Puppet ASTs into mini catalogs")
 
   (get-environment-module-info

--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -24,7 +24,7 @@ public interface JRubyPuppet {
     List getTransportInfoForEnvironment(String environment);
     List getModuleInfoForEnvironment(String environment);
     Map compileCatalog(Map requestBody);
-    Map compileAST(Map compileOptions);
+    Map compileAST(Map compileOptions, List boltlibPath);
     Map getModuleInfoForAllEnvironments();
     JRubyPuppetResponse handleRequest(Map request);
     Object getSetting(String setting);

--- a/src/ruby/puppetserver-lib/puppet/server/ast_compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/ast_compiler.rb
@@ -5,7 +5,7 @@ require 'puppet/server/logging'
 module Puppet
   module Server
     class ASTCompiler
-      def self.compile(compile_options)
+      def self.compile(compile_options, boltlib_path)
         options = compile_options['options'] || {}
 
         log_level = options['log_level']
@@ -13,41 +13,122 @@ module Puppet
 
         if options['capture_logs']
           catalog, logs = Logging.capture_logs(log_level) do
-            compile_ast(code, compile_options)
+            compile_ast(code, compile_options, boltlib_path)
           end
 
           { catalog: catalog, logs: logs }
         else
-          catalog = compile_ast(code, compile_options)
+          catalog = compile_ast(code, compile_options, boltlib_path)
           { catalog: catalog }
         end
       end
 
-      def self.compile_ast(code, compile_options)
-        Puppet[:node_name_value] = compile_options['certname']
+      def self.compile_ast(code, compile_options, boltlib_path)
+        # If the request requires that bolt be loaded we assume we are in a properly 
+        # configured PE environment
+        if compile_options.dig('options', 'compile_for_plan')
+          unless boltlib_path
+            msg = "When compile_for_plan is set, the path to boltlib modules " \
+            "must be provided by setting boltlib-path as a jruby-puppet setting in pe-puppet-server.conf"
+            raise(Puppet::Error, msg)
+          end
 
-        # Use the existing environment with the requested name
-        Puppet::Pal.in_environment(compile_options['environment'],
-                                   envpath: Puppet[:environmentpath],
-                                   facts: compile_options['facts']['values'],
-                                   variables: compile_options['variables']['values']) do |pal|
-          Puppet.lookup(:pal_current_node).trusted_data = compile_options['trusted_facts']['values']
+          # TODO: PE-28677 Develop entrypoint for loading bits of bolt we need here.
+          require 'bolt/apply_inventory'
+          require 'bolt/apply_target'
+          require 'bolt/pal/issues'
 
-          # This compiler has been configured with a node containing
-          # the requested environment, facts, and variables, and is used
-          # to compile a catalog in that context from the supplied AST.
-          pal.with_catalog_compiler do |compiler|
-            # We have to parse the AST inside the compiler block, because it
-            # initializes the necessary type loaders for us.
-            ast = Puppet::Pops::Serialization::FromDataConverter.convert(code)
+          Puppet[:node_name_value] = compile_options['certname']
 
-            compiler.evaluate(ast)
-            compiler.compile_additions
-            compiler.catalog_data_hash
+          env_conf = {
+            pre_modulepath: boltlib_path,
+            envpath: Puppet[:environmentpath],
+            facts: compile_options['facts']['values'],
+            variables: compile_options['variables']['values']
+          }
+
+          # Use the existing environment with the requested name
+          Puppet::Pal.in_environment(compile_options['environment'], env_conf) do |pal|
+            # TODO: Given we hide this from plan authors this current iteration has only
+            # the "required" data for now. Once we can get https://github.com/puppetlabs/bolt/pull/1770
+            # merged and promoted we can just use an empty hash.
+            fake_config = {
+              'transport' => 'redacted',
+              'transports' => {
+                'redacted' => 'redacted'
+              }
+            }
+            bolt_inv = Bolt::ApplyInventory.new(fake_config)
+            Puppet.override(bolt_inventory: bolt_inv) do
+              Puppet.lookup(:pal_current_node).trusted_data = compile_options['trusted_facts']['values']
+              # This compiler has been configured with a node containing
+              # the requested environment, facts, and variables, and is used
+              # to compile a catalog in that context from the supplied AST.
+              pal.with_catalog_compiler() do |compiler|
+                # TODO: PUP-10476 Explore setting these as default in PAL. They are the defaults in Puppet
+                Puppet[:strict] = :warning
+                Puppet[:strict_variables] = false
+
+                ast = build_program(code)
+                compiler.evaluate(ast)
+                compiler.evaluate_ast_node
+                compiler.compile_additions
+                compiler.catalog_data_hash
+              end
+            end
+          end
+        else
+          # When we do not need to load bolt we assume there are no Bolt types to resolve in
+          # AST compilation.
+          Puppet[:node_name_value] = compile_options['certname']
+
+          # Use the existing environment with the requested name
+          Puppet::Pal.in_environment(compile_options['environment'],
+                                     envpath: Puppet[:environmentpath],
+                                     facts: compile_options['facts']['values'],
+                                     variables: compile_options['variables']['values']) do |pal|
+            Puppet.lookup(:pal_current_node).trusted_data = compile_options['trusted_facts']['values']
+
+            # This compiler has been configured with a node containing
+            # the requested environment, facts, and variables, and is used
+            # to compile a catalog in that context from the supplied AST.
+            pal.with_catalog_compiler do |compiler|
+              # We have to parse the AST inside the compiler block, because it
+              # initializes the necessary type loaders for us.
+              ast = Puppet::Pops::Serialization::FromDataConverter.convert(code)
+
+              compiler.evaluate(ast)
+              compiler.compile_additions
+              compiler.catalog_data_hash
+            end
           end
         end
       end
       private_class_method :compile_ast
+
+      def self.build_program(code)
+        ast = Puppet::Pops::Serialization::FromDataConverter.convert(code)
+        # Node definitions must be at the top level of the apply block.
+        # That means the apply body either a) consists of just a
+        # NodeDefinition, b) consists of a BlockExpression which may
+        # contain NodeDefinitions, or c) doesn't contain NodeDefinitions.
+        # See https://github.com/puppetlabs/bolt/pull/1512 for more details
+        definitions = if ast.is_a?(Puppet::Pops::Model::BlockExpression)
+                        ast.statements.select { |st| st.is_a?(Puppet::Pops::Model::NodeDefinition) }
+                      elsif ast.is_a?(Puppet::Pops::Model::NodeDefinition)
+                        [ast]
+                      else
+                        []
+                      end
+        # During ordinary compilation, definitions are stored on the parser at
+        # parse time and then added to the Program node at the root of the AST
+        # before evaluation. Because the AST for an apply block has already been
+        # parsed and is not a complete tree with a Program at the root level, we
+        # need to rediscover the definitions and construct our own Program object.
+        # https://github.com/puppetlabs/bolt/commit/3a7597dda25cdb25854c7d08d37c5c58ab6a016b
+        Puppet::Pops::Model::Factory.PROGRAM(ast, definitions, ast.locator).model
+      end
+      private_class_method :build_program
     end
   end
 end

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -192,13 +192,30 @@ class Puppet::Server::Master
 
   private
 
+  # This helper is used to resolve all java objects in an array.
+  # Each array element is examined, if it is expected to be a map
+  # we call back to the convert_java_args_to_ruby method, if it
+  # is expected to be an array, we recurse otherwise we do not modify
+  # the value. 
+  def resolve_java_objects_from_list(list)
+    list.map do |value|
+      if value.java_kind_of?(Java::ClojureLang::IPersistentMap)
+        convert_java_args_to_ruby(value)
+      elsif value.java_kind_of?(Java::JavaUtil::List)
+        resolve_java_objects_from_list(value)
+      else
+        value
+      end
+    end
+  end
+
   def convert_java_args_to_ruby(hash)
     Hash[hash.collect do |key, value|
-      # Stolen and modified from params_to_ruby in handler.rb
+      # Stolen and heavily modified from params_to_ruby in handler.rb
       if value.java_kind_of?(Java::ClojureLang::IPersistentMap)
         [key, convert_java_args_to_ruby(value)]
       elsif value.java_kind_of?(Java::JavaUtil::List)
-        [key, value.to_a]
+        [key, resolve_java_objects_from_list(value)]
       else
         [key, value]
       end

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -91,8 +91,10 @@ class Puppet::Server::Master
     end
   end
 
-  def compileAST(compile_options)
-    Puppet::Server::ASTCompiler.compile(convert_java_args_to_ruby(compile_options))
+  def compileAST(compile_options, boltlib_path)
+    ruby_compile_options = convert_java_args_to_ruby(compile_options)
+    ruby_boltlib_path = boltlib_path.java_kind_of?(Java::JavaUtil::List) ? boltlib_path.to_a : nil
+    Puppet::Server::ASTCompiler.compile(ruby_compile_options, ruby_boltlib_path)
   end
 
   def create_recorder

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -36,7 +36,8 @@
                    identity
                    (fn [___] (throw (IllegalStateException. "Versioned code not supported.")))
                    (constantly nil)
-                   true)
+                   true
+                   nil)
       (comidi/routes->handler)
       (wrap-middleware puppet-version)))
 
@@ -400,7 +401,7 @@
                                                                                 :gem-path "bar:foobar"
                                                                                 :ruby-load-path ["foo"]})))
                           (compile-catalog [_ _ _] {:cool "catalog"})
-                          (compile-ast [_ _ _] {:cool "catalog"}))
+                          (compile-ast [_ _ _ _] {:cool "catalog"}))
           handler (fn ([req] {:request req}))
           app (build-ring-handler handler "1.2.3" jruby-service)]
       (testing "compile endpoint"
@@ -424,7 +425,7 @@
                                                                                 :gem-path "bar:foobar"
                                                                                 :ruby-load-path ["foo"]})))
                           (compile-catalog [_ _ _] {:cool "catalog"})
-                          (compile-ast [_ _ _] {:cool "catalog"}))
+                          (compile-ast [_ _ _ _] {:cool "catalog"}))
           handler (fn ([req] {:request req}))
           app (build-ring-handler handler "1.2.3" jruby-service)]
       (testing "catalog endpoint"


### PR DESCRIPTION
Previously when the compile endpoint was asked to compile AST with references to Bolt objects the compile would fail. This commit updates the compiler to accept serialized pcore and to deserialize it for compilation. This adds the requirement of some Bolt library code (and some supporting gems [addressable, public_suffix]) as well as the boltlib module. Part of making the serialized types perform as expected the compiler now creates specialized bolt inventory to back operations on bolt Target options. This work depends on two new additions to the `jruby-puppet` configuration section for pe-puppetserver. The first is appending the path to the bolt library code in the `ruby-load-path` array. The second is a new setting called `boltlib-path` which is an array pointing to the path of any bolt modules to prepend to the modulepath for compilation. The compile request now accepts an option to load bolt types. The default behavior is to *not* attempt to load bolt types.