### PR TITLE
(SERVER-2895) Bump puppetserver-ca to 2.0.0

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.9.0
+puppetserver-ca 2.0.0


### PR DESCRIPTION
This commit bumps the puppetserver-ca gem to 2.0.0, which includes the new
cadir location.