### PR TITLE
(maint) Bump to clj-parent 1.7.36

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.35"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.36"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit updates clj-parent to 1.7.36, which updates postgresql to address a
security issue in pgjdbc driver. This issue does not affect puppetserver, but
updating for consistency with puppetdb.