### PR TITLE
(SERVER-2793) Update clj-parent to 4.4.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.4.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.4.5"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This version rolls JRuby forward again to 9.2.11.1. We are going to
experiment with increasing the JVM stack size to 2MB, which is the
size recommended by JRuby.