### PR TITLE
(maint) Bump jruby hocon to 1.3.1

### DIFF
--- a/resources/ext/build-scripts/jruby-gem-list.txt
+++ b/resources/ext/build-scripts/jruby-gem-list.txt
@@ -1,5 +1,5 @@
 semantic_puppet 1.0.2
-hocon 1.2.5
+hocon 1.3.1
 text 1.3.1
 locale 2.1.2
 gettext 3.2.2

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -266,8 +266,8 @@
   (testing "Improperly URL encoded content"
     (is (thrown+? [:kind :bad-request
                    :msg (str "Unable to URL decode the x-client-cert header: "
-                             "For input string: \"1%\"")]
-                  (jruby-request-with-client-cert-header "%1%2"))))
+                             "For input string: \"1Q\"")]
+                  (jruby-request-with-client-cert-header "%1Q%2"))))
   (testing "Bad certificate content"
     (is (thrown+? [:kind :bad-request
                    :msg (str "Unable to parse x-client-cert into "


### PR DESCRIPTION
 - Includes feature from 1.2.7 to load environment variables into lists
   like:

    FOO.1
    FOO.2

    See https://github.com/puppetlabs/ruby-hocon/pull/117