### PR TITLE
(maint) Update puppet 5 compatibilty tests

### DIFF
--- a/acceptance/lib/puppetserver/acceptance/compat_utils.rb
+++ b/acceptance/lib/puppetserver/acceptance/compat_utils.rb
@@ -15,7 +15,7 @@ class { 'simmons':
 SITEPP
   on(master, "chmod 644 #{sitepp}")
   with_puppet_running_on(master, {"master" => {"autosign" => true}}) do
-    on(agent, puppet("agent --test"), :acceptable_exit_codes => [0,2])
+    on(agent, puppet("agent --test --digest_algorithm sha256"), :acceptable_exit_codes => [0,2])
   end
 end
 

--- a/acceptance/suites/compat_tests/020_backwards_compat/binary_file_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/binary_file_test.rb
@@ -14,13 +14,14 @@ agents.each do |agent|
   end
 
   step "Validate binary-file" do
-    md5 = on(agent, "md5sum #{studio}/binary-file | awk '{print $1}'").stdout.chomp
-    assert_equal('7cfc2db80222ef224d99648716cea8e4', md5)
+    sha256 = on(agent, "sha256sum #{studio}/binary-file | awk '{print $1}'").stdout.chomp
+    assert_equal('55a26d3939c947e4455e8f48ffb4724170aa4f9aa4c8d58c57800ad2026f4d79', sha256)
   end
 
   step "Validate binary-file filebucket backup" do
-    old_md5 = on(agent, "md5sum #{studio}/binary-file-old | awk '{print $1}'").stdout.chomp
-    on(agent, puppet("filebucket restore #{studio}/binary-file-backup #{old_md5}"))
+    old_sha256 = on(agent, "sha256sum #{studio}/binary-file-old | awk '{print $1}'").stdout.chomp
+
+    on(agent, puppet("filebucket restore #{studio}/binary-file-backup --digest_algorithm sha256 #{old_sha256}"))
     diff = on(agent, "diff #{studio}/binary-file-old #{studio}/binary-file-backup").exit_code
     assert_equal(0, diff, 'binary-file was not backed up to filebucket')
   end

--- a/acceptance/suites/compat_tests/020_backwards_compat/source_file_test.rb
+++ b/acceptance/suites/compat_tests/020_backwards_compat/source_file_test.rb
@@ -19,8 +19,9 @@ agents.each do |agent|
   end
 
   step "Validate source-file filebucket backup" do
-    old_md5 = on(agent, "md5sum #{studio}/source-file-old | awk '{print $1}'").stdout.chomp
-    on(agent, puppet("filebucket restore #{studio}/source-file-backup #{old_md5}"))
+    old_sha256 = on(agent, "sha256sum #{studio}/source-file-old  | awk '{print $1}'").stdout.chomp
+
+    on(agent, puppet("filebucket restore #{studio}/source-file-backup --digest_algorithm sha256 #{old_sha256}"))
     diff = on(agent, "diff #{studio}/source-file-old #{studio}/source-file-backup").exit_code
     assert_equal(0, diff, 'source-file was not backed up to filebucket')
   end


### PR DESCRIPTION
Puppet default digest algorithm was changed to sha256
https://github.com/puppetlabs/puppet/pull/8315

This commit updates the compatibilty test to
specify the checksum explicitly as `sha256`