### PR TITLE
(SERVER-2760) Symlink new to old cadir on bootstrap

### DIFF
--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -156,6 +156,27 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
 
+(deftest symlink-cadir-test
+  (testing "does not symlink if custom cadir"
+    (let [tmpdir (ks/temp-dir)
+          cadir (str tmpdir "/foo/bar")
+          ssldir (str tmpdir "puppet/ssl")]
+      (fs/mkdirs cadir)
+      (fs/mkdirs ssldir)
+      (symlink-cadir cadir)
+      (is (not (fs/exists? (str ssldir "/ca"))))))
+  (testing "symlinks correctly and removes existing old-cadir if needed"
+    (let [tmpdir (ks/temp-dir)
+          cadir (str tmpdir "/puppetserver/ca")
+          ssldir (str tmpdir "/puppet/ssl")
+          old-cadir (str ssldir "/ca")]
+      (fs/mkdirs ssldir)
+      (fs/mkdirs cadir)
+      (symlink-cadir cadir)
+      (is (fs/link? old-cadir))
+      (let [target (-> old-cadir fs/read-sym-link str)]
+        (is (= target cadir))))))
+
 (deftest validate-settings-test
   (testing "invalid ca-ttl is rejected"
     (let [settings (assoc


### PR DESCRIPTION
Previously, was curious about why we never used the cadir setting before. I haven't found anything conclusive but I'm thinking that it was just expedient the last time it came up and prior to that we only cared about what was actually set since each setting we get that is nested inside the cadir is also independently configurable...

------------------

With Puppet 7 we want to move the cadir outside of the ssldir however we
want to symlink back to the old cadir to ease the transition. This
provide existing documentation and code to largely just work for new
users, preventing them from being able to accidentally delete their
cadir.

This commit looks at the last portion of the cadir to determine if it is
the the new default or something else while also allowing us to
substitute out the confdir/root for easy testing and switching between
running puppetserver as a regular user or as root. If the last portion
of the cadir matches the new default we will symlink back to the old
cadir location. Otherwise nothing happens.