### PR TITLE
Use PUPPETSERVER_HOSTNAME as certname if set

### DIFF
--- a/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
+++ b/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
@@ -7,7 +7,7 @@ echo "* HOSTNAME: '${HOSTNAME}'"
 echo "* hostname -f: '$(hostname -f)'"
 if test -n "${PUPPETSERVER_HOSTNAME}"; then
   echo "* PUPPETSERVER_HOSTNAME: '${PUPPETSERVER_HOSTNAME}'"
-  certname='${PUPPETSERVER_HOSTNAME}.pem'
+  certname=${PUPPETSERVER_HOSTNAME}.pem
 else
   echo "* PUPPETSERVER_HOSTNAME: unset"
   certname=$(ls "${SSLDIR}/certs" | grep --invert-match ca.pem)

--- a/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
+++ b/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
@@ -5,9 +5,15 @@ echo "System configuration values:"
 # shellcheck disable=SC2039 # Docker injects $HOSTNAME
 echo "* HOSTNAME: '${HOSTNAME}'"
 echo "* hostname -f: '$(hostname -f)'"
-echo "* PUPPETSERVER_HOSTNAME:PUPPET_MASTERPORT: '${PUPPETSERVER_HOSTNAME}:${PUPPET_MASTERPORT}'"
-certname=$(ls "${SSLDIR}/certs" | grep --invert-match ca.pem)
-echo "* Generated certname: '${certname}'"
+if test -n "${PUPPETSERVER_HOSTNAME}"; then
+  echo "* PUPPETSERVER_HOSTNAME: '${PUPPETSERVER_HOSTNAME}'"
+  certname='${PUPPETSERVER_HOSTNAME}.pem'
+else
+  echo "* PUPPETSERVER_HOSTNAME: unset"
+  certname=$(ls "${SSLDIR}/certs" | grep --invert-match ca.pem)
+fi
+echo "* PUPPET_MASTERPORT: '${PUPPET_MASTERPORT}'"
+echo "* Certname: '${certname}'"
 echo "* DNS_ALT_NAMES: '${DNS_ALT_NAMES}'"
 echo "* SSLDIR: '${SSLDIR}'"
 


### PR DESCRIPTION
As per the documentation, PUPPETSERVER_HOSTNAME will be used to configure the `certname`. If found, use it as the `certname` when printing the config too.

Retrieving the certname from the `${SSLDIR}/certs` can lead to various problems, e.g. when that directory contains more than one certificate (if mounted from the docker host). E.g.:
```
# ls -lra /etc/puppetlabs/puppet/ssl/certs/
total 20
-rw-r--r-- 1 systemd-coredump input 2134 Sep 22 14:52 puppetserver001.domain.com.pem
-rw-r--r-- 1 systemd-coredump input 2074 Dec  2 12:00 puppetserver002.domain.com.pem
-rw-r--r-- 1 systemd-coredump input 2134 Sep 22 14:45 puppetserver002.domain.com.pem
-rw-r--r-- 1 systemd-coredump input 6010 Dec  8 19:07 ca.pem
```
# docker logs puppetserver
```
Running /docker-entrypoint.d/90-log-config.sh
System configuration values:
* HOSTNAME: 'bc36b74abe3e'
* hostname -f: 'bc36b74abe3e'
* PUPPETSERVER_HOSTNAME:PUPPET_MASTERPORT: 'puppetserver001.domain.com.pem:8140'
* Generated certname: 'puppetserver001.domain.com.pem
puppetserver002.domain.com.pem
puppetserver002.domain.com.pem'
* DNS_ALT_NAMES: 'puppet.domain.com'
* SSLDIR: '/etc/puppetlabs/puppet/ssl'
CA Certificate:
### OMITTED ###
Certificate:
Can't open /etc/puppetlabs/puppet/ssl/certs/puppetserver001.domain.com.pem
puppetserver002.domain.com.pem
puppetserver003.domain.com.pem for reading, No such file or directory
140076958831680:error:02001002:system library:fopen:No such file or directory:crypto/bio/bss_file.c:69:fopen('/etc/puppetlabs/puppet/ssl/certs/puppetserver001.domain.com.pem
puppetserver002.domain.com.pem
puppetserver003.domain.com.pem','r')
140076958831680:error:2006D080:BIO routines:BIO_new_file:no such file:crypto/bio/bss_file.c:76:
unable to load certificate
```

This essentially renders the container unusable if more than one certificate is found in `$SSLDIR`