### PR TITLE
(maint) Don't set `use-legacy-auth-conf` to true

### DIFF
--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -16,11 +16,6 @@ step 'Turn on new auth support' do
                    {'jruby-puppet' => {'use-legacy-auth-conf' => false}})
 end
 
-teardown do
-  modify_tk_config(master, options['puppetserver-config'],
-                   {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
-end
-
 def curl_authenticated(path)
   curl = 'curl '
   curl += '--cert $(puppet config print hostcert) '


### PR DESCRIPTION
This commit removes the teardown step to set `use-legacy-auth-conf` back to
true. We no longer use the legacy auth, but this setting was bleeding into other
tests. This caused test failures because legacy auth doesn't have a way to
restrict access based on cert extensions.