### PR TITLE
(SERVER-2565) Write files atomically in CA

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.4.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.4.2"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
When writing files always use the atomic-write function from kitchensink which
ensures the file is either fully written or not at all by writing out a temp
file and moving it into place.