### PR TITLE
(SERVER-2965) Better environment handling for v4 catalogs

### DIFF
--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -429,7 +429,7 @@
                           (compile-ast [_ _ _ _] {:cool "catalog"}))
           handler (fn ([req] {:request req}))
           app (build-ring-handler handler "1.2.3" jruby-service)]
-      (testing "catalog endpoint"
+      (testing "catalog endpoint succeeds"
           (let [response (app (-> {:request-method :post
                                    :uri "/v4/catalog"
                                    :content-type "application/json"}
@@ -439,4 +439,15 @@
                                                                 {:catalog true
                                                                  :facts true}}))))]
             (is (= 200 (:status response)))
-            (is (= {:cool "catalog"} (json/decode (:body response) true))))))))
+            (is (= {:cool "catalog"} (json/decode (:body response) true)))))
+      (testing "catalog endpoint fails with invalid environment name"
+          (let [response (app (-> {:request-method :post
+                                   :uri "/v4/catalog"
+                                   :content-type "application/json"}
+                                  (ring-mock/body (json/encode {:certname "foo"
+                                                                :environment ""
+                                                                :persistence
+                                                                {:catalog true
+                                                                 :facts true}}))))]
+            (is (= 400 (:status response)))
+            (is (re-matches #".*Invalid input:.*\"\".*" (:body response))))))))


### PR DESCRIPTION
Previously, the v4 catalong endpoint had these issues with environment
handling:
1. Would not use the environment in the body of the request for code_id
generation.
2. Did not validate environment names.

The issue was needed for feature parity with Puppet while the
first issue caused spurious warnings to be issued.