### PR TITLE
Rewrite Docker health check to avoid making assumptions

### DIFF
--- a/docker/puppetserver/healthcheck.sh
+++ b/docker/puppetserver/healthcheck.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
 
-set -x
-set -e
+set -euo pipefail
 
-certname=$(ls "${SSLDIR}/certs" | grep --invert-match ca.pem) && \
-hostname=$(basename $certname .pem) && \
-hostprivkey="${SSLDIR}/private_keys/$certname" && \
-hostcert="${SSLDIR}/certs/$certname" && \
-localcacert="${SSLDIR}/certs/ca.pem" && \
-curl --fail \
---resolve "${hostname}:${PUPPET_MASTERPORT}:127.0.0.1" \
---cert   $hostcert \
---key    $hostprivkey \
---cacert $localcacert \
-"https://${hostname}:${PUPPET_MASTERPORT}/status/v1/simple" \
-|  grep -q '^running$' \
-|| exit 1
+declare certname hostprivkey hostcert localcacert
+
+while read -r line; do
+  IFS=' = ' read -r key value <<< "${line}"
+  printf -v "${key}" '%s' "${value}"
+done < <(cat /tmp/puppet-config-values 2>/dev/null ||
+           puppet config print certname hostprivkey hostcert localcacert |
+             tee /tmp/puppet-config-values)
+# In the above we first try to read cached values to avoid calling `puppet
+# config print` on every health check invocation. If the file doesn't exist we
+# call `puppet config print` on the values we need and then use `read` to
+# extract the key and value and then use `printf` to declare the variable using
+# these.
+
+curl --fail                                                 \
+     --verbose                                              \
+     --resolve "${certname}:${PUPPET_MASTERPORT}:127.0.0.1" \
+     --cert   "${hostcert}"                                 \
+     --key    "${hostprivkey}"                              \
+     --cacert "${localcacert}"                              \
+     "https://${certname}:${PUPPET_MASTERPORT}/status/v1/simple" |
+  grep -q '^running$' || exit 1


### PR DESCRIPTION
The previous health check would break if more than one certificate (other than
`ca.pem`) is present in `${SSLDIR}/certs`:

~~~
# bash -x healthcheck.sh
+ set -x
+ set -e
++ ls /etc/puppetlabs/puppet/ssl/certs
++ grep --invert-match ca.pem
+ certname='puppet.company.com.pem
puppet.company.internal.pem
puppet01.company.pem
puppet02.company.pem
puppetdiff.company.pem
puppetserver.company.internal.pem'
++ basename puppet.company.com.pem puppet.company.internal.pem puppet01.company.pem puppet02.company.pem puppetdiff.company.pem puppetserver.company.internal.pem .pem
basename: extra operand 'puppet01.company.pem'
Try 'basename --help' for more information.
+ hostname=
+ exit 1
~~~

This PR makes use of `puppet config print` to read values from the config
instead of making assumption based on the name of PEM files.

To avoid unnecessarily running `puppet config print` the output is cached in
`/tmp/puppet-config-values`. If the file exists it will be used, otherwise
`puppet config print` will be called and the result placed in this file.