### PR TITLE
(maint) Remove environment and status leftovers

### DIFF
--- a/acceptance/suites/tests/authorization/fixtures/extensions_test_auth.conf
+++ b/acceptance/suites/tests/authorization/fixtures/extensions_test_auth.conf
@@ -94,16 +94,6 @@ authorization: {
         },
         {
             match-request: {
-                path: "/puppet/v3/status"
-                type: path
-                method: get
-            }
-            allow-unauthenticated: true
-            sort-order: 500
-            name: "puppetlabs status"
-        },
-        {
-            match-request: {
                 path: "/puppet/v3/static_file_content"
                 type: path
                 method: get

--- a/acceptance/suites/tests/certificate_authority/fixtures/auth.conf
+++ b/acceptance/suites/tests/certificate_authority/fixtures/auth.conf
@@ -105,16 +105,6 @@ authorization: {
         },
         {
             match-request: {
-                path: "/puppet/v3/status"
-                type: path
-                method: get
-            }
-            allow-unauthenticated: true
-            sort-order: 500
-            name: "puppetlabs status"
-        },
-        {
-            match-request: {
                 path: "/puppet/v3/static_file_content"
                 type: path
                 method: get

--- a/dev-resources/puppetlabs/puppetserver/auth_conf_test/auth.conf
+++ b/dev-resources/puppetlabs/puppetserver/auth_conf_test/auth.conf
@@ -42,10 +42,6 @@ allow $1
 path /puppet/v3/file
 allow *
 
-path /puppet/v3/status
-method find
-allow *
-
 # allow all nodes to access the certificates services
 path /puppet-ca/v1/certificate_revocation_list/ca
 method find

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -1130,8 +1130,6 @@
                (request-handler request))
    (comidi/PUT ["/report/" [#".*" :rest]] request
                (request-handler request))
-   (comidi/GET ["/environment/" [#".*" :environment]] request
-               (request-handler (assoc request :include-code-id? true)))
    (comidi/GET "/environments" request
                (request-handler request))
    (comidi/GET ["/status/" [#".*" :rest]] request

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -1131,8 +1131,6 @@
    (comidi/PUT ["/report/" [#".*" :rest]] request
                (request-handler request))
    (comidi/GET "/environments" request
-               (request-handler request))
-   (comidi/GET ["/status/" [#".*" :rest]] request
                (request-handler request))))
 
 (schema/defn ^:always-validate

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -64,8 +64,7 @@
             {:get ["node"
                    "file_metadatas"
                    "file_metadata"
-                   "file_bucket_file"
-                   "status"]
+                   "file_bucket_file"]
              :put ["file_bucket_file"
                    "report"]
              :head ["file_bucket_file"]}

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -62,7 +62,6 @@
     (is (nil? (request "/foo/bar")))
     (doseq [[method paths]
             {:get ["node"
-                   "environment"
                    "file_metadatas"
                    "file_metadata"
                    "file_bucket_file"


### PR DESCRIPTION
I missed removing the `/puppet/v3/environment` route in https://github.com/puppetlabs/puppetserver/pull/2411. While I was there, I updated `/puppet/v3/status` and removed it from some test fixtures.