### PR TITLE
(SERVER-2551) Make CA cert and CRL expirations available via API

### DIFF
--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -87,6 +87,17 @@ authorization: {
             name: "puppetlabs cert statuses"
         },
         {
+            # Allow authenticated access to the CA expirations endpoint
+            match-request: {
+                path: "/puppet-ca/v1/expirations"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs CA cert and CRL expirations"
+        },
+        {
             # Allow unauthenticated access to the status service endpoint
             match-request: {
                 path: "/status/v1/services"

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -104,6 +104,14 @@
         (rr/status ((response :outcome) outcomes->codes))
         (rr/content-type "text/plain"))))
 
+(schema/defn handle-get-ca-expirations
+  [ca-settings :- ca/CaSettings]
+  (let [response {:ca-certs (ca/ca-expiration-dates (:cacert ca-settings))
+                  :crls (ca/crl-expiration-dates (:cacrl ca-settings))}]
+    (-> (rr/response (cheshire/generate-string response))
+        (rr/status 200)
+        (rr/content-type "application/json"))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Web app
 
@@ -345,7 +353,9 @@
         (DELETE [""] [subject]
           (handle-delete-certificate-request! subject ca-settings)))
       (GET ["/certificate_revocation_list/" :ignored-node-name] request
-        (handle-get-certificate-revocation-list request ca-settings)))
+        (handle-get-certificate-revocation-list request ca-settings))
+      (GET ["/expirations"] request
+        (handle-get-ca-expirations ca-settings)))
     (comidi/not-found "Not Found")))
 
 (schema/defn ^:always-validate

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -794,18 +794,18 @@
                      (assoc :keylength 768))
         ca-settings (assoc (testutils/ca-settings (str tmp-confdir "/ssl/ca")) :keylength 768)]
 
-  (retrieve-ca-cert! (:cacert ca-settings) (:localcacert settings))
-  (initialize-master-ssl! settings "master" ca-settings)
+    (retrieve-ca-cert! (:cacert ca-settings) (:localcacert settings))
+    (initialize-master-ssl! settings "master" ca-settings)
 
-  (testing "hostprivkey should have correct keylength"
-    (let [key (-> settings :hostprivkey utils/pem->private-key)]
-      (is (utils/private-key? key))
-      (is (= 768 (utils/keylength key)))))
+    (testing "hostprivkey should have correct keylength"
+      (let [key (-> settings :hostprivkey utils/pem->private-key)]
+        (is (utils/private-key? key))
+        (is (= 768 (utils/keylength key)))))
 
-  (testing "hostpubkey should have correct keylength"
-    (let [key (-> settings :hostpubkey utils/pem->public-key)]
-      (is (utils/public-key? key))
-      (is (= 768 (utils/keylength key)))))))
+    (testing "hostpubkey should have correct keylength"
+      (let [key (-> settings :hostpubkey utils/pem->public-key)]
+        (is (utils/public-key? key))
+        (is (= 768 (utils/keylength key)))))))
 
 (when-not (SSLUtils/isFIPS)
   (deftest initialize-master-ssl!-test-with-incorrect-keylength
@@ -1296,12 +1296,12 @@
       (testing "pp_authorization is caught"
         (is (thrown+-with-msg?
              [:kind :disallowed-extension]
-              #".*borges.*contains an authorization extension.*"
+             #".*borges.*contains an authorization extension.*"
              (ensure-no-authorization-extensions! auth-csr false))))
       (testing "pp_auth_role is caught"
         (is (thrown+-with-msg?
              [:kind :disallowed-extension]
-              #".*borges.*contains an authorization extension..*"
+             #".*borges.*contains an authorization extension..*"
              (ensure-no-authorization-extensions! auth-role-csr false)))))))
 
 (deftest validate-subject!-test
@@ -1400,3 +1400,17 @@
     (testing "and the file doesn't exist"
       (testing "the result is nil"
         (is (nil? (create-csr-attrs-exts "does/not/exist.yaml")))))))
+
+(deftest ca-expiration-dates-test
+  (testing "returns a map of names to dates"
+    (let [settings (testutils/ca-sandbox! bundle-cadir)
+          expiration-map (ca-expiration-dates (:cacert settings))]
+      (is (= "2036-09-06T05:58:33UTC" (get expiration-map "rootca.example.org")))
+      (is (= "2036-09-06T06:09:14UTC" (get expiration-map "intermediateca.example.org"))))))
+
+(deftest crl-expiration-dates-test
+  (testing "returns a map of names to dates"
+    (let [settings (testutils/ca-sandbox! bundle-cadir)
+          expiration-map (crl-expiration-dates (:cacrl settings))]
+      (is (= "2016-10-11T06:42:52UTC" (get expiration-map "rootca.example.org")))
+      (is (= "2016-10-11T06:40:47UTC" (get expiration-map "intermediateca.example.org"))))))


### PR DESCRIPTION
This commit adds a `puppet-ca/v1/ca-expirations` endpoint that returns the expiration date of each CA cert and CRL in their respective bundles, keyed by common name. For the certs, this is the "not-after" date, while for CRLs it is the "next-update" date.

Interested in feedback on the format of the response and the name of the endpoint, as well as the usual things.