### PR TITLE
(SERVER-2233) Add query params for filtering certificate statuses

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1477,6 +1477,14 @@
                                    (fs/find-files signeddir pem-pattern)))]
     (map (partial get-certificate-status* signeddir csrdir crl) all-subjects)))
 
+(schema/defn ^:always-validate filter-by-certificate-state :- [CertificateStatusResult]
+  "Get the status of all certificates in the given state."
+  [settings :- CaSettings
+   state :- schema/Str]
+  (->> settings
+       (get-certificate-statuses)
+       (filter (fn [cert-status] (= state (:state cert-status))))))
+
 (schema/defn sign-existing-csr!
   "Sign the subject's certificate request."
   [{:keys [csrdir] :as settings} :- CaSettings

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -511,6 +511,32 @@
             (is (= #{localhost-status test-agent-status revoked-agent-status}
                  (set (json/parse-string (:body response) true))))))
 
+        (testing "respects 'state' query param"
+          (testing "requested"
+            (let [response (test-app
+                             {:uri            "/v1/certificate_statuses/thisisirrelevant"
+                              :params         {"state" "requested"}
+                              :request-method :get})]
+              (is (= 200 (:status response)))
+              (is (= #{test-agent-status}
+                     (set (json/parse-string (:body response) true))))))
+          (testing "signed"
+            (let [response (test-app
+                             {:uri            "/v1/certificate_statuses/thisisirrelevant"
+                              :params         {"state" "signed"}
+                              :request-method :get})]
+              (is (= 200 (:status response)))
+              (is (= #{localhost-status}
+                     (set (json/parse-string (:body response) true))))))
+          (testing "revoked"
+            (let [response (test-app
+                             {:uri            "/v1/certificate_statuses/thisisirrelevant"
+                              :params         {"state" "revoked"}
+                              :request-method :get})]
+              (is (= 200 (:status response)))
+              (is (= #{revoked-agent-status}
+                     (set (json/parse-string (:body response) true)))))))
+
         (testing "returns json when no accept header specified"
           (let [response (test-app
                           {:uri "/v1/certificate_statuses/thisisirrelevant"


### PR DESCRIPTION
This commit updates the `certificate_statuses` API endpoint to accept query
params for filtering by a given 'state'. For example, this can be used to
identify all agents with unsigned (i.e. requested) certs.