### PR TITLE
(maint) Update required agent version to 6.16.0

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -7,7 +7,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["puppet-agent >= 5.5.0"],
+      redhat: { dependencies: ["puppet-agent >= 6.16.0"],
                 build-dependencies: ["%{open_jdk}"],
                 # Install some gems
                 install: [
@@ -35,7 +35,7 @@ ezbake: {
                ]
              }
 
-      debian: { dependencies: ["puppet-agent (>= 5.5.0)"],
+      debian: { dependencies: ["puppet-agent (>= 6.16.0)"],
                 build-dependencies: ["openjdk-8-jre-headless"],
                 # Install some gems
                 install: [


### PR DESCRIPTION
This commit updates the packaging requirement for what puppet-agent
version must be installed alongside the server to 6.16.0, which is the
vesrion that shipped with the last PE LTS release. Notably, this version
contains all the necessary changes for multithreaded support, which
should allow us to remove some speical-casing eventually.