### PR TITLE
(CPR-768) Update github workflow to build on pushes to 'main' branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker test and publish
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
I think the differences in the workflow between 6.x (the default branch)
and main (the branch we build from) was the source of the issues.

I was able to confirm on my fork that this change allowed builds to happen on push to main.