### PR TITLE
(maint) Bump i18n to 0.9.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -84,7 +84,9 @@
                  ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/"]]
 
   :plugins [[lein-parent "0.3.7"]
-            [puppetlabs/i18n "0.8.0" :hooks false]]
+            ;; We have to have this, and it needs to agree with clj-parent
+            ;; until/unless you can have managed plugin dependencies.
+            [puppetlabs/i18n "0.9.0" :hooks false]]
 
   :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"


### PR DESCRIPTION
This commit bumps i18n to 0.9.0, to match the version specified in clj-parent.
According to a comment in the pe-puppetdb-extensions repo (which I've copied
here), we need to specify this separately and it must match the version in
clj-parent.