### PR TITLE
(Docs) Reorganise server installing instructions

### DIFF
--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -12,10 +12,8 @@ Puppet provides official packages that install Puppet Server 6 and all of its pr
 
 * Red Hat Enterprise Linux 6, 7
 * Debian 8 (Jessie), 9 (Stretch), 10 (Buster)
-* Ubuntu 18.04 (Bionic), 16.04 (Xenial) — Enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu), which contains packages necessary for Puppet Server.
+* Ubuntu 18.04 (Bionic), 16.04 (Xenial)
 * SLES 12 SP1
-
-> Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). 
 
 #### Java support
 
@@ -30,6 +28,8 @@ Puppet Server versions are tested against the following versions of Java:
 
 
 Some Java versions may work with other Puppet Server versions, but we do not test or support those cases. Community submitted patches for support greater than Java 11 are welcome. Both Java 8 and 11 are considered long-term support versions and are planned to be supported by upstream maintainers until 2022 or later.
+
+> Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie) or Ubuntu 18.04 (Bionic).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). To install Puppet Sevrer on Bionic, enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu).
 
 ## Installing Puppet Server
 
@@ -63,13 +63,7 @@ There is no `-` in the package name.
 systemctl start puppetserver
 ``` 
 
-or 
-
-```
-service puppetserver start
-```
-
-### Running Puppet Server on a VM
+#### Running Puppet Server on a VM
 
 By default, Puppet Server is configured to use 2GB of RAM. However, if you want to experiment with Puppet Server on a VM, you can safely allocate as little as 512MB of memory. To change the Puppet Server memory allocation, you can edit the init config file.
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -1,16 +1,25 @@
 ---
 layout: default
-title: "Puppet Server: Installing From Packages"
+title: "Install Puppet Server"
 canonical: "/puppetserver/latest/install_from_packages.html"
 ---
 
 [repodocs]: https://puppet.com/docs/puppet/latest/puppet_platform.html
 
+Puppet provides official packages that install Puppet Server 6.0 and all of its prerequisites on x86_64 architectures for the following platforms, as part of [Puppet Platform][repodocs].
+
+* Red Hat Enterprise Linux 6, 7
+* Debian 8 (Jessie), 9 (Stretch), 10 (Buster)
+* Ubuntu 18.04 (Bionic) - enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu), which contains packages necessary for Puppet Server, 16.04 (Xenial)
+* SLES 12 SP1
+
+> Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). 
+
+### Before you begin
+
 Puppet Server is configured to use 2 GB of RAM by default. If you're just testing an installation on a Virtual Machine, this much memory is not necessary. To change the memory allocation, see [Memory Allocation](#memory-allocation).
 
-> If you're also using PuppetDB, check its [requirements](https://puppet.com/docs/puppetdb/latest/index.html#system-requirements).
-
-## Java support
+#### Java support
 
 Puppet Server versions are tested against the following versions of Java:
 
@@ -24,17 +33,19 @@ Puppet Server versions are tested against the following versions of Java:
 
 Some Java versions may work with other Puppet Server versions, but we do not test or support those cases. Community submitted patches for support greater than Java 11 are welcome. Both Java 8 and 11 are considered long-term support versions and are planned to be supported by upstream maintainers until 2022 or later.
 
-## Install Puppet Server from packages
+## Install the Puppet Server package
 
 1.  [Enable the Puppet package repositories][repodocs], if you haven't already done so.
 
-2.  Install the Puppet Server package by running:
+2.  Install the Puppet Server package by running one of the following commands.
+
+Red Hat operating systems: 
 
 ````
 yum install puppetserver
 ````
 
-or
+Debian and Ubuntu: 
 
 ```
 apt-get install puppetserver
@@ -71,13 +82,8 @@ Puppet provides official packages that install Puppet Server 6.0 and all of its 
 
 > Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). 
 
-## Platforms without packages
 
-For platforms and architectures where no official packages are available, you can build Puppet Server from source. Such platforms are not tested, and running Puppet Server from source is not recommended for production use.
-
-For details, see [Running from Source](./dev_running_from_source.markdown).
-
-## Memory allocation
+## Running Puppet Server on a VM
 
 By default, Puppet Server is configured to use 2GB of RAM. However, if you want to experiment with Puppet Server on a VM, you can safely allocate as little as 512MB of memory. To change the Puppet Server memory allocation, you can edit the init config file.
 
@@ -94,7 +100,3 @@ By default, Puppet Server is configured to use 2GB of RAM. However, if you want 
     For more information about the recommended settings for the JVM, see [Oracle's docs on JVM tuning.](http://docs.oracle.com/cd/E15523_01/web.1111/e13814/jvm_tuning.htm)
 
 2. Restart the `puppetserver` service after making any changes to this file.
-
-## Reporting Issues
-
-Submit issues to our [bug tracker](https://tickets.puppet.com/browse/SERVER).

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -4,13 +4,13 @@ title: "Install Puppet Server"
 canonical: "/puppetserver/latest/install_from_packages.html"
 ---
 
-Puppet Server is a required application that runs on the Java Virtual Machine (JVM). It performs the role of the master node that controls configuration information for one or more managed agent nodes
+Puppet Server is a required application that runs on the Java Virtual Machine (JVM). It performs the role of a central node that controls configuration information for one or more managed agent nodes.
 
 > Note: If you have any issues with the steps below, submit these to our [bug tracker](https://tickets.puppet.com/browse/SERVER).
 
 ## Before you begin
 
-Review the system requirements and make sure you have a supported version of Java. 
+Review the supported operating systems and make sure you have a supported version of Java. 
 
 ### Supported operating systems
 
@@ -18,7 +18,7 @@ Puppet provides official packages that install Puppet Server 6 and all of its pr
 
 * Red Hat Enterprise Linux 6, 7
 * Debian 8 (Jessie), 9 (Stretch), 10 (Buster)
-* Ubuntu 18.04 (Bionic), 16.04 (Xenial)
+* Ubuntu 16.04 (Xenial), 18.04 (Bionic)
 * SLES 12 SP1
 
 ### Java support
@@ -34,7 +34,7 @@ Puppet Server versions are tested against the following versions of Java:
 
 Some Java versions may work with other Puppet Server versions, but we do not test or support those cases. Community submitted patches for support greater than Java 11 are welcome. Both Java 8 and 11 are considered long-term support versions and are planned to be supported by upstream maintainers until 2022 or later.
 
-> Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie) or Ubuntu 18.04 (Bionic).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). To install Puppet Sevrer on Bionic, enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu).
+> Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie) or Ubuntu 18.04 (Bionic).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). To install Puppet Server on Bionic, enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu).
 
 ## Install Puppet Server
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -6,7 +6,7 @@ canonical: "/puppetserver/latest/install_from_packages.html"
 
 Puppet Server is a required application that runs on the Java Virtual Machine (JVM) on the master.
 
-## Supported operating systems
+### Supported operating systems
 
 Puppet provides official packages that install Puppet Server 6 and all of its prerequisites on x86_64 architectures for the following platforms:
 
@@ -17,7 +17,7 @@ Puppet provides official packages that install Puppet Server 6 and all of its pr
 
 > Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). 
 
-### Java support
+#### Java support
 
 Puppet Server versions are tested against the following versions of Java:
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -4,22 +4,20 @@ title: "Install Puppet Server"
 canonical: "/puppetserver/latest/install_from_packages.html"
 ---
 
-[repodocs]: https://puppet.com/docs/puppet/latest/puppet_platform.html
+Puppet Server is a required application that runs on the Java Virtual Machine (JVM) on the master.
 
-Puppet provides official packages that install Puppet Server 6.0 and all of its prerequisites on x86_64 architectures for the following platforms, as part of [Puppet Platform][repodocs].
+## Supported operating systems
+
+Puppet provides official packages that install Puppet Server 6 and all of its prerequisites on x86_64 architectures for the following platforms:
 
 * Red Hat Enterprise Linux 6, 7
 * Debian 8 (Jessie), 9 (Stretch), 10 (Buster)
-* Ubuntu 18.04 (Bionic) - enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu), which contains packages necessary for Puppet Server, 16.04 (Xenial)
+* Ubuntu 18.04 (Bionic), 16.04 (Xenial) — Enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu), which contains packages necessary for Puppet Server.
 * SLES 12 SP1
 
 > Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). 
 
-### Before you begin
-
-Puppet Server is configured to use 2 GB of RAM by default. If you're just testing an installation on a Virtual Machine, this much memory is not necessary. To change the memory allocation, see [Memory Allocation](#memory-allocation).
-
-#### Java support
+### Java support
 
 Puppet Server versions are tested against the following versions of Java:
 
@@ -33,7 +31,11 @@ Puppet Server versions are tested against the following versions of Java:
 
 Some Java versions may work with other Puppet Server versions, but we do not test or support those cases. Community submitted patches for support greater than Java 11 are welcome. Both Java 8 and 11 are considered long-term support versions and are planned to be supported by upstream maintainers until 2022 or later.
 
-## Install the Puppet Server package
+## Install Puppet Server
+
+Puppet Server is configured to use 2 GB of RAM by default. If you're just testing an installation on a Virtual Machine, this much memory is not necessary. To change the memory allocation, see [Running Puppet Server on a VM](#Running-Puppet-Server-on-a-VM).
+
+### Install the Puppet Server package
 
 1.  [Enable the Puppet package repositories][repodocs], if you haven't already done so.
 
@@ -67,23 +69,7 @@ or
 service puppetserver start
 ```
 
-## Platforms with packages
-
-Puppet provides official packages that install Puppet Server 6.0 and all of its prerequisites on x86_64 architectures for the following platforms, as part of [Puppet Platform][repodocs].
-
-* Red Hat Enterprise Linux 6
-* Red Hat Enterprise Linux 7
-* Debian 8 (Jessie)
-* Debian 9 (Stretch)
-* Debian 10 (Buster)
-* Ubuntu 18.04 (Bionic) - enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu), which contains packages necessary for Puppet Server.
-* Ubuntu 16.04 (Xenial)
-* SLES 12 SP1
-
-> Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). 
-
-
-## Running Puppet Server on a VM
+### Running Puppet Server on a VM
 
 By default, Puppet Server is configured to use 2GB of RAM. However, if you want to experiment with Puppet Server on a VM, you can safely allocate as little as 512MB of memory. To change the Puppet Server memory allocation, you can edit the init config file.
 
@@ -100,3 +86,5 @@ By default, Puppet Server is configured to use 2GB of RAM. However, if you want 
     For more information about the recommended settings for the JVM, see [Oracle's docs on JVM tuning.](http://docs.oracle.com/cd/E15523_01/web.1111/e13814/jvm_tuning.htm)
 
 2. Restart the `puppetserver` service after making any changes to this file.
+
+> Note: Submit issues to our [bug tracker](https://tickets.puppet.com/browse/SERVER).

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -31,7 +31,7 @@ Puppet Server versions are tested against the following versions of Java:
 
 Some Java versions may work with other Puppet Server versions, but we do not test or support those cases. Community submitted patches for support greater than Java 11 are welcome. Both Java 8 and 11 are considered long-term support versions and are planned to be supported by upstream maintainers until 2022 or later.
 
-## Install Puppet Server
+## Installing Puppet Server
 
 Puppet Server is configured to use 2 GB of RAM by default. If you're just testing an installation on a Virtual Machine, this much memory is not necessary. To change the memory allocation, see [Running Puppet Server on a VM](#Running-Puppet-Server-on-a-VM).
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -6,6 +6,8 @@ canonical: "/puppetserver/latest/install_from_packages.html"
 
 Puppet Server is a required application that runs on the Java Virtual Machine (JVM) on the master.
 
+> Note: If you have any issues with the steps below, submit these to our [bug tracker](https://tickets.puppet.com/browse/SERVER).
+
 ### Supported operating systems
 
 Puppet provides official packages that install Puppet Server 6 and all of its prerequisites on x86_64 architectures for the following platforms:
@@ -80,5 +82,3 @@ By default, Puppet Server is configured to use 2GB of RAM. However, if you want 
     For more information about the recommended settings for the JVM, see [Oracle's docs on JVM tuning.](http://docs.oracle.com/cd/E15523_01/web.1111/e13814/jvm_tuning.htm)
 
 2. Restart the `puppetserver` service after making any changes to this file.
-
-> Note: Submit issues to our [bug tracker](https://tickets.puppet.com/browse/SERVER).

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -4,7 +4,7 @@ title: "Install Puppet Server"
 canonical: "/puppetserver/latest/install_from_packages.html"
 ---
 
-Puppet Server is a required application that runs on the Java Virtual Machine (JVM). It performs the role of a central node that controls configuration information for one or more managed agent nodes.
+Puppet Server is a required application that runs on the Java Virtual Machine (JVM). It controls the configuration information for one or more managed agent nodes.
 
 > Note: If you have any issues with the steps below, submit these to our [bug tracker](https://tickets.puppet.com/browse/SERVER).
 

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -4,9 +4,13 @@ title: "Install Puppet Server"
 canonical: "/puppetserver/latest/install_from_packages.html"
 ---
 
-Puppet Server is a required application that runs on the Java Virtual Machine (JVM) on the master.
+Puppet Server is a required application that runs on the Java Virtual Machine (JVM). It performs the role of the master node that controls configuration information for one or more managed agent nodes
 
 > Note: If you have any issues with the steps below, submit these to our [bug tracker](https://tickets.puppet.com/browse/SERVER).
+
+## Before you begin
+
+Review the system requirements and make sure you have a supported version of Java. 
 
 ### Supported operating systems
 
@@ -17,7 +21,7 @@ Puppet provides official packages that install Puppet Server 6 and all of its pr
 * Ubuntu 18.04 (Bionic), 16.04 (Xenial)
 * SLES 12 SP1
 
-#### Java support
+### Java support
 
 Puppet Server versions are tested against the following versions of Java:
 
@@ -28,16 +32,13 @@ Puppet Server versions are tested against the following versions of Java:
 | 6.0-6.5  | 8, 11 (experimental)  |
 | 6.6 and later  | 8, 11  |
 
-
 Some Java versions may work with other Puppet Server versions, but we do not test or support those cases. Community submitted patches for support greater than Java 11 are welcome. Both Java 8 and 11 are considered long-term support versions and are planned to be supported by upstream maintainers until 2022 or later.
 
 > Note: Java 8 runtime packages do not exist in the standard repositories for Debian 8 (Jessie) or Ubuntu 18.04 (Bionic).  To install Puppet Server on Jessie, [configure the `jessie-backports` repository](https://backports.debian.org/Instructions/). To install Puppet Sevrer on Bionic, enable the [universe repository](https://help.ubuntu.com/community/Repositories/Ubuntu).
 
-## Installing Puppet Server
+## Install Puppet Server
 
 Puppet Server is configured to use 2 GB of RAM by default. If you're just testing an installation on a Virtual Machine, this much memory is not necessary. To change the memory allocation, see [Running Puppet Server on a VM](#Running-Puppet-Server-on-a-VM).
-
-### Install the Puppet Server package
 
 1.  [Enable the Puppet package repositories][repodocs], if you haven't already done so.
 
@@ -62,10 +63,23 @@ There is no `-` in the package name.
 3.  Start the Puppet Server service:
 
 ```
-systemctl start puppetserver
+sudo systemctl start puppetserver
 ``` 
 
-#### Running Puppet Server on a VM
+4. To check you have installed the Puppet Server package correctnly, run the following command to check the version:
+
+```
+puppetserver -v
+```
+
+### What to do next
+
+Now that Puppet Server is installed, move on to these next steps:
+
+1. [Install a Puppet agent](https://puppet.com/docs/puppet/latest/install_agents.html)
+2. [Install PuppetDB](https://puppet.com/docs/puppetdb/latest/install_via_module.html) (optional) ⁠— if you would like to to enable extra features, including enhanced queries and reports about your infrastructure.
+
+## Running Puppet Server on a VM
 
 By default, Puppet Server is configured to use 2GB of RAM. However, if you want to experiment with Puppet Server on a VM, you can safely allocate as little as 512MB of memory. To change the Puppet Server memory allocation, you can edit the init config file.
 


### PR DESCRIPTION
Do not merge yet (first iteration of changes).

I've made a few updates to start addressing the following feedback:

- The instructions jump around a lot - linking elsewhere on the same page - it really just needs a good prereq section
- The doc links to Enabling package repositories - that page should just list the available packages for each OS and the correct `wget` instead of making the user search for them (a nice touch would be adding the command for each OS to view their current OS build)
- There is an `apt-get` command, so perhaps the issue is that the commands are not clearly separated by platform. Separating the docs in this way would make them more user-friendly, especially for newer users who may not already be familiar with the command-line.

If anyone has other thoughts on how we could address this, please let me know or edit this PR. Thank you!