### PR TITLE
(SERVER-2925) Use correct build of JRuby 9.1.17.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def ps-version "5.3.17-SNAPSHOT")
 (def jruby-1_7-version "1.7.27-1")
-(def jruby-9k-version "9.1.17.0-1")
+(def jruby-9k-version "9.1.17.0-2")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This picks up an updated release of jruby-deps that correctly makes its
project.clj available top-level, to enable ezbake's dependency
resolution for additional uberjars.