### PR TITLE
(SERVER-2848) Branch twiddling

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,9 @@ PUPPET_SERVER_RUBY_SRC = File.join(PROJECT_ROOT, 'src', 'ruby', 'puppetserver-li
 PUPPET_SERVER_RUBY_SPEC = File.join(PROJECT_ROOT, 'spec')
 PUPPET_SUBMODULE_PATH = File.join('ruby','puppet')
 # Branch of puppetserver for which to update submodule pins
-PUPPETSERVER_BRANCH = ENV['PUPPETSERVER_BRANCH'] || 'master'
+PUPPETSERVER_BRANCH = ENV['PUPPETSERVER_BRANCH'] || 'main'
 # Branch of puppet-agent to track for passing puppet SHA
-PUPPET_AGENT_BRANCH = ENV['PUPPET_AGENT_BRANCH'] || 'master'
+PUPPET_AGENT_BRANCH = ENV['PUPPET_AGENT_BRANCH'] || 'next'
 
 TEST_GEMS_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_gems')
 TEST_BUNDLE_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_bundle')

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,6 +1,5 @@
 ---
 project: 'puppetserver'
 
-repo_name: 'puppet6'
-nonfinal_repo_name: 'puppet6-nightly'
-repo_link_target: 'puppet'
+repo_name: 'puppet7'
+nonfinal_repo_name: 'puppet7-nightly'

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "6.12.2-SNAPSHOT")
+(def ps-version "7.0.0-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This PR updates:
* `build_defaults.yaml` to point to the right build and nightly repos
* Rakefile to ensure that the puppet and puppet-agent versions point to the right branches
* project version to 7.0.0