### PR TITLE
(SERVER-2848) Update major version in compat test

### DIFF
--- a/acceptance/suites/puppet5_tests/puppet5_version_test.rb
+++ b/acceptance/suites/puppet5_tests/puppet5_version_test.rb
@@ -8,9 +8,9 @@ on(legacy_agents, puppet("--version")) do
   assert_match(/\A5\./, stdout, "puppet --version does not start with major version 5.")
 end
 
-step "Check that Puppet Server has Puppet 6.x installed"
+step "Check that Puppet Server has Puppet 7.x installed"
 on(master, puppet("--version")) do
-  assert_match(/\A6/, stdout, "puppet --version does not start with major version 6.x")
+  assert_match(/\A7/, stdout, "puppet --version does not start with major version 7.x")
 end
 
 step "Check that the agent on the master runs against the master"


### PR DESCRIPTION
The Puppet 5 compat test was asserting that the version installed on the
master be 6, but it should be 7.