### PR TITLE
(TK-489) Bump to clj-parent 4.5.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.5.2"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.5.4"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit updates clj-parent to 4.5.4, which updates trapperkeeper-metrics to
1.3.1. This includes support for trapperkeeper-authorization.