### PR TITLE
(maint) Remove leftover test fixtures for legacy routes test

### DIFF
--- a/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/codedir/environments/production/modules/foo/manifests/bar.pp
+++ b/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/codedir/environments/production/modules/foo/manifests/bar.pp
@@ -1,8 +1,0 @@
-class foo::bar inherits foo {
-   include foo::baz
-   notify { "Foo::Bar": }
-   $digest = digest("Foo::Bar")
-   notify { "Foo Digest":
-     message => $digest,
-   }
-}

--- a/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/codedir/environments/production/modules/foo/manifests/baz.pp
+++ b/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/codedir/environments/production/modules/foo/manifests/baz.pp
@@ -1,3 +1,0 @@
-class foo::baz {
-   notify { "FOO::BAZ!": }
-}

--- a/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/codedir/environments/production/modules/foo/manifests/init.pp
+++ b/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/codedir/environments/production/modules/foo/manifests/init.pp
@@ -1,3 +1,0 @@
-class foo inherits foo::params {
-    notify { "Foo!": }
-}

--- a/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/codedir/environments/production/modules/foo/manifests/params.pp
+++ b/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/codedir/environments/production/modules/foo/manifests/params.pp
@@ -1,3 +1,0 @@
-class foo::params {
-   $param1 = "param1!"
-}

--- a/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/confdir/puppet.conf
+++ b/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/confdir/puppet.conf
@@ -1,5 +1,0 @@
-[server]
-cadir = $confdir/ca
-certname = localhost
-node_terminus = exec
-external_nodes = "/bin/sh ./dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/enc.sh"

--- a/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/enc.sh
+++ b/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/enc.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-printf "classes:\n  foo::bar:\n"

--- a/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test/puppet.conf
@@ -1,3 +1,0 @@
-[main]
-cadir = $confdir/ca
-certname = localhost


### PR DESCRIPTION
We deleted the tests that use these a while back as part of removing the
feature for Platform 7.