### PR TITLE
(SERVER-2870) Update Puppet APIs that use master

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/auth_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/auth_config.rb
@@ -6,7 +6,7 @@
 
 class Puppet::Server::AuthConfig
   def initialize
-    Puppet.debug 'Using PuppetServer AuthConfig for master routes'
+    Puppet.debug 'Using PuppetServer AuthConfig for server routes'
   end
 
   def check_authorization(method, path, params)

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -3,6 +3,7 @@ require 'puppet/server'
 require 'puppet/info_service'
 
 require 'puppet/network/http'
+# TODO: In Puppet 8, require the "server" vesion of this path
 require 'puppet/network/http/api/master/v3'
 require 'puppet/node/facts'
 
@@ -37,12 +38,14 @@ class Puppet::Server::Master
     Puppet::Server::Config.initialize_puppet_server(puppet_server_config)
     Puppet::Server::PuppetConfig.initialize_puppet(puppet_config: puppet_config)
     # Tell Puppet's network layer which routes we are willing to handle - which is
-    # the master routes, not the CA routes.
-    master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/")
-    master_routes = Puppet::Network::HTTP::Route.path(master_prefix).
+    # the server routes, not the CA routes.
+    # There are SERVER variants of this constant in Puppet > 7.4, but we should
+    # continue to use this one until Puppet 8 for backwards compatibility.
+    server_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/")
+    server_routes = Puppet::Network::HTTP::Route.path(server_prefix).
                           any.
                           chain(Puppet::Network::HTTP::API::Master::V3.routes)
-    register([master_routes])
+    register([server_routes])
     @env_loader = Puppet.lookup(:environments)
     @transports_loader = Puppet::Util::Autoload.new(self, "puppet/transport/schema")
     @catalog_compiler = Puppet::Server::Compiler.new

--- a/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/puppet_config.rb
@@ -102,7 +102,7 @@ class Puppet::Server::PuppetConfig
       Puppet::Node.indirection.cache_class = Puppet[:node_cache_terminus]
     end
 
-    Puppet::ApplicationSupport.configure_indirector_routes("master")
+    Puppet::ApplicationSupport.configure_indirector_routes("server")
 
     oid_defns = Puppet::SSL::Oids.parse_custom_oid_file(Puppet[:trusted_oid_mapping_file])
     if oid_defns


### PR DESCRIPTION
This work was to update Puppet Server to ensure all the modern
non-harmful terminology APIs were being used. However, some terminology
in Puppet around routing was missed in the 7.0 release. This changes as
much terminology as possible while commenting as to why the rest hasn't
changed.