### PR TITLE
(maint) Update CA CLI gem to 1.8.0

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.7.0
+puppetserver-ca 1.8.0


### PR DESCRIPTION
This version updates the Facter version requirement to allow Facter 4.