### PR TITLE
(PUP-10656) Use json fact terminus by default

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -53,7 +53,7 @@ class Puppet::Server::PuppetConfig
 
     app_defaults = Puppet::Settings.app_defaults_for_run_mode(Puppet::Util::RunMode[:master]).
         merge({:name => "master",
-               :facts_terminus => 'yaml'})
+               :facts_terminus => 'json'})
     Puppet.settings.initialize_app_defaults(app_defaults)
 
     if push_settings_globally


### PR DESCRIPTION
This commit switches the default facter terminus from yaml to json,
which has more robust parsing support and better number handling.