### PR TITLE
(SERVER-2925) Update JRuby 9k to 9.1.17.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def ps-version "5.3.17-SNAPSHOT")
 (def jruby-1_7-version "1.7.27-1")
-(def jruby-9k-version "9.1.16.0-1")
+(def jruby-9k-version "9.1.17.0-1")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit updates our JRuby 9k version to 9.1.17.0, which contains a
fix for a memory leak in FilenoUtil.