### PR TITLE
(maint) Stop registering server HttpClient class

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/config.rb
@@ -26,7 +26,6 @@ class Puppet::Server::Config
     end
 
     Puppet::Server::HttpClient.initialize_settings(puppet_server_config)
-    Puppet::Network::HttpPool.http_client_class = Puppet::Server::HttpClient
 
     if !puppet_server_config["use_legacy_auth_conf"]
       Puppet::Network::Authorization.authconfigloader_class =

--- a/src/ruby/puppetserver-lib/puppet/server/http_response.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/http_response.rb
@@ -39,7 +39,7 @@ class Puppet::Server::HttpResponse < Puppet::HTTP::Response
   end
 
   # Yield each header name and value. Returns an enumerator if no block is given.
-  def each_header
+  def each_header(&block)
     @java_response.get_headers.each(&block)
   end
 


### PR DESCRIPTION
We want to defer to Puppet's shim implementation for the HTTP client
class registered with the HTTP pool. This shim will adapt calls made to
the old-style HTTP client API to the new form, which will then get
passed to our client impl, which is registered as
`Puppet.runtime[:http]`.