### PR TITLE
(SERVER-2763) Use `uri:classloader` to avoid globbing issue

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -30,9 +30,9 @@
   directory is placed into the root of the jar structure which is on the
   classpath.
 
-  See also:  http://jruby.org/apidocs/org/jruby/runtime/load/LoadService.html"
+  See also:  https://www.javadoc.io/doc/org.jruby/jruby-core/latest/org/jruby/runtime/load/LoadService.html"
 
-  "classpath:/puppetserver-lib")
+  "uri:classloader:/puppetserver-lib")
 
 (def default-http-connect-timeout
   "The default number of milliseconds that the client will wait for a connection


### PR DESCRIPTION
The upgrade to Rubygems 3 broken some of JRuby's globbing code. They
fixed the issue around `uri:classloader`, but not issues with the
`classpath` protocol, which we were using to load our Ruby code inside
puppetserver. However, it appears we can switch to using
`uri:classloader` instead, so this PR changes our loadpath addition to
use that protocol. This means that globbing against our loadpath (e.g.
when installing gem documentation) now works.