### PR TITLE
(maint) Unpin r10k

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -120,7 +120,7 @@ end
 
 step 'SETUP: Install and configure r10k, and perform the initial commit' do
   on master, "puppet config set server #{fqdn}"
-  on master, '/opt/puppetlabs/puppet/bin/gem install r10k -v 2.6.9'
+  on master, '/opt/puppetlabs/puppet/bin/gem install r10k'
   on master, "cd #{git_local_repo} && git checkout -b production"
   r10k_yaml=<<-R10K
 # The location to use for storing cached Git repos


### PR DESCRIPTION
We want to pin r10k to a version that still supports Ruby < 2.5 on the
5.x branch, but allow 6.x to float. This reverts the pin to r10k in our
acceptance tests for Puppetserver 6+.