### PR TITLE
(PE-29443) Preserve hash order for plan variables

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -1007,7 +1007,7 @@
    (schema/required-key "code_ast") schema/Str
    (schema/required-key "trusted_facts") {(schema/required-key "values") {schema/Str schema/Any}}
    (schema/required-key "facts") {(schema/required-key "values") {schema/Str schema/Any}}
-   (schema/required-key "variables") {(schema/required-key "values") {schema/Str schema/Any}}
+   (schema/required-key "variables") {(schema/required-key "values") (schema/either [{schema/Str schema/Any}] {schema/Str schema/Any})}
    (schema/optional-key "job_id") schema/Str
    (schema/optional-key "transaction_uuid") schema/Str
    (schema/optional-key "options") {(schema/optional-key "capture_logs") schema/Bool


### PR DESCRIPTION
This commit updates the compile_ast endpoint to support loading plan variables from an ordered list. Deserialization requires ordered hashes. Hash order is lost when moving from ruby -> clojure -> json so the ordered data is preserved in a list and then an ordered hash is created.