### PR TITLE
(maint) Pin r10k to latest 2.x

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -120,7 +120,7 @@ end
 
 step 'SETUP: Install and configure r10k, and perform the initial commit' do
   on master, "puppet config set server #{fqdn}"
-  on master, '/opt/puppetlabs/puppet/bin/gem install r10k'
+  on master, '/opt/puppetlabs/puppet/bin/gem install r10k -v 2.6.9'
   on master, "cd #{git_local_repo} && git checkout -b production"
   r10k_yaml=<<-R10K
 # The location to use for storing cached Git repos


### PR DESCRIPTION
Newer versions of r10k pull new versions of CRI which does not work on
the older versions of Ruby that we still must support in Server 5.x.

-----

Validated this works locally on 5.x:

```
Test Suite: tests @ 2021-01-12 16:12:42 -0800                                                           
                                                                                                              
      - Host Configuration Summary -                                                                          
                                                                                                              
                                                                                                              
              - Test Case Summary for suite 'tests' -                                                         
       Total Suite Time: 910.51 seconds                                                                       
      Average Test Time: 60.70 seconds                                                                        
              Attempted: 15                                                                                   
                 Passed: 15                                                                                   
                 Failed: 0                                                                                    
                Errored: 0                                                                                    
                Skipped: 0                                                                                    
                Pending: 0                                                                                    
                  Total: 15                                                                                   
                                                                                                              
      - Specific Test Case Status -                                                                           
                                                                                                              
Failed Tests Cases:                                                                                           
Errored Tests Cases:                                                                                          
Skipped Tests Cases:                                                                                          
Pending Tests Cases:
````

See [5.3.x smoke](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppetserver/view/all/job/platform_puppetserver_integration-system_no-conditional_smoke-5.3.x/422/LAYOUT=redhat7-64ma-64a,LDAP_TYPE=default,label=beaker/console) for the failure.