### PR TITLE
(maint) Update travis script to remove caches

### DIFF
--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -4,6 +4,10 @@ set -e
 
 echo "Total memory available: $(grep MemTotal /proc/meminfo | awk '{print $2}')"
 
+git submodule update --recursive --init
+lein clean
+rm -rf vendor
+
 ./dev/install-test-gems.sh
 
 if [ "$MULTITHREADED" = "true" ]; then


### PR DESCRIPTION
We recently had several issues with running Puppet Server's specs
locally all relating to keeping cached data around longer than
necessary.

This adds that information to our travis script, ensuring the builds in
travis and locally work similarly.