### PR TITLE
(SERVER-2948) Treat ASCII-8BIT body as bytes

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -69,10 +69,16 @@ class Puppet::Server::Master
 
     body = response[:body]
     body_to_return =
-        if body.is_a? String or body.nil?
-          body
+        if body.is_a? String
+          if body.encoding == Encoding::ASCII_8BIT
+            body.to_java_bytes
+          else
+            body
+          end
         elsif body.is_a? IO
           body.to_inputstream
+        elsif body.nil?
+          body
         else
           raise "Don't know how to handle response body from puppet, which is a #{body.class}"
         end


### PR DESCRIPTION
Puppet returns binary data for some endpoints as a string encoded with
Ruby's ASCII-8BIT encoding. This encoding is unique to ruby and is
essentially meant to be treated as raw bytes. As of version 1.6.0,
ring-servlet attempts to encode the response body when it's a string
using the charset in the header, falling back to UTF-8. When we
encounter this encoding now we will convert it to a java byte array and
ring won't attempt to encode it.