### PR TITLE
(SERVER-2799) Bump clj-parent to 4.5.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.4.5"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.5.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit bumps clj-parent to 4.5.0, which includes bumps to jetty and
trapperkeeper-metrics in preparation for the LTS.