### PR TITLE
(PE-30976) Pin protobuf test dep to 3.4.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -121,7 +121,12 @@
                                         [ring-basic-authentication]
                                         [ring/ring-mock]
                                         [beckon]
-                                        [com.cemerick/url "0.1.1"]]}
+                                        [com.cemerick/url "0.1.1"]
+                                        ;; Pinned to fix CVE-2015-5237, overrides what's pulled
+                                        ;; in by cemerick/url, which is unmaintained.
+                                        ;; This pin should be removed when we can rip out
+                                        ;; cemerick/url, see SERVER-2959.
+                                        [com.google.protobuf/protobuf-java "3.4.0"]]}
              :dev [:defaults
                    {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]}]
              :fips [:defaults


### PR DESCRIPTION
One of the libraries we use in testing, cemerick/url, is unmaintained
and archived. It has not been updated to pull in a non-vulnerable
version of protobuf, so this commit overrides that dependency to pull in
the fixed version.

Ultimately we should probably try to stop using cemerick/url. When that
happens, we can remove this pin as well.