### PR TITLE
(maint) Update puppet-agent branch to `main`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ PUPPET_SUBMODULE_PATH = File.join('ruby','puppet')
 # Branch of puppetserver for which to update submodule pins
 PUPPETSERVER_BRANCH = ENV['PUPPETSERVER_BRANCH'] || 'main'
 # Branch of puppet-agent to track for passing puppet SHA
-PUPPET_AGENT_BRANCH = ENV['PUPPET_AGENT_BRANCH'] || 'next'
+PUPPET_AGENT_BRANCH = ENV['PUPPET_AGENT_BRANCH'] || 'main'
 
 TEST_GEMS_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_gems')
 TEST_BUNDLE_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_bundle')


### PR DESCRIPTION
Previously, the puppet-agent branch for Platform 7 was called "next",
but it was recently renamed to "main". This commit updates our tracking
branch to point to `main`.