### PR TITLE
(maint) Update ezbake to 2.2.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -167,7 +167,7 @@
                                                [puppetlabs/jruby-utils]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9]]
-                      :plugins [[puppetlabs/lein-ezbake "2.2.1"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.2.2"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk15on]
                                       [puppetlabs/trapperkeeper-webserver-jetty9]]


### PR DESCRIPTION
This update contains a new GPG key.