### PR TITLE
(PE-30410) Do not preserve hash order for target vars

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/ast_compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/ast_compiler_spec.rb
@@ -98,12 +98,12 @@ describe Puppet::Server::ASTCompiler do
           ]
         }
         target_variables = {
-          "values" => [
+          "values" => {
             # should be shadowed by target_var_fact fact
-            {"target_var_fact" => "target_value"},
+            "target_var_fact" => "target_value",
             # should be shadowed by plan_var_plain plan variable
-            {"plan_var_plain"  => "target_value"},
-          ]
+            "plan_var_plain"  => "target_value"
+          }
         }
 
         code = <<CODE

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -894,7 +894,7 @@
    (schema/required-key "trusted_facts") {(schema/required-key "values") {schema/Str schema/Any}}
    (schema/required-key "facts") {(schema/required-key "values") {schema/Str schema/Any}}
    (schema/required-key "variables") {(schema/required-key "values") (schema/either [{schema/Str schema/Any}] {schema/Str schema/Any})}
-   (schema/optional-key "target_variables") {(schema/required-key "values") [{schema/Str schema/Any}]}
+   (schema/optional-key "target_variables") {(schema/required-key "values") {schema/Str schema/Any}}
    (schema/optional-key "job_id") schema/Str
    (schema/optional-key "transaction_uuid") schema/Str
    (schema/optional-key "options") {(schema/optional-key "capture_logs") schema/Bool

--- a/src/ruby/puppetserver-lib/puppet/server/ast_compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/ast_compiler.rb
@@ -40,7 +40,7 @@ module Puppet
           # Prior to PE-29443 variables were in a hash. Serialization between ruby/clojure/json did
           # not preserver hash order necessary for deserialization. The data strucutre is now stored
           # in a list for moving data and the list is used to construct an ordered ruby hash.
-          variables = if compile_options['variables']['values'].is_a?(Array)
+          plan_variables = if compile_options['variables']['values'].is_a?(Array)
                         compile_options['variables']['values'].each_with_object({}) do |param_hash, acc|
                           acc[param_hash.keys.first] = param_hash.values.first
                         end
@@ -48,16 +48,10 @@ module Puppet
                         compile_options['variables']['values']
                       end
 
-          target_variables = if compile_options.key?('target_variables')
-                               compile_options['target_variables']['values'].each_with_object({}) do |param_hash, acc|
-                                 acc[param_hash.keys.first] = param_hash.values.first
-                               end
-                             else
-                               {}
-                             end
+          target_variables = compile_options.dig('target_variables', 'values') || {}
 
           variables = {
-            variables: variables,
+            variables: plan_variables,
             target_variables: target_variables,
           }
 


### PR DESCRIPTION
Target vars do not need to maintain hash order. This commit updates the compile_ast endpoint to remove the complexity in keeping target vars ordered.