### PR TITLE
(SERVER-1061) Remove pre-suite step to redirect dujour ping

### DIFF
--- a/acceptance/suites/pre_suite/foss/85_configure_sut.rb
+++ b/acceptance/suites/pre_suite/foss/85_configure_sut.rb
@@ -1,18 +1,3 @@
-step "Prevent master nodes from checking in with dujour" do
-  manifest_path = master.tmpfile("puppetserver_manifest.pp")
-
-  manifest_content = <<-EOS
-    host { "updates.puppetlabs.com":
-    ip => '127.0.0.1',
-    ensure => 'present',
-  }
-  EOS
-
-  create_remote_file(master, manifest_path, manifest_content)
-
-  on master, puppet_apply("#{manifest_path}")
-end
-
 step "Use Java 11 on RHEL 8" do
   if master['platform'].start_with?('el-8')
     on master, 'yum install -y java-11'


### PR DESCRIPTION
Beaker has had a built-in option to configure `/etc/hosts` to redirect
update.puppetlabs.com to localhost for a long time, and it is enabled by
default. This commit removes our duplication of this configuration.