### PR TITLE
(maint) Remove max-queued-requests warning note

### DIFF
--- a/documentation/config_file_puppetserver.markdown
+++ b/documentation/config_file_puppetserver.markdown
@@ -55,7 +55,6 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
         JRuby flushing can be useful for working around buggy module code that would otherwise cause memory leaks, but it slightly reduces performance whenever a new JRuby instance reloads all of the Puppet Ruby code. If memory leaks from module code are not an issue in your deployment, the default value of 0 performs best.
 
     * `max-queued-requests`: Optional. The maximum number of requests that may be queued waiting to borrow a JRuby from the pool. Once this limit is exceeded, a 503 "Service Unavailable" response will be returned for all new requests until the queue drops below the limit. If `max-retry-delay` is set to a positive value, then the 503 responses will include a `Retry-After` header indicating a random sleep time after which the client may retry the request. The default is 0, which disables the queue limit.
-      > **Note:** Don't use this solution if your managed infrastructure includes a significant number of agents older than Puppet 5.3. Older agents treat a 503 response as a failure, which ends their runs, causing groups of older agents to schedule their next runs at the same time, creating a thundering herd problem.
 
     * `max-retry-delay`: Optional. Sets the upper limit for the random sleep set as a `Retry-After` header on 503 responses returned when `max-queued-requests` is enabled. A value of 0 will cause the `Retry-After` header to be omitted. Default is 1800 seconds which corresponds to the default run interval of the Puppet daemon.
 


### PR DESCRIPTION
This commit removes a warning against using the `max-queued-requests`
setting with a node population that includes significant numbers of
agents running a version older than 5.3.1. The fixes for SERVER-2405,
and SERVER-2696 shipped in Puppet Server 5.3.11 and 6.9.0 make this
warning obsolete as Puppet Server now checks the agent version headers
and skips enforcement of the limit if the agent is too old or the
header is missing.