### PR TITLE
(maint) Update parameter check in settings

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -31,7 +31,7 @@ class Puppet::Server::PuppetConfig
     end
 
     # We check parameter length because Method#arity returns -1 for varargs
-    if Puppet.method(:initialize_settings).parameters.length == 3
+    if Puppet.method(:initialize_settings).parameters.length >= 3
       Puppet.initialize_settings(cli_flags, require_config, push_settings_globally)
     else
       Puppet.initialize_settings(cli_flags)


### PR DESCRIPTION
The underlying method here had a parameter added so our check was too
specific. Update it so it's slightly better and we aren't accidentally
pushing settings globally all the time.