### PR TITLE
(PE-30068) Log certnames that are revoked

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1339,9 +1339,10 @@
         new-crl (utils/revoke-multiple original-crl ca-private-key
                                        ca-public-key serials)]
     (write-crl new-crl cacrl)
-    (log/debug (if (= 1 serial-count)
-                 (i18n/trs "Revoked 1 certificate.")
-                 (i18n/trs "Revoked {0} certificates." serial-count)))))
+    (log/info (i18n/trsn "Revoked 1 certificate: {1}"
+                         "Revoked {0} certificates: {1}"
+                         serial-count
+                         (str/join ", " subjects)))))
 
 (schema/defn ^:always-validate set-certificate-status!
   "Sign or revoke the certificate for the given subject."


### PR DESCRIPTION
Previously, when a cert was revoked the certname was not logged. This
caused problems keeping track of what certnames were revoked. Prior to
the bulk API existing, customers had been largely able to review
revocation activity based on puppetserver-access.log. This new logging
effectively restores prior log functionality.