### PR TITLE
(maint) Fix issue setting container DNS_ALT_NAMES

### DIFF
--- a/docker/puppetserver/docker-entrypoint.d/80-ca.sh
+++ b/docker/puppetserver/docker-entrypoint.d/80-ca.sh
@@ -53,7 +53,10 @@ else
       # Append user-supplied DNS Alt Names
       if [ -n "$DNS_ALT_NAMES" ]; then
           current="$(puppet config print --section main dns_alt_names)"
-          puppet config set --section main dns_alt_names "$current","$DNS_ALT_NAMES"
+          # shell parameter expansion to remove trailing comma if there is one
+          updated="${DNS_ALT_NAMES%,}"
+          if [ -n "$current" ]; then updated="$current","$updated"; fi
+          puppet config set --section main dns_alt_names "$updated"
       fi
 
       timestamp="$(date '+%Y-%m-%d %H:%M:%S %z')"


### PR DESCRIPTION
- As part of a refactoring made in #2327 / 8c305fe470, in scenarios
  where dns_alt_names were not already set in the main section of
  puppet.conf, the dns_alt_names value would be set to

       ,$DNS_ALT_NAMES

  when it instead should have been set to

       $DNS_ALT_NAMES

- Similarly, when a value was used in a docker-compose file like:

       DNS_ALT_NAMES=puppet,${DNS_ALT_NAMES:-}

  When the environment variable is not set, the value `puppet,` is
  set in the conf file

- These bugs resulted in values like `DNS:, DNS:puppet, DNS:puppet`
  being generated via `puppetserver ca setup` which would immediately
  crash container startup:

    /opt/puppetlabs/puppet/lib/ruby/2.5.0/openssl/x509.rb:20:in `create_ext': subjectAltName = DNS:, DNS:puppet, DNS:puppet: invalid extension string (OpenSSL::X509::ExtensionError)

- This makes sure that no leading "," gets inserted when there's
  nothing to append to and that similarly there are no trailing ","