### PR TITLE
(maint) Inherit from Puppet's HTTP error class for HTTPClientError

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
@@ -106,8 +106,8 @@ describe 'Puppet::Server::HttpClient' do
       describe "#{request} request" do
         subject { requests[request].call }
 
-        it 'raises a SocketError' do
-          expect { subject }.to raise_error SocketError
+        it 'raises a Puppet::HTTP::HTTPError' do
+          expect { subject }.to raise_error Puppet::HTTP::HTTPError
         end
         it 'raises a Puppet::Server::HttpClientError' do
           expect { subject }.to raise_error Puppet::Server::HttpClientError

--- a/src/ruby/puppetserver-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/http_client.rb
@@ -3,6 +3,7 @@ require 'puppet/server'
 require 'puppet/server/config'
 require 'puppet/server/http_response'
 require 'puppet/http/client'
+require 'puppet/http/errors'
 require 'base64'
 
 require 'java'
@@ -12,7 +13,7 @@ java_import com.puppetlabs.http.client.CompressType
 java_import com.puppetlabs.http.client.ResponseBodyType
 SyncHttpClient = com.puppetlabs.http.client.Sync
 
-class Puppet::Server::HttpClientError < SocketError
+class Puppet::Server::HttpClientError < Puppet::HTTP::HTTPError
   attr_reader :cause
 
   def initialize(message, cause = nil)


### PR DESCRIPTION
In order to be consistent with Puppet's API, we need the errors raised
by our HTTP client implementation to match what Puppet raises.