### PR TITLE
REVIEW: DOC-4463 sidebar nav revision

### DIFF
--- a/documentation/_puppetserver_nav.html
+++ b/documentation/_puppetserver_nav.html
@@ -6,58 +6,81 @@
     <ul>
       <li><a href="/puppetserver/{{ server_version }}/index.html">Index</a></li>
       <li><a href="/puppetserver/{{ server_version }}/services_master_puppetserver.html">About Puppet Server</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/release_notes.html">Release Notes</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/puppetserver_vs_passenger.html">Notable Differences vs. the Apache/Passenger Stack</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/install_from_packages.html">Installation</a></li>
-      <li><strong>Configuring Puppet Server</strong>
+      <li><a href="/puppetserver/{{ server_version }}/release_notes.html">Release notes</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/deprecated_features.html">Deprecated features</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/compatibility_with_puppet_agent.html">Compatibility with Puppet agent</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/install_from_packages.html">Installing Puppet Server</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/configuration.html">Configuring Puppet Server</a></li>
         <ul>
-          <li><a href="/puppetserver/{{ server_version }}/configuration.html">Puppet Server's Config Files</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_file_puppetserver.html">puppetserver.conf: Main Config File</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_file_auth.html">auth.conf: Access Control</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_file_webserver.html">webserver.conf: Jetty Web Server Config</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_file_web-routes.html">web-routes.conf: Mount Points for Component Services</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_file_global.html">global.conf: Trapperkeeper Settings</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_file_ca.html">ca.conf: CA Service Configuration</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_file_master.html">master.conf: Authorization by HTTP Header (deprecated)</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_file_product.html">product.conf: Configuring Product-level Interactions (optional)</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_file_logbackxml.html">logback.xml: Logging Level and Location</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/config_logging_advanced.html">Advanced Logging Configuration</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/bootstrap_upgrade_notes.html">Bootstrap Upgrade Notes</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_puppetserver.html">Main Puppet Server configurations: puppetserver.conf</a>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_global.html">Global settings: global.conf</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_webserver.html">Webserver service: webserver.conf</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_web-routes.html">Web application mount points: web-routes.conf</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_auth.html">Access control: auth.conf</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_metrics.html">Metrics services: metrics.conf</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_logbackxml.html">Log level and location: logback.xml</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_logging_advanced.html">Advanced logging configuration</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_ca.html">CA service: ca.conf</a></li>
+         <li><a href="/puppetserver/{{ server_version }}/puppet_conf_setting_diffs.html">Puppet Server use of puppet.conf settings</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_product.html">Configuring product-level interactions (optional): product.conf</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/bootstrap_upgrade_notes.html">Bootstrap upgrade notes</a></li>
+        </ul>
+      <li><strong>Using and extending Puppet Server</strong>
+        <ul>
+          <li><a href="/puppetserver/{{ server_version }}/gems.html">Using Ruby gems</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/subcommands.html">Subcommands</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/external_ca_configuration.html">Using an external certificate authority</a></li>
           <li><a href="/puppetserver/{{ server_version }}/infrastructure_crl.html">Infrastructure CRL</a></li>
-      </ul>
-      </li>
-      <li><a href="/puppetserver/{{ server_version }}/puppet_conf_setting_diffs.html">Differing Behavior in puppet.conf</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/gems.html">Using Ruby Gems</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/subcommands.html">Subcommands</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/compatibility_with_puppet_agent.html">Backward Compatibility With Puppet 3 Agents</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/config_file_auth_migration.html">Migrating to the HOCON auth.conf Format</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/external_ca_configuration.html">Using an External CA</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/intermediate_ca.html">Puppet as an Intermediate CA</a><li>
-      <li><a href="/puppetserver/{{ server_version }}/external_ssl_termination.html">External SSL Termination</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/tuning_guide.html">Tuning Guide</a></li>
-      <li><a href="/puppetserver/{{ server_version }}/restarting.html">Restarting the Server</a></li>
-      <li><strong>Known Issues and Workarounds</strong>
-        <ul>
-          <li><a href="/puppetserver/{{ server_version }}/known_issues.html">Known Issues</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/ssl_server_certificate_change_and_virtual_ips.html">SSL Problems With Load-Balanced PuppetDB Servers ("Server Certificate Change" error)</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/intermediate_ca.html"> Intermediate CA</a><li>
+          <li><a href="/puppetserver/{{ server_version }}/external_ssl_termination.html">External SSL germination</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/restarting.html">Restarting Puppet server</a></li>
         </ul>
       </li>
-      <li><strong>Administrative API</strong>
+      <li><strong>Tuning, troubleshooting, and known issues</strong>
         <ul>
-          <li><a href="/puppetserver/{{ server_version }}/admin-api/v1/environment-cache.html">Environment Cache</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/admin-api/v1/jruby-pool.html">JRuby Pool</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/known_issues.html">Known issues</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/ssl_server_certificate_change_and_virtual_ips.html">SSL problems with load-balanced PuppetDB servers ("Server Certificate Change" error)</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/tuning_guide.html">Puppet Server tuning guide</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_auth_migration.html">Migrating to the HOCON auth.conf format</a></li>
+        </ul>
+      <li><strong>Administrative API endpoints</strong>
+        <ul>
+          <li><a href="/puppetserver/{{ server_version }}/admin-api/v1/environment-cache.html">Environment cache</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/admin-api/v1/jruby-pool.html">JRuby pool</a></li>
         </ul>
       </li>
-      <li><strong>Status API</strong>
+      <li><strong>CA API endpoints</strong>
         <ul>
-          <li><a href="/puppetserver/{{ server_version }}/status-api/v1/services.markdown">Services</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/http_certificate.html">Certificate</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/http_certificate_request.html">Certificate signing request</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/http_certificate_status.html">Certificate status</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/http_certificate_revocation_list.html">Certificate revocation list</a></li>
         </ul>
       </li>
-      <li><strong>Developer Info</strong>
+      <li><strong>Server-specific Puppet API endpoints</strong>
         <ul>
-          <li><a href="/puppetserver/{{ server_version }}/dev_debugging.html">Debugging</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/dev_running_from_source.html">Running From Source</a></li>
-          <li><a href="/puppetserver/{{ server_version }}/dev_trace_func.html">Tracing Code Events</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/puppet-api/v3/environment_classes.html">Environment classes</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/puppet-api/v3/environment_modules.html">Environment modules</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/puppet-api/v3/static_file_content.html">Static file content</a></li>
+        </ul>
+      </li>
+      <li><strong>Status API endpoints</strong>
+        <ul>
+          <li><a href="/puppetserver/{{ server_version }}/status-api/v1/services.html">Services endpoint</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/status-api/v1/simple.html">Simple endpoint</a></li>
+        </ul>
+      </li>
+      <li><strong>Metrics API endpoints</strong>
+        <ul>
+          <li><a href="/puppetserver/{{ server_version }}/metrics-api/v1/metrics_api.html">v1 metrics</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/metrics-api/v2/metrics_api.html">v2 (Jolokia) metrics</a></li>
+        </ul>
+      </li>
+      <li><strong>Developer information</strong>
+        <ul>
+          <li><a href="/puppetserver/{{ server_version }}/dev_debugging.html">Developer debugging</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/dev_running_from_source.html">Running from source</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/dev_trace_func.html">Tracing code events</a></li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
Here's a first swing at revising the sidebar nav for Puppet Server. We think it's less confusing if Puppet Server goes back to having its own sidebar, where the context is more clearly "you are in the Puppet Server docs now!"

I moved some things, removed others, and added others. There are some questions on DOC-4463, and a few revision notes for context. I'll ping you there as well.