### PR TITLE
(maint) Switch to using `server` instead of `master` puppet.conf section

### DIFF
--- a/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/confdir/puppet.conf
+++ b/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/confdir/puppet.conf
@@ -1,4 +1,4 @@
-[master]
+[server]
 certname = localhost
 node_terminus = exec
 external_nodes = "/bin/sh ./dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/enc.sh"

--- a/dev-resources/puppetlabs/services/master/master_service_test/confdir/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/master_service_test/confdir/puppet.conf
@@ -1,4 +1,4 @@
-[master]
+[server]
 certname = localhost
 node_terminus = exec
 facts_terminus = yaml

--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -86,7 +86,7 @@ class Puppet::Server::PuppetConfig
       Puppet.push_context(dummy_ssl_context)
     end
 
-    Puppet.settings.use :main, :master, :ssl, :metrics
+    Puppet.settings.use :main, :server, :ssl, :metrics
 
     if Puppet::Indirector::Indirection.method_defined?(:set_global_setting)
       Puppet::FileServing::Content.indirection.set_global_setting(:terminus_class, :file_server)


### PR DESCRIPTION
This commit updates the settings section we load from `master` to
`server` to avoid deprecation warnings. Puppet will make sure both
sections are always loaded, but specifying `server` instead of `master`
avoids the warning.