### PR TITLE
(maint) Update facter submodule to point at facter#4.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/puppetlabs/puppet-resource_api.git
 [submodule "ruby/facter"]
 	path = ruby/facter
-	url = https://github.com/puppetlabs/facter-ng.git
+	url = https://github.com/puppetlabs/facter.git


### PR DESCRIPTION
Previously, the Facter 4 code lived in the facter-ng repo. Now that it
has moved to the main facter repo, this commit updates our submodule pin
to point there, to the 4.x branch.