### PR TITLE
(maint) Bump clj-parent to 4.5.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.5.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.5.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit bumps clj-parent to 4.5.1, which includes i18n 0.9.0.