### PR TITLE
(PUP-10673) add simple server endpoint

### DIFF
--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -184,6 +184,11 @@
       (status-core/get-artifact-version "puppetlabs" "puppetserver")
       master-service-status-version
       (partial core/v1-status http-metrics http-client-metric-ids-for-status registry))
+     (register-status
+      "server"
+      (status-core/get-artifact-version "puppetlabs" "puppetserver")
+      master-service-status-version
+      (partial core/v1-status http-metrics http-client-metric-ids-for-status registry))
      (-> context
          (assoc :http-metrics http-metrics)
          (assoc :http-client-metric-ids-for-status http-client-metric-ids-for-status))))

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -123,7 +123,7 @@
      (is (= 200 (:status resp)))
      (let [status (json/parse-string (:body resp) true)]
 
-       (is (= #{:ca :jruby-metrics :master :puppet-profiler :status-service}
+       (is (= #{:ca :jruby-metrics :master :puppet-profiler :status-service :server}
               (set (keys status))))
 
        (is (= 1 (get-in status [:jruby-metrics :service_status_version])))

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -166,7 +166,7 @@
      (let [resp (http-get "/status/v1/services?level=debug")]
        (is (= 200 (:status resp)))
        (let [status (json/parse-string (:body resp) true)]
-         (is (= #{:ca :jruby-metrics :master :puppet-profiler :status-service}
+         (is (= #{:ca :jruby-metrics :master :puppet-profiler :status-service :server}
                 (set (keys status))))
 
          (is (= 1 (get-in status [:jruby-metrics :service_status_version])))


### PR DESCRIPTION
This commit adds `/status/v1/simple/server` endpoint
similar to `/status/v1/simple/master`

It also updates the `/status/v1/services` endpoint
with a new field `server` containing the same
information as `master`.


LE: this might do more than i thought.