### PR TITLE
(SERVER-2809) Add rake task for updating facter submodule

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,10 +13,15 @@ FACTER_LIB = File.join(PROJECT_ROOT, 'ruby', 'facter', 'lib')
 PUPPET_SERVER_RUBY_SRC = File.join(PROJECT_ROOT, 'src', 'ruby', 'puppetserver-lib')
 PUPPET_SERVER_RUBY_SPEC = File.join(PROJECT_ROOT, 'spec')
 PUPPET_SUBMODULE_PATH = File.join('ruby','puppet')
+FACTER_SUBMODULE_PATH = File.join('ruby','facter')
 # Branch of puppetserver for which to update submodule pins
 PUPPETSERVER_BRANCH = ENV['PUPPETSERVER_BRANCH'] || 'master'
 # Branch of puppet-agent to track for passing puppet SHA
 PUPPET_AGENT_BRANCH = ENV['PUPPET_AGENT_BRANCH'] || 'master'
+# Branch of puppet-agent to track for Facter's passing SHA.
+# This needs to be separate because for 6.x, we want to use facter#main
+# instead of Facter 3.
+FACTER_BRANCH = ENV['FACTER_BRANCH'] || 'main'
 
 TEST_GEMS_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_gems')
 TEST_BUNDLE_DIR = File.join(PROJECT_ROOT, 'vendor', 'test_bundle')
@@ -81,8 +86,8 @@ def re_run_basic_smoke_test
   sh beaker
 end
 
-def jenkins_passing_json_parsed
-  passing_url = "http://builds.delivery.puppetlabs.net/passing-agent-SHAs/api/v1/json/report-#{PUPPET_AGENT_BRANCH}"
+def jenkins_passing_json_parsed(branch)
+  passing_url = "http://builds.delivery.puppetlabs.net/passing-agent-SHAs/api/v1/json/report-#{branch}"
   uri = URI.parse(passing_url)
   begin
     # DO NOT use uri-open if accepting user input for the uri
@@ -90,13 +95,13 @@ def jenkins_passing_json_parsed
     #   but not enough to cleanse malicious user input
     jenkins_result = uri.open(redirect: false)
   rescue OpenURI::HTTPError => e
-    abort "ERROR: Could not get last passing run data for #{PUPPET_AGENT_BRANCH} of puppet-agent: '#{e.message}'"
+    abort "ERROR: Could not get last passing run data for #{branch} of puppet-agent: '#{e.message}'"
   end
 
   begin
     jenkins_result_parsed = JSON.parse(jenkins_result.read)
   rescue JSON::ParserError => e
-    abort "ERROR: Could not get valid json for last passing run of #{PUPPET_AGENT_BRANCH}: '#{e.message}'"
+    abort "ERROR: Could not get valid json for last passing run of #{branch}: '#{e.message}'"
   end
 end
 
@@ -114,6 +119,21 @@ def lookup_passing_puppet_sha(my_jenkins_passing_json)
     abort "ERROR: Could not get puppet's last passing SHA for #{PUPPET_AGENT_BRANCH}\n\n  #{e}"
   end
 end
+def lookup_passing_facter_sha(my_jenkins_passing_json)
+  begin
+    my_jenkins_passing_json['facter']
+  rescue => e
+    abort "ERROR: Could not get facter's last passing SHA for #{FACTER_BRANCH}\n\n  #{e}"
+  end
+end
+
+def update_submodule(submodule_path, submodule_sha, submodule_name)
+  #  ensure we fetch here, or the describe done later could be wrong
+  git_checkout_command = "cd #{submodule_path} && git fetch origin && " \
+    "git checkout #{submodule_sha}"
+  puts("checking out known passing #{submodule_name} version in submodule: `#{git_checkout_command}`")
+  system(git_checkout_command)
+end
 
 def replace_puppet_pins(passing_puppetagent_sha)
   # read beaker options hash from its file
@@ -125,30 +145,34 @@ def replace_puppet_pins(passing_puppetagent_sha)
   File.write(BEAKER_OPTIONS_FILE, beaker_options_from_file.pretty_inspect)
 end
 
-namespace :puppet_submodule do
+namespace :dev_deps_update do
   desc 'update puppet submodule commit'
   task :update_puppet_version do
-    #  ensure we fetch here, or the describe done later could be wrong
-    my_jenkins_passing_json = jenkins_passing_json_parsed
-    git_checkout_command = "cd #{PUPPET_SUBMODULE_PATH} && git fetch origin && " \
-      "git checkout #{lookup_passing_puppet_sha(my_jenkins_passing_json)}"
-    puts("checking out known passing puppet version in submodule: `#{git_checkout_command}`")
-    system(git_checkout_command)
+    my_jenkins_passing_json = jenkins_passing_json_parsed(PUPPET_AGENT_BRANCH)
+    puppet_sha = lookup_passing_puppet_sha(my_jenkins_passing_json)
+    update_submodule(PUPPET_SUBMODULE_PATH, puppet_sha, 'puppet')
     # replace puppet-agent sha pin in beaker options file
     replace_puppet_pins(lookup_passing_puppetagent_sha(my_jenkins_passing_json))
+  end
+  desc 'update facter submodule commit'
+  task :update_facter_version do
+    my_jenkins_passing_json = jenkins_passing_json_parsed(FACTER_BRANCH)
+    facter_sha = lookup_passing_facter_sha(my_jenkins_passing_json)
+    update_submodule(FACTER_SUBMODULE_PATH, facter_sha, 'facter')
   end
   desc 'commit and push; CAUTION: WILL commit and push, upstream, local changes to the puppet submodule and acceptance options'
   task :commit_push do
     git_commit_command = "git checkout #{PUPPETSERVER_BRANCH} && git add #{PUPPET_SUBMODULE_PATH} " \
-      "&& git add #{BEAKER_OPTIONS_FILE} && git commit -m '(maint) update puppet submodule version and agent pin'"
+      "&& git add #{FACTER_SUBMODULE_PATH} && git add #{BEAKER_OPTIONS_FILE} " \
+      "&& git commit -m '(maint) update submodule versions and agent pin'"
     git_push_command = "git checkout #{PUPPETSERVER_BRANCH} && git push origin HEAD:#{PUPPETSERVER_BRANCH}"
-    puts "committing submodule and agent pin via: `#{git_commit_command}`"
+    puts "committing submodules and agent pin via: `#{git_commit_command}`"
     system(git_commit_command)
-    puts "pushing submodule and agent pin via: `#{git_push_command}`"
+    puts "pushing submodules and agent pin via: `#{git_push_command}`"
     system(git_push_command)
   end
   desc 'update puppet versions and commit and push; CAUTION: WILL commit and push, upstream, local changes to the puppet submodule and acceptance options'
-  task :update_puppet_version_w_push => [:update_puppet_version, :commit_push]
+  task :update_dev_deps_w_push => [:update_puppet_version, :update_facter_version, :commit_push]
 end
 
 namespace :spec do


### PR DESCRIPTION
This commit adds a new rake task that can be used to update the Facter
submodule commit based on the last passing version published by the
puppet-agent Jenkins pipeline.

It introduces a new variable to track which branch to pull the Facter
SHA from, because while the 6.x agent is still using Facter 3, in our
submodule we use Facter 4, because we need it to be a Ruby lib rather
than C++.

This also renames some tasks to be more descriptive of the new state, so
any automation around these tasks will need to be updated accordingly.