### PR TITLE
(SERVER-2677) Extend sleep for unsigned certs

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -121,8 +121,8 @@ module PuppetServerExtensions
           response = on(host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,1])
           if response.exit_code == 1
             if response.stdout.match?(/Certificate (.+) has not been signed yet/)
-              Beaker::Log.notify "Cert not signed, possibly due to CI load; running agent again"
-              sleep 3
+              Beaker::Log.notify "Cert not signed, possibly due to 'puppet resource service puppetserver ensure=running' returning early, retrying in 20 seconds"
+              sleep 20
               on(host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0])
             else
               fail_test("Exit code of 1 with unexpected stdout:\n#{response.stdout}")


### PR DESCRIPTION
When puppet is trying to manage the puppetserver service and starts
it, the shell command seemed to return very early, 1.37 seconds for
redhat 8 as opposed to ~18 for other platforms.. Beaker does a
check to http://localhost:8140 after the command, but it is only
ostensibly successful; this change extends the timeout to 20 seconds
to see if this allows the pre-suite step to complete successfully.

If this is successful, we should probably look into why redhat 8 is
completing the service start command so quickly.