### PR TITLE
(SERVER-2867) Make server-* configs preferred to master-* variants

### DIFF
--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -57,19 +57,19 @@ jruby-puppet: {
     gem-path: [${jruby-puppet.gem-home}, ${HOME}"/.puppetlabs/opt/server/data/puppetserver/vendored-jruby-gems"]
 
     # (optional) path to puppet conf dir; if not specified, will use the puppet default
-    master-conf-dir: ${HOME}"/.puppetlabs/etc/puppet"
+    server-conf-dir: ${HOME}"/.puppetlabs/etc/puppet"
 
     # (optional) path to puppet code dir; if not specified, will use the puppet default
-    master-code-dir: ${HOME}"/.puppetlabs/etc/code"
+    server-code-dir: ${HOME}"/.puppetlabs/etc/code"
 
     # (optional) path to puppet var dir; if not specified, will use the puppet default
-    master-var-dir: ${HOME}"/.puppetlabs/opt/puppet/cache"
+    server-var-dir: ${HOME}"/.puppetlabs/opt/puppet/cache"
 
     # (optional) path to puppet run dir; if not specified, will use the puppet default
-    master-run-dir: ${HOME}"/.puppetlabs/var/run"
+    server-run-dir: ${HOME}"/.puppetlabs/var/run"
 
     # (optional) path to puppet log dir; if not specified, will use the puppet default
-    master-log-dir: ${HOME}"/.puppetlabs/var/log"
+    server-log-dir: ${HOME}"/.puppetlabs/var/log"
 
     # (optional) maximum number of JRuby instances to allow
     max-active-instances: 1

--- a/ext/thread_test/puppetserver.conf
+++ b/ext/thread_test/puppetserver.conf
@@ -56,19 +56,19 @@ jruby-puppet: {
     gem-path: [${jruby-puppet.gem-home}, ${HOME}"/.puppetlabs/opt/server/data/puppetserver/vendored-jruby-gems"]
 
     # (optional) path to puppet conf dir; if not specified, will use the puppet default
-    master-conf-dir: ${HOME}"/.puppetlabs/etc/puppet"
+    server-conf-dir: ${HOME}"/.puppetlabs/etc/puppet"
 
     # (optional) path to puppet code dir; if not specified, will use the puppet default
-    master-code-dir: "./ext/thread_test"
+    server-code-dir: "./ext/thread_test"
 
     # (optional) path to puppet var dir; if not specified, will use the puppet default
-    master-var-dir: ${HOME}"/.puppetlabs/opt/puppet/cache"
+    server-var-dir: ${HOME}"/.puppetlabs/opt/puppet/cache"
 
     # (optional) path to puppet run dir; if not specified, will use the puppet default
-    master-run-dir: ${HOME}"/.puppetlabs/var/run"
+    server-run-dir: ${HOME}"/.puppetlabs/var/run"
 
     # (optional) path to puppet log dir; if not specified, will use the puppet default
-    master-log-dir: ${HOME}"/.puppetlabs/var/log"
+    server-log-dir: ${HOME}"/.puppetlabs/var/log"
 
     # (optional) maximum number of JRuby instances to allow
     max-active-instances: 2

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -16,33 +16,33 @@ jruby-puppet: {
     # PLEASE NOTE: Use caution when modifying the below settings. Modifying
     # these settings will change the value of the corresponding Puppet settings
     # for Puppet Server, but not for the Puppet CLI tools. This likely will not
-    # be a problem with master-var-dir, master-run-dir, or master-log-dir unless
+    # be a problem with server-var-dir, server-run-dir, or server-log-dir unless
     # some critical setting in puppet.conf is interpolating the value of one
     # of the corresponding settings, but it is important that any changes made to
-    # master-conf-dir and master-code-dir are also made to the corresponding Puppet
+    # server-conf-dir and server-code-dir are also made to the corresponding Puppet
     # settings when running the Puppet CLI tools. See
     # https://docs.puppetlabs.com/puppetserver/latest/puppet_conf_setting_diffs.html#overriding-puppet-settings-in-puppet-server
     # for more information.
 
     # (optional) path to puppet conf dir; if not specified, will use
     # /etc/puppetlabs/puppet
-    master-conf-dir: /etc/puppetlabs/puppet
+    server-conf-dir: /etc/puppetlabs/puppet
 
     # (optional) path to puppet code dir; if not specified, will use
     # /etc/puppetlabs/code
-    master-code-dir: /etc/puppetlabs/code
+    server-code-dir: /etc/puppetlabs/code
 
     # (optional) path to puppet var dir; if not specified, will use
     # /opt/puppetlabs/server/data/puppetserver
-    master-var-dir: /opt/puppetlabs/server/data/puppetserver
+    server-var-dir: /opt/puppetlabs/server/data/puppetserver
 
     # (optional) path to puppet run dir; if not specified, will use
     # /var/run/puppetlabs/puppetserver
-    master-run-dir: /var/run/puppetlabs/puppetserver
+    server-run-dir: /var/run/puppetlabs/puppetserver
 
     # (optional) path to puppet log dir; if not specified, will use
     # /var/log/puppetlabs/puppetserver
-    master-log-dir: /var/log/puppetlabs/puppetserver
+    server-log-dir: /var/log/puppetlabs/puppetserver
 
     # (optional) maximum number of JRuby instances to allow
     #max-active-instances: 1

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -10,19 +10,19 @@
 
   The keys should have the following values:
 
-    * :master-conf-dir - file path to puppetmaster's conf dir;
+    * :server-conf-dir - file path to Puppet Server's conf dir;
         if not specified, will use the puppet default.
 
-    * :master-code-dir - file path to puppetmaster's code dir;
+    * :server-code-dir - file path to Puppet Server's code dir;
         if not specified, will use the puppet default.
 
-    * :master-var-dir - path to the puppetmaster's var dir;
+    * :server-var-dir - path to the Puppet Server's var dir;
         if not specified, will use the puppet default.
 
-    * :master-run-dir - path to the puppetmaster's run dir;
+    * :server-run-dir - path to the Puppet Server's run dir;
         if not specified, will use the puppet default.
 
-    * :master-log-dir - path to the puppetmaster's log dir;
+    * :server-log-dir - path to the Puppet Server's log dir;
         if not specified, will use the puppet default.
 
     * :track-lookups - a boolean to turn on tracking hiera lookups during compilation;
@@ -54,11 +54,11 @@
     * :boltlib-path - Optional array containing path(s) to bolt modules. This path
          will be prepended to AST compilation modulepath. This is required for
          compiling AST that contains bolt types."
-  {:master-conf-dir (schema/maybe schema/Str)
-   :master-code-dir (schema/maybe schema/Str)
-   :master-var-dir (schema/maybe schema/Str)
-   :master-run-dir (schema/maybe schema/Str)
-   :master-log-dir (schema/maybe schema/Str)
+  {(schema/optional-key :server-conf-dir) (schema/maybe schema/Str)
+   (schema/optional-key :server-code-dir) (schema/maybe schema/Str)
+   (schema/optional-key :server-var-dir) (schema/maybe schema/Str)
+   (schema/optional-key :server-run-dir) (schema/maybe schema/Str)
+   (schema/optional-key :server-log-dir) (schema/maybe schema/Str)
    (schema/optional-key :track-lookups) schema/Bool
    (schema/optional-key :disable-i18n) schema/Bool
    :http-client-ssl-protocols [schema/Str]
@@ -67,5 +67,12 @@
    :http-client-idle-timeout-milliseconds schema/Int
    :http-client-metrics-enabled schema/Bool
    :max-requests-per-instance schema/Int
-   (schema/optional-key :boltlib-path) [schema/Str]})
+   (schema/optional-key :boltlib-path) [schema/Str]
+   ;; Deprecated in favor of their `server-*` counterparts.
+   ;; to be removed in Puppet 8.
+   (schema/optional-key :master-conf-dir) (schema/maybe schema/Str)
+   (schema/optional-key :master-code-dir) (schema/maybe schema/Str)
+   (schema/optional-key :master-var-dir) (schema/maybe schema/Str)
+   (schema/optional-key :master-run-dir) (schema/maybe schema/Str)
+   (schema/optional-key :master-log-dir) (schema/maybe schema/Str)})
 

--- a/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
@@ -15,11 +15,11 @@
      app {}
      (is (true? true))
      (testing "Private keys have the correct permissions."
-       (let [pk-dir (str bootstrap/master-conf-dir "/ssl/private_keys")
+       (let [pk-dir (str bootstrap/server-conf-dir "/ssl/private_keys")
              pks (fs/find-files pk-dir #".*pem$")]
          (is (= ca/private-key-dir-perms (ca/get-file-perms pk-dir)))
          (is (= ca/private-key-perms
-                (ca/get-file-perms (str bootstrap/master-conf-dir
+                (ca/get-file-perms (str bootstrap/server-conf-dir
                                         "/ca/ca_key.pem"))))
          (doseq [pk pks]
            (is (= ca/private-key-perms (ca/get-file-perms (.getPath pk)))))))

--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -24,20 +24,20 @@
 (def logging-test-conf-file
   "./dev-resources/logback-test.xml")
 
-(def master-conf-dir
-  "./target/master-conf")
+(def server-conf-dir
+  "./target/server-conf")
 
-(def master-code-dir
-  "./target/master-code")
+(def server-code-dir
+  "./target/server-code")
 
-(def master-var-dir
-  "./target/master-var")
+(def server-var-dir
+  "./target/server-var")
 
-(def master-run-dir
-  "./target/master-var/run")
+(def server-run-dir
+  "./target/server-var/run")
 
-(def master-log-dir
-  "./target/master-var/log")
+(def server-log-dir
+  "./target/server-var/log")
 
 (def multithreaded
   (= "true" (System/getenv "MULTITHREADED")))
@@ -48,11 +48,11 @@
     (fs/copy dev-config-file tmp-conf)
     (-> (tk-config/load-config (.getPath tmp-conf))
         (assoc-in [:global :logging-config] logging-test-conf-file)
-        (assoc-in [:jruby-puppet :master-conf-dir] master-conf-dir)
-        (assoc-in [:jruby-puppet :master-code-dir] master-code-dir)
-        (assoc-in [:jruby-puppet :master-var-dir] master-var-dir)
-        (assoc-in [:jruby-puppet :master-run-dir] master-run-dir)
-        (assoc-in [:jruby-puppet :master-log-dir] master-log-dir)
+        (assoc-in [:jruby-puppet :server-conf-dir] server-conf-dir)
+        (assoc-in [:jruby-puppet :server-code-dir] server-code-dir)
+        (assoc-in [:jruby-puppet :server-var-dir] server-var-dir)
+        (assoc-in [:jruby-puppet :server-run-dir] server-run-dir)
+        (assoc-in [:jruby-puppet :server-log-dir] server-log-dir)
         (assoc-in [:jruby-puppet :multithreaded] multithreaded)
         (ks/deep-merge overrides))))
 
@@ -175,14 +175,14 @@
 
 (schema/defn get-ca-cert-for-running-server :- ca/Certificate
   []
-  (ssl-utils/pem->cert "./target/master-conf/ca/ca_crt.pem"))
+  (ssl-utils/pem->cert "./target/server-conf/ca/ca_crt.pem"))
 
 (schema/defn get-cert-signed-by-ca-for-running-server
   :- (schema/pred ssl-simple/ssl-cert?)
   [ca-cert :- ca/Certificate
    certname :- schema/Str]
   (let [ca-private-key (ssl-utils/pem->private-key
-                        (str "./target/master-conf/ca/ca_key.pem"))
+                        (str "./target/server-conf/ca/ca_key.pem"))
         ca-dn (-> ca-cert
                   (.getSubjectX500Principal)
                   (.getName))

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -47,7 +47,7 @@
 ;;; Default settings
 
 (schema/def ^:always-validate conf-dir :- schema/Str
-  "./target/master-conf")
+  "./target/server-conf")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Certificates and keys
@@ -369,7 +369,7 @@
   "This function returns a test fixture that will copy a specified puppet.conf
   file into the provided location for testing, and then delete it after the
   tests have completed. If no destination dir is provided then the puppet.conf
-  file is copied to the default location of './target/master-conf'."
+  file is copied to the default location of './target/server-conf'."
   ([puppet-conf-file]
    (with-puppet-conf puppet-conf-file conf-dir))
   ([puppet-conf-file dest-dir]

--- a/test/integration/puppetlabs/services/jruby/class_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/class_info_test.clj
@@ -94,8 +94,8 @@
           conf-dir (ks/temp-dir)
           config (jruby-testutils/jruby-puppet-tk-config
                   (jruby-testutils/jruby-puppet-config
-                   {:master-code-dir (.getAbsolutePath code-dir)
-                    :master-conf-dir (.getAbsolutePath conf-dir)}))]
+                   {:server-code-dir (.getAbsolutePath code-dir)
+                    :server-conf-dir (.getAbsolutePath conf-dir)}))]
 
       (tk-bootstrap/with-app-with-config
        app

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -560,7 +560,7 @@
        (try
          (testing "Various data types"
            (is (= "ldap" (.getSetting jruby-puppet "ldapserver")))
-           (is (= 8140 (.getSetting jruby-puppet "masterport")))
+           (is (= 8140 (.getSetting jruby-puppet "serverport")))
            (is (= false (.getSetting jruby-puppet "onetime"))))
          (finally
            (jruby-testutils/return-instance jruby-service jruby-instance :settings-plumbed-test)))))))

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -526,11 +526,11 @@
        {:ruby-load-path  jruby-testutils/ruby-load-path
         :gem-home        jruby-testutils/gem-home
         :gem-path        jruby-testutils/gem-path
-        :master-conf-dir jruby-testutils/conf-dir
-        :master-code-dir jruby-testutils/code-dir
-        :master-var-dir  jruby-testutils/var-dir
-        :master-run-dir  jruby-testutils/run-dir
-        :master-log-dir  jruby-testutils/log-dir}))
+        :server-conf-dir jruby-testutils/conf-dir
+        :server-code-dir jruby-testutils/code-dir
+        :server-var-dir  jruby-testutils/var-dir
+        :server-run-dir  jruby-testutils/run-dir
+        :server-log-dir  jruby-testutils/log-dir}))
      (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
            jruby-instance (jruby-testutils/borrow-instance jruby-service :test)
            jruby-puppet (:jruby-puppet jruby-instance)]
@@ -579,11 +579,11 @@
               {:ruby-load-path   jruby-testutils/ruby-load-path
                :gem-home         jruby-testutils/gem-home
                :gem-path         jruby-testutils/gem-path
-               :master-conf-dir  jruby-testutils/conf-dir
-               :master-code-dir  jruby-testutils/code-dir
-               :master-var-dir   jruby-testutils/var-dir
-               :master-run-dir   jruby-testutils/run-dir
-               :master-log-dir   jruby-testutils/log-dir}
+               :server-conf-dir  jruby-testutils/conf-dir
+               :server-code-dir  jruby-testutils/code-dir
+               :server-var-dir   jruby-testutils/var-dir
+               :server-run-dir   jruby-testutils/run-dir
+               :server-log-dir   jruby-testutils/log-dir}
               (tk-config/load-config (.getPath tmp-conf))))))
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
             jruby-instance (jruby-testutils/borrow-instance jruby-service :test)

--- a/test/integration/puppetlabs/services/jruby/module_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/module_info_test.clj
@@ -41,8 +41,8 @@
           conf-dir (ks/temp-dir)
           config (jruby-testutils/jruby-puppet-tk-config
                   (jruby-testutils/jruby-puppet-config
-                   {:master-code-dir (.getAbsolutePath code-dir)
-                    :master-conf-dir (.getAbsolutePath conf-dir)}))]
+                   {:server-code-dir (.getAbsolutePath code-dir)
+                    :server-conf-dir (.getAbsolutePath conf-dir)}))]
 
       (tk-bootstrap/with-app-with-config
        app

--- a/test/integration/puppetlabs/services/jruby/request_handler_test.clj
+++ b/test/integration/puppetlabs/services/jruby/request_handler_test.clj
@@ -28,7 +28,7 @@
 (deftest ^:integration file-bucket-test
   (testing "that a file bucket upload with *binary*, non-UTF-8, content is
             successful (SERVER-269)"
-    (let [bucket-dir (str bootstrap/master-var-dir "/bucket")]
+    (let [bucket-dir (str bootstrap/server-var-dir "/bucket")]
       (fs/delete-dir bucket-dir)
       (bootstrap/with-puppetserver-running
         app

--- a/test/integration/puppetlabs/services/jruby/tasks_test.clj
+++ b/test/integration/puppetlabs/services/jruby/tasks_test.clj
@@ -21,8 +21,8 @@
   [code-dir :- File, conf-dir :- File]
   (jruby-testutils/jruby-puppet-tk-config
    (jruby-testutils/jruby-puppet-config
-    {:master-code-dir (.getAbsolutePath code-dir)
-     :master-conf-dir (.getAbsolutePath conf-dir)})))
+    {:server-code-dir (.getAbsolutePath code-dir)
+     :server-conf-dir (.getAbsolutePath conf-dir)})))
 
 (def puppet-conf-file-contents
   "[main]\nenvironment_timeout=0\nbasemodulepath=$codedir/modules\n")
@@ -67,7 +67,7 @@
 
   This function exists in addition to the tasks-generating utilities in
   puppetlabs.puppetserver.testutils primarily because those other utilites only
-  generate things inside a hardcoded conf-dir at 'target/master-conf'."
+  generate things inside a hardcoded conf-dir at 'target/server-conf'."
   [env-dir :- (schema/cond-pre File schema/Str)
    task :- TaskOptions]
   (let [task-name (:name task)
@@ -97,7 +97,7 @@
 
   This function exists in addition to the tasks-generating utilities in
   puppetlabs.puppetserver.testutils primarily because those other utilites only
-  generate things inside a hardcoded conf-dir at 'target/master-conf'."
+  generate things inside a hardcoded conf-dir at 'target/server-conf'."
   [env-dir tasks]
   (dorun (map (partial gen-empty-task env-dir) tasks)))
 

--- a/test/integration/puppetlabs/services/master/master_service_test.clj
+++ b/test/integration/puppetlabs/services/master/master_service_test.clj
@@ -95,8 +95,8 @@
      app
      {:jruby-puppet {:gem-path gem-path
                      :max-active-instances 1
-                     :master-code-dir test-resources-code-dir
-                     :master-conf-dir master-service-test-runtime-dir}
+                     :server-code-dir test-resources-code-dir
+                     :server-conf-dir master-service-test-runtime-dir}
       :metrics {:server-id "localhost"}}
      ;; mostly just making sure we can get here w/o exception
      (is (true? true))
@@ -234,8 +234,8 @@
      app
      {:jruby-puppet {:gem-path gem-path
                      :max-active-instances 1
-                     :master-code-dir test-resources-code-dir
-                     :master-conf-dir master-service-test-runtime-dir}
+                     :server-code-dir test-resources-code-dir
+                     :server-conf-dir master-service-test-runtime-dir}
       :metrics {:server-id "localhost"}}
      (let [jruby-metrics-service (tk-app/get-service app :JRubyMetricsService)
            svc-context (tk-services/service-context jruby-metrics-service)
@@ -319,7 +319,7 @@
         (bootstrap-testutils/with-puppetserver-running
          app
          {:jruby-puppet {:gem-path gem-path
-                         :master-conf-dir ca-files-test-runtime-dir
+                         :server-conf-dir ca-files-test-runtime-dir
                          :max-active-instances 1}
           :webserver {:port 8081}}
          (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
@@ -351,8 +351,8 @@
              :registries {:puppetserver
                           {:reporters {:graphite {:enabled true}}}}}
    :jruby-puppet {:gem-path gem-path
-                  :master-code-dir test-resources-code-dir
-                  :master-conf-dir master-service-test-runtime-dir}})
+                  :server-code-dir test-resources-code-dir
+                  :server-conf-dir master-service-test-runtime-dir}})
 
 (defn get-puppetserver-registry-context
       [app]
@@ -608,8 +608,8 @@
              test-service)
        {:jruby-puppet {:gem-path gem-path
                        :max-active-instances 1
-                       :master-code-dir test-resources-code-dir
-                       :master-conf-dir master-service-test-runtime-dir}
+                       :server-code-dir test-resources-code-dir
+                       :server-conf-dir master-service-test-runtime-dir}
         :metrics {:server-id "localhost"}}
        (testing "atom has correct metric-ids"
          (let [master-service (tk-app/get-service app :MasterService)
@@ -663,8 +663,8 @@
      app
      {:jruby-puppet {:gem-path gem-path
                      :max-active-instances 2 ; we need 2 jruby-instances since processing the report uses an instance
-                     :master-code-dir test-resources-code-dir
-                     :master-conf-dir master-service-test-runtime-dir}
+                     :server-code-dir test-resources-code-dir
+                     :server-conf-dir master-service-test-runtime-dir}
       :metrics {:server-id "localhost"}}
      (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
            jruby-instance (jruby-testutils/borrow-instance jruby-service :http-report-processor-metrics-test)
@@ -700,7 +700,7 @@
      _
      {:jruby-puppet {:gem-path gem-path
                      :max-active-instances 1
-                     :master-conf-dir master-service-test-runtime-dir}}
+                     :server-conf-dir master-service-test-runtime-dir}}
      ;; SERVER-1954 - In bidi 1.25.0 and later, %20 in a URL would cause a 500 to be raised here instead
      (let [resp (http-get "/puppet/v3/enviro%20nment")]
        (is (= 404 (:status resp)))))))
@@ -710,9 +710,9 @@
    app
    {:jruby-puppet {:gem-path gem-path
                    :max-active-instances 2 ; we need 2 jruby-instances since processing the upload uses an instance
-                   :master-code-dir test-resources-code-dir
-                   :master-conf-dir master-service-test-runtime-dir
-                   :master-var-dir (fs/tmpdir)}}
+                   :server-code-dir test-resources-code-dir
+                   :server-conf-dir master-service-test-runtime-dir
+                   :server-var-dir (fs/tmpdir)}}
    (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
          jruby-instance (jruby-testutils/borrow-instance jruby-service :facts-upload-endpoint-test)
          container (:scripting-container jruby-instance)]
@@ -742,9 +742,9 @@
                    :max-active-instances 1
                    :max-retry-delay 1800
                    :max-queued-requests 1
-                   :master-code-dir test-resources-code-dir
-                   :master-conf-dir master-service-test-runtime-dir
-                   :master-var-dir (fs/tmpdir)}}
+                   :server-code-dir test-resources-code-dir
+                   :server-conf-dir master-service-test-runtime-dir
+                   :server-var-dir (fs/tmpdir)}}
    (let [metrics-svc (tk-app/get-service app :JRubyMetricsService)
          metrics (jruby-metrics/get-metrics metrics-svc)
          _ (swap! (:requested-instances metrics) assoc :foo "bar" :baz "bar")]
@@ -766,8 +766,8 @@
             :projects-dir "./dev-resources/puppetlabs/services/master/master_core_test/bolt_projects"}
      :jruby-puppet {:gem-path gem-path
                     :max-active-instances 1
-                    :master-code-dir test-resources-code-dir
-                    :master-conf-dir master-service-test-runtime-dir}}
+                    :server-code-dir test-resources-code-dir
+                    :server-conf-dir master-service-test-runtime-dir}}
 
     (testing "can retrieve file_content from the modules mount from a project"
       (let [response (http-get "/puppet/v3/file_content/modules/utilities/etc/greeting?versioned_project=local_23")]

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -17,7 +17,7 @@
            config (-> (jruby-testutils/jruby-puppet-tk-config
                        (jruby-testutils/jruby-puppet-config
                         {:max-active-instances 1}))
-                      (assoc-in [:jruby-puppet :master-conf-dir]
+                      (assoc-in [:jruby-puppet :server-conf-dir]
                                 puppet-conf-dir)
                       (assoc :puppet {"vardir" (str puppet-conf-dir "/var")}))]
        (tk-testutils/with-app-with-config

--- a/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -15,8 +15,8 @@
 
 (deftest ^:integration test-puppet-config-values
   (let [jruby-config (-> (jruby-testutils/jruby-puppet-config)
-                         (update :master-conf-dir #(str (fs/normalized %)))
-                         (update :master-code-dir #(str (fs/normalized %))))]
+                         (update :server-conf-dir #(str (fs/normalized %)))
+                         (update :server-code-dir #(str (fs/normalized %))))]
     (tk-bootstrap/with-app-with-config
      app
      jruby-testutils/jruby-service-and-dependencies

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -30,7 +30,7 @@
   (-> (jruby-testutils/jruby-puppet-tk-config
         (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))
       (assoc :webserver {:port 8081})
-      (assoc-in [:jruby-puppet :master-conf-dir]
+      (assoc-in [:jruby-puppet :server-conf-dir]
                 (str test-resources-dir "/master/conf"))))
 
 (deftest config-service-functions
@@ -45,11 +45,11 @@
             service-config (get-config service)]
 
         (is (= (-> (:jruby-puppet service-config)
-                   (dissoc :master-conf-dir)
+                   (dissoc :server-conf-dir)
                    (dissoc :profiler-output-file))
                (-> (:jruby-puppet (jruby-testutils/jruby-puppet-tk-config
                                     (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))
-                   (dissoc :master-conf-dir)
+                   (dissoc :server-conf-dir)
                    (dissoc :profiler-output-file))))
         (is (= (:webserver service-config) {:port 8081}))
         (is (= (:my-config service-config) {:foo "bar"}))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -64,28 +64,41 @@
       (is (= false (:http-client-metrics-enabled initialized-config)))))
 
   (testing "jruby-puppet values are not overridden by defaults"
-    (let [jruby-puppet-config {:master-run-dir "one"
-                               :master-var-dir "two"
-                               :master-conf-dir "three"
-                               :master-log-dir "four"
-                               :master-code-dir "five"}
+    (let [jruby-puppet-config {:server-run-dir "one"
+                               :server-var-dir "two"
+                               :server-conf-dir "three"
+                               :server-log-dir "four"
+                               :server-code-dir "five"}
           initialized-config (jruby-puppet-core/initialize-puppet-config {} jruby-puppet-config true)]
-      (is (= "one" (:master-run-dir initialized-config)))
-      (is (= "two" (:master-var-dir initialized-config)))
-      (is (= "three" (:master-conf-dir initialized-config)))
-      (is (= "four" (:master-log-dir initialized-config)))
-      (is (= "five" (:master-code-dir initialized-config)))
+      (is (= "one" (:server-run-dir initialized-config)))
+      (is (= "two" (:server-var-dir initialized-config)))
+      (is (= "three" (:server-conf-dir initialized-config)))
+      (is (= "four" (:server-log-dir initialized-config)))
+      (is (= "five" (:server-code-dir initialized-config)))
       (is (= true (:disable-i18n initialized-config)))))
 
   (testing "jruby-puppet values are set to defaults if not provided"
     (let [initialized-config (jruby-puppet-core/initialize-puppet-config {} {} false)]
-      (is (= "/var/run/puppetlabs/puppetserver" (:master-run-dir initialized-config)))
-      (is (= "/opt/puppetlabs/server/data/puppetserver" (:master-var-dir initialized-config)))
-      (is (= "/etc/puppetlabs/puppet" (:master-conf-dir initialized-config)))
-      (is (= "/var/log/puppetlabs/puppetserver" (:master-log-dir initialized-config)))
-      (is (= "/etc/puppetlabs/code" (:master-code-dir initialized-config)))
+      (is (= "/var/run/puppetlabs/puppetserver" (:server-run-dir initialized-config)))
+      (is (= "/opt/puppetlabs/server/data/puppetserver" (:server-var-dir initialized-config)))
+      (is (= "/etc/puppetlabs/puppet" (:server-conf-dir initialized-config)))
+      (is (= "/var/log/puppetlabs/puppetserver" (:server-log-dir initialized-config)))
+      (is (= "/etc/puppetlabs/code" (:server-code-dir initialized-config)))
       (is (= false (:disable-i18n initialized-config)))
-      (is (= true (:http-client-metrics-enabled initialized-config))))))
+      (is (= true (:http-client-metrics-enabled initialized-config)))))
+
+  (testing "jruby-puppet server-* prefer master-* variants to default values"
+    (let [initialized-config (jruby-puppet-core/initialize-puppet-config
+                              {}
+                              {:master-conf-dir "/etc/puppetlabs/puppetserver"
+                               :master-code-dir "/etc/puppetlabs/puppetserver/code"
+                               :master-log-dir "/log/foo"}
+                              false)]
+      (is (= "/var/run/puppetlabs/puppetserver" (:server-run-dir initialized-config)))
+      (is (= "/opt/puppetlabs/server/data/puppetserver" (:server-var-dir initialized-config)))
+      (is (= "/etc/puppetlabs/puppetserver" (:server-conf-dir initialized-config)))
+      (is (= "/log/foo" (:server-log-dir initialized-config)))
+      (is (= "/etc/puppetlabs/puppetserver/code" (:server-code-dir initialized-config))))))
 
 (deftest create-jruby-config-test
   (testing "provided values are not overriden"

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -31,11 +31,11 @@
 (def gem-home "./target/jruby-gem-home")
 (def gem-path "./target/jruby-gem-home:./target/vendored-jruby-gems")
 
-(def conf-dir "./target/master-conf")
-(def code-dir "./target/master-code")
-(def var-dir "./target/master-var")
-(def run-dir "./target/master-var/run")
-(def log-dir "./target/master-var/log")
+(def conf-dir "./target/server-conf")
+(def code-dir "./target/server-code")
+(def var-dir "./target/server-var")
+(def run-dir "./target/server-var/run")
+(def log-dir "./target/server-var/log")
 
 (def multithreaded
   (= "true" (System/getenv "MULTITHREADED")))
@@ -150,11 +150,11 @@ create-mock-pool-instance :- JRubyInstance
    (let [combined-configs
          (merge (jruby-puppet-core/initialize-puppet-config
                  {}
-                 {:master-conf-dir conf-dir
-                  :master-code-dir code-dir
-                  :master-var-dir var-dir
-                  :master-run-dir run-dir
-                  :master-log-dir log-dir}
+                 {:server-conf-dir conf-dir
+                  :server-code-dir code-dir
+                  :server-var-dir var-dir
+                  :server-run-dir run-dir
+                  :server-log-dir log-dir}
                  false)
                 (jruby-core/initialize-config {:ruby-load-path ruby-load-path
                                                :gem-home gem-home
@@ -218,11 +218,11 @@ create-mock-pool-instance :- JRubyInstance
   mock-puppet-config-settings :- {schema/Str schema/Any}
   "Return a map of settings that mock the settings that core Ruby Puppet
   would return via a call to JRubyPuppet.getSetting()."
-  [jruby-puppet-config :- {:master-conf-dir schema/Str
-                           :master-code-dir schema/Str
+  [jruby-puppet-config :- {:server-conf-dir schema/Str
+                           :server-code-dir schema/Str
                            schema/Keyword schema/Any}]
   (let [certname "localhost"
-        confdir (:master-conf-dir jruby-puppet-config)
+        confdir (:server-conf-dir jruby-puppet-config)
         ssldir (str confdir "/ssl")
         certdir (str ssldir "/certs")
         cadir (str confdir "/ca")
@@ -240,7 +240,7 @@ create-mock-pool-instance :- JRubyInstance
      "certdir" certdir
      "certname" certname
      "cert_inventory" (str cadir "/inventory.txt")
-     "codedir" (:master-code-dir jruby-puppet-config)
+     "codedir" (:server-code-dir jruby-puppet-config)
      "csr_attributes" (str confdir "/csr_attributes.yaml")
      "csrdir" (str cadir "/requests")
      "dns_alt_names" ""


### PR DESCRIPTION
This creates new server-* variants of the existing master-* config
names (master-conf-dir, master-code-dir, etc). When resolving values
we will prefer the new setting, the old setting, then the default.

This updates the default config files shipped with Puppet Server to use
the new setting names. It also updates the variable names containing the
default values in code. This updates the tests to use the new names,
changes the name of the variables that hold their test values, and in
select cases changes the names of the test directories from `master` to
`server` (only for the autogenerated test directiories, not the
fixtures).
