### PR TITLE
(Docs) Incorrect webserver.conf client-auth example

### DIFF
--- a/documentation/config_file_webserver.markdown
+++ b/documentation/config_file_webserver.markdown
@@ -16,11 +16,11 @@ webserver: {
     # Log webserver access to a specific file.
     access-log-config = /etc/puppetlabs/puppetserver/request-logging.xml
     # Require a valid certificate from the client.
-    client-auth = want
+    client-auth: need
     # Listen for HTTPS traffic on all available hostnames.
-    ssl-host = 0.0.0.0
+    ssl-host: 0.0.0.0
     # Listen for HTTPS traffic on port 8140.
-    ssl-port = 8140
+    ssl-port: 8140
 }
 ~~~
 

--- a/documentation/config_file_webserver.markdown
+++ b/documentation/config_file_webserver.markdown
@@ -14,7 +14,7 @@ The `webserver.conf` file looks something like this:
 # Configure the webserver.
 webserver: {
     # Log webserver access to a specific file.
-    access-log-config = /etc/puppetlabs/puppetserver/request-logging.xml
+    access-log-config: /etc/puppetlabs/puppetserver/request-logging.xml
     # Require a valid certificate from the client.
     client-auth: need
     # Listen for HTTPS traffic on all available hostnames.


### PR DESCRIPTION
Based on the following customer ticket: https://tickets.puppetlabs.com/browse/DOCUMENT-1114.

I wasn't sure whether the equals sign in `access-log-config = /etc/puppetlabs/puppetserver/request-logging.xml` should also be replaced with a colon?