### PR TITLE
(SERVER-2558) Use puppet's copy of CRL as jetty CRL

### DIFF
--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -109,13 +109,13 @@
      (assoc config :puppet-version (.puppetVersion jruby-puppet)))))
 
 (defn init-webserver!
-  "Initialize Jetty with paths to the master's SSL certs."
+  "Initialize Jetty with paths to puppetserver's SSL certs."
   [override-webserver-settings! webserver-settings puppet-config]
-  (let [{:keys [hostcert localcacert cacrl hostprivkey]} puppet-config
+  (let [{:keys [hostcert localcacert hostcrl hostprivkey]} puppet-config
         overrides {:ssl-cert     hostcert
                    :ssl-key      hostprivkey
                    :ssl-ca-cert  localcacert
-                   :ssl-crl-path cacrl}]
+                   :ssl-crl-path hostcrl}]
     (if (some #((key %) webserver-settings) overrides)
       (log/info (i18n/trs "Not overriding webserver settings with values from core Puppet"))
       (do

--- a/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -67,6 +67,7 @@
         puppet-config        {:hostcert    "thehostcert"
                               :hostprivkey "thehostprivkey"
                               :cacrl       "thecacrl"
+                              :hostcrl     "thehostcrl"
                               :localcacert "thelocalcacert"}
         init-webserver-fn    (fn [webserver-settings]
                                (reset! settings-passed nil)
@@ -77,7 +78,7 @@
         webserver-ssl-config {:ssl-cert     "thehostcert"
                               :ssl-key      "thehostprivkey"
                               :ssl-ca-cert  "thelocalcacert"
-                              :ssl-crl-path "thecacrl"}]
+                              :ssl-crl-path "thehostcrl"}]
 
     (testing (str "no call made to override default webserver settings if "
                   "full ssl cert configuration already in webserver settings")


### PR DESCRIPTION
This commit changes the default CRL path supplied to Jetty from the CA's
to the local server's copy. This latter path, in the ssldir rather than
the CA, is present even if the CA service is disabled, because the
puppet agent will write the CRL it fetches to that location, while the
CA's copy is not always available.

This mirrors what we configure in PE, and makes setting up compilers in
FOSS easier.