### PR TITLE
(PUP-10386) Remove tk-auth rule for puppet status endpoint

### DIFF
--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -137,11 +137,6 @@ with_puppet_running_on(master, {}) do
     assert_denied(/\/puppet\/v3\/file_bucket_file\/md5\/123 \(method :get\)/)
   end
 
-  step 'status endpoint' do
-    curl_unauthenticated('/puppet/v3/status/foo?environment=production')
-    assert_allowed
-  end
-
   step 'status service endpoint' do
     curl_unauthenticated('/status/v1/services')
     assert_allowed

--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -217,16 +217,6 @@ authorization: {
         },
         {
             match-request: {
-                path: "/puppet/v3/status"
-                type: path
-                method: get
-            }
-            allow-unauthenticated: true
-            sort-order: 500
-            name: "puppetlabs status"
-        },
-        {
-            match-request: {
                 path: "/puppet/v3/static_file_content"
                 type: path
                 method: get


### PR DESCRIPTION
The `/puppet/v3/status` endpoint and associated indirection were
recently removed. This commit removes the associated tk-auth rule and
test for the endpoint.