### PR TITLE
(SERVER-2793) Update clj-parent to 4.5.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.5.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.5.2"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -86,7 +86,7 @@
   :plugins [[lein-parent "0.3.7"]
             ;; We have to have this, and it needs to agree with clj-parent
             ;; until/unless you can have managed plugin dependencies.
-            [puppetlabs/i18n "0.9.0" :hooks false]]
+            [puppetlabs/i18n "0.8.0" :hooks false]]
 
   :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"


### PR DESCRIPTION
This commit adds a flag to not use invoke-dynamic for yields in JRuby,
since that mode may be causing StackOverflows.