### PR TITLE
(TK-486) Update clj-parent to 1.7.35

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.34"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.35"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This version deprecates the v1 version of the metrics endpoint.