### PR TITLE
(FACT-2742) Exclude net/https when running on jruby FIPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/puppetlabs/puppet-resource_api.git
 [submodule "ruby/facter"]
 	path = ruby/facter
-	url = https://github.com/puppetlabs/facter.git
+	url = https://github.com/IrimieBogdan/facter.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/puppetlabs/puppet-resource_api.git
 [submodule "ruby/facter"]
 	path = ruby/facter
-	url = https://github.com/IrimieBogdan/facter.git
+	url = https://github.com/puppetlabs/facter.git


### PR DESCRIPTION
`net/http` uses `openssl` which is not FIPS compliant on jRuby. We can use the same mechanism that is used for missing gems to detect this case and log an error message, but continue to provide the facts we can resolve.