### PR TITLE
(SERVER-2793) Update clj-parent to 4.4.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.4.2"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.4.4"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This update downgrades JRuby to 9.2.8.0 to avoid a potential bug that
causes StackOverflow errors in 9.2.11.1.