### PR TITLE
(SERVER-2795) Fix CSR deletion and cleanup whitespace

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -64,36 +64,36 @@
       ;; Respond to all CSR validation failures with a 400
       (middleware-utils/plain-response 400 msg))))
 
-  (schema/defn format-http-date :- (schema/maybe DateTime)
-    "Formats an http-date into joda time.  Returns nil for malformed or nil
-     http-dates"
-    [http-date :- (schema/maybe schema/Str)]
-    (when http-date
-      (try
-        (time-format/parse
-          (time-format/formatters :rfc822)
-          (string/replace http-date #"GMT" "+0000"))
-        (catch IllegalArgumentException e
-          nil))))
+(schema/defn format-http-date :- (schema/maybe DateTime)
+  "Formats an http-date into joda time.  Returns nil for malformed or nil
+   http-dates"
+  [http-date :- (schema/maybe schema/Str)]
+  (when http-date
+    (try
+      (time-format/parse
+        (time-format/formatters :rfc822)
+        (string/replace http-date #"GMT" "+0000"))
+      (catch IllegalArgumentException e
+        nil))))
 
-  (defn handle-get-certificate-revocation-list
-    "Always return the crl if no 'If-Modified-Since' header is provided or
-    if that header is not in correct http-date format. If the header is
-    present and has correct format, only return the crl if the master
-    cacrl is newer than the agent crl."
-    [request {:keys [cacrl infra-crl-path enable-infra-crl]}]
-    (let [agent-crl-last-modified-val (rr/get-header request "If-Modified-Since")
-          agent-crl-last-modified-date-time (format-http-date agent-crl-last-modified-val)
-          master-crl-to-use (if (true? enable-infra-crl) infra-crl-path cacrl)
-          master-crl-last-modified-date-time (ca/get-crl-last-modified master-crl-to-use)]
-      (if (or (nil? agent-crl-last-modified-date-time)
-              (time/after? master-crl-last-modified-date-time agent-crl-last-modified-date-time))
-        (-> (ca/get-certificate-revocation-list master-crl-to-use)
-            (rr/response)
-            (rr/content-type "text/plain"))
-        (-> (rr/response nil)
-            (rr/status 304)
-            (rr/content-type "text/plain")))))
+(defn handle-get-certificate-revocation-list
+  "Always return the crl if no 'If-Modified-Since' header is provided or
+  if that header is not in correct http-date format. If the header is
+  present and has correct format, only return the crl if the master
+  cacrl is newer than the agent crl."
+  [request {:keys [cacrl infra-crl-path enable-infra-crl]}]
+  (let [agent-crl-last-modified-val (rr/get-header request "If-Modified-Since")
+        agent-crl-last-modified-date-time (format-http-date agent-crl-last-modified-val)
+        master-crl-to-use (if (true? enable-infra-crl) infra-crl-path cacrl)
+        master-crl-last-modified-date-time (ca/get-crl-last-modified master-crl-to-use)]
+    (if (or (nil? agent-crl-last-modified-date-time)
+            (time/after? master-crl-last-modified-date-time agent-crl-last-modified-date-time))
+      (-> (ca/get-certificate-revocation-list master-crl-to-use)
+          (rr/response)
+          (rr/content-type "text/plain"))
+      (-> (rr/response nil)
+          (rr/status 304)
+          (rr/content-type "text/plain")))))
 
 (schema/defn handle-delete-certificate-request!
   [subject :- String
@@ -273,12 +273,12 @@
                   (name desired-state) subject))
               (let [cert-ttl (:cert_ttl json-body)]
                 (if (and cert-ttl (schema/check schema/Int cert-ttl))
-                     (malformed
-                      (i18n/tru "cert_ttl specified for host {0} must be an integer, not \"{1}\"" subject cert-ttl))
-                     ; this is the happy path. we have a body, it's parsable json,
-                     ; and the desired_state field is one of (signed revoked), and
-                     ; it potentially has a valid cert_ttl field
-                     [false {::json-body json-body}])))
+                  (malformed
+                   (i18n/tru "cert_ttl specified for host {0} must be an integer, not \"{1}\"" subject cert-ttl))
+                  ; this is the happy path. we have a body, it's parsable json,
+                  ; and the desired_state field is one of (signed revoked), and
+                  ; it potentially has a valid cert_ttl field
+                  [false {::json-body json-body}])))
             (malformed (i18n/tru "Missing required parameter \"desired_state\"")))
           (malformed (i18n/tru "Request body is not JSON.")))
         (malformed (i18n/tru "Empty request body.")))))

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -341,9 +341,9 @@
         (GET [""] [subject]
           (handle-get-certificate-request subject ca-settings))
         (PUT [""] [subject :as {body :body}]
-          (handle-put-certificate-request! subject body ca-settings)))
+          (handle-put-certificate-request! subject body ca-settings))
         (DELETE [""] [subject]
-          (handle-delete-certificate-request! subject ca-settings))
+          (handle-delete-certificate-request! subject ca-settings)))
       (GET ["/certificate_revocation_list/" :ignored-node-name] request
         (handle-get-certificate-revocation-list request ca-settings)))
     (comidi/not-found "Not Found")))

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -27,9 +27,9 @@
           oid-mappings (ca/get-oid-mappings custom-oid-file)
           auth-handler (fn [request] (wrap-with-authorization-check request {:oid-map oid-mappings}))
           ca-crl-file (.getCanonicalPath (fs/file
-                                       (get-in-config [:puppetserver :cacrl])))
+                                          (get-in-config [:puppetserver :cacrl])))
           host-crl-file (.getCanonicalPath (fs/file
-                                       (get-in-config [:puppetserver :hostcrl])))
+                                            (get-in-config [:puppetserver :hostcrl])))
           infra-nodes-file (.getCanonicalPath (fs/file (str (fs/parent ca-crl-file) "/infra_inventory.txt")))
           watcher (create-watcher {:recursive false})]
       (ca/validate-settings! settings)

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -293,75 +293,75 @@
            (is (= "Not Found" (:body response)))))))))
 
 (deftest ^:integration crl-reloaded-without-server-restart
-         (bootstrap/with-puppetserver-running
-           app
-           {:jruby-puppet
-            {:gem-path [(ks/absolute-path jruby-testutils/gem-path)]}
-            :webserver
-            {:ssl-cert (str bootstrap/master-conf-dir "/ssl/certs/localhost.pem")
-             :ssl-key (str bootstrap/master-conf-dir "/ssl/private_keys/localhost.pem")
-             :ssl-ca-cert (str bootstrap/master-conf-dir "/ssl/ca/ca_crt.pem")
-             :ssl-crl-path (str bootstrap/master-conf-dir "/ssl/crl.pem")}}
-           (let [key-pair (ssl-utils/generate-key-pair)
-                 subject "crl_reload"
-                 subject-dn (ssl-utils/cn subject)
-                 public-key (ssl-utils/get-public-key key-pair)
-                 private-key (ssl-utils/get-private-key key-pair)
-                 private-key-file (ks/temp-file)
-                 csr (ssl-utils/generate-certificate-request key-pair subject-dn)
-                 options {:ssl-cert (str bootstrap/master-conf-dir
-                                         "/ssl/ca/ca_crt.pem")
-                          :ssl-key (str bootstrap/master-conf-dir
-                                        "/ssl/ca/ca_key.pem")
-                          :ssl-ca-cert (str bootstrap/master-conf-dir
-                                            "/ssl/ca/ca_crt.pem")
-                          :as :text}
-                 _ (ssl-utils/key->pem! private-key private-key-file)
-                 _ (ssl-utils/obj->pem! csr (str bootstrap/master-conf-dir
-                                                "/ssl/ca/requests/"
-                                                subject
-                                                ".pem"))
-                 cert-status-request (fn [action]
-                                       (http-client/put
-                                         (str "https://localhost:8140/"
-                                              "puppet-ca/v1/certificate_status/"
-                                              subject)
-                                         (merge options
-                                                {:body (str "{\"desired_state\": \""
-                                                            action
-                                                            "\"}")
-                                                 :headers {"content-type"
-                                                           "application/json"}})))
-                 client-request #(http-client/get
-                                  "https://localhost:8140/status/v1/services"
-                                   (merge options
-                                          {:ssl-key (str private-key-file)
-                                           :ssl-cert (str bootstrap/master-conf-dir
-                                                          "/ssl/ca/signed/"
-                                                          subject
-                                                          ".pem")}))]
-             (testing "node certificate request can be signed successfully"
-               (let [sign-response (cert-status-request "signed")]
-                 (is (= 204 (:status sign-response)))))
-             (testing "node request before revocation is successful"
-               (let [node-response-before-revoke (client-request)]
-                 (is (= 200 (:status node-response-before-revoke)))))
-             (testing "node certificate can be successfully revoked"
-               (let [revoke-response (cert-status-request "revoked")]
-                 (is (= 204 (:status revoke-response)))))
-             (testing "node request after revocation fails"
-               (let [ssl-exception-for-request? #(try
-                                                   (client-request)
-                                                   false
-                                                   (catch SSLException e
-                                                     true))]
-                 (is (loop [times 30]
-                       (cond
-                         (ssl-exception-for-request?) true
-                         (zero? times) false
-                         :else (do
-                                 (Thread/sleep 500)
-                                 (recur (dec times)))))))))))
+  (bootstrap/with-puppetserver-running
+    app
+    {:jruby-puppet
+     {:gem-path [(ks/absolute-path jruby-testutils/gem-path)]}
+     :webserver
+     {:ssl-cert (str bootstrap/master-conf-dir "/ssl/certs/localhost.pem")
+      :ssl-key (str bootstrap/master-conf-dir "/ssl/private_keys/localhost.pem")
+      :ssl-ca-cert (str bootstrap/master-conf-dir "/ssl/ca/ca_crt.pem")
+      :ssl-crl-path (str bootstrap/master-conf-dir "/ssl/crl.pem")}}
+    (let [key-pair (ssl-utils/generate-key-pair)
+          subject "crl_reload"
+          subject-dn (ssl-utils/cn subject)
+          public-key (ssl-utils/get-public-key key-pair)
+          private-key (ssl-utils/get-private-key key-pair)
+          private-key-file (ks/temp-file)
+          csr (ssl-utils/generate-certificate-request key-pair subject-dn)
+          options {:ssl-cert (str bootstrap/master-conf-dir
+                                  "/ssl/ca/ca_crt.pem")
+                   :ssl-key (str bootstrap/master-conf-dir
+                                 "/ssl/ca/ca_key.pem")
+                   :ssl-ca-cert (str bootstrap/master-conf-dir
+                                     "/ssl/ca/ca_crt.pem")
+                   :as :text}
+          _ (ssl-utils/key->pem! private-key private-key-file)
+          _ (ssl-utils/obj->pem! csr (str bootstrap/master-conf-dir
+                                         "/ssl/ca/requests/"
+                                         subject
+                                         ".pem"))
+          cert-status-request (fn [action]
+                                (http-client/put
+                                  (str "https://localhost:8140/"
+                                       "puppet-ca/v1/certificate_status/"
+                                       subject)
+                                  (merge options
+                                         {:body (str "{\"desired_state\": \""
+                                                     action
+                                                     "\"}")
+                                          :headers {"content-type"
+                                                    "application/json"}})))
+          client-request #(http-client/get
+                           "https://localhost:8140/status/v1/services"
+                            (merge options
+                                   {:ssl-key (str private-key-file)
+                                    :ssl-cert (str bootstrap/master-conf-dir
+                                                   "/ssl/ca/signed/"
+                                                   subject
+                                                   ".pem")}))]
+      (testing "node certificate request can be signed successfully"
+        (let [sign-response (cert-status-request "signed")]
+          (is (= 204 (:status sign-response)))))
+      (testing "node request before revocation is successful"
+        (let [node-response-before-revoke (client-request)]
+          (is (= 200 (:status node-response-before-revoke)))))
+      (testing "node certificate can be successfully revoked"
+        (let [revoke-response (cert-status-request "revoked")]
+          (is (= 204 (:status revoke-response)))))
+      (testing "node request after revocation fails"
+        (let [ssl-exception-for-request? #(try
+                                            (client-request)
+                                            false
+                                            (catch SSLException e
+                                              true))]
+          (is (loop [times 30]
+                (cond
+                  (ssl-exception-for-request?) true
+                  (zero? times) false
+                  :else (do
+                          (Thread/sleep 500)
+                          (recur (dec times)))))))))))
 
 
 (deftest ^:integration revoke-compile-master-test


### PR DESCRIPTION
This commit fixes a misplaced parenthesis that made it impossible to
delete CSRs via the API. It also cleans up some erroneous whitespace.