### PR TITLE
(maint) Make server-* configs available at master-*

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -196,20 +196,20 @@
                              default-http-socket-timeout))
                  (assoc :http-client-metrics-enabled
                         (get http-config :metrics-enabled default-http-metrics-enabled))
-                 (update-in [:master-conf-dir] #(or % default-server-conf-dir))
-                 (update-in [:master-var-dir] #(or % default-server-var-dir))
-                 (update-in [:master-code-dir] #(or % default-server-code-dir))
-                 (update-in [:master-run-dir] #(or % default-server-run-dir))
-                 (update-in [:master-log-dir] #(or % default-server-log-dir))
+                 (update-in [:server-conf-dir] #(or % (:master-conf-dir jruby-puppet-config) default-server-conf-dir))
+                 (update-in [:server-var-dir] #(or % (:master-var-dir jruby-puppet-config) default-server-var-dir))
+                 (update-in [:server-code-dir] #(or % (:master-code-dir jruby-puppet-config) default-server-code-dir))
+                 (update-in [:server-run-dir] #(or % (:master-run-dir jruby-puppet-config) default-server-run-dir))
+                 (update-in [:server-log-dir] #(or % (:master-log-dir jruby-puppet-config) default-server-log-dir))
                  (update-in [:max-requests-per-instance] #(or % 0))
                  (assoc :disable-i18n multithreaded)
                  (dissoc :environment-class-cache-enabled))]
-    (-> config
-      (update-in [:server-conf-dir] #(or % (:master-conf-dir config)))
-      (update-in [:server-var-dir] #(or % (:master-var-dir config)))
-      (update-in [:server-code-dir] #(or % (:master-code-dir config)))
-      (update-in [:server-run-dir] #(or % (:master-run-dir config)))
-      (update-in [:server-log-dir] #(or % (:master-log-dir config))))))
+    (assoc config
+           :master-conf-dir (:server-conf-dir config)
+           :master-var-dir (:server-var-dir config)
+           :master-code-dir (:server-code-dir config)
+           :master-run-dir (:server-run-dir config)
+           :master-log-dir (:server-log-dir config))))
 
 (schema/defn create-jruby-config :- jruby-schemas/JRubyConfig
   "Handles creating a valid JRubyConfig map for use in the jruby-puppet-service.

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -98,7 +98,19 @@
       (is (= "/opt/puppetlabs/server/data/puppetserver" (:server-var-dir initialized-config)))
       (is (= "/etc/puppetlabs/puppetserver" (:server-conf-dir initialized-config)))
       (is (= "/log/foo" (:server-log-dir initialized-config)))
-      (is (= "/etc/puppetlabs/puppetserver/code" (:server-code-dir initialized-config))))))
+      (is (= "/etc/puppetlabs/puppetserver/code" (:server-code-dir initialized-config)))))
+  (testing "still provides proper values at master-* variants"
+    (let [initialized-config (jruby-puppet-core/initialize-puppet-config
+                               {}
+                               {:master-conf-dir "/my/master/conf"
+                                :server-code-dir "/my/server/code"}
+                               false)]
+      (is (= "/my/master/conf" (:master-conf-dir initialized-config)))
+      (is (= "/my/master/conf" (:server-conf-dir initialized-config)))
+      (is (= "/my/server/code" (:server-code-dir initialized-config)))
+      (is (= "/my/server/code" (:master-code-dir initialized-config)))
+      (is (= "/var/run/puppetlabs/puppetserver" (:server-run-dir initialized-config)))
+      (is (= "/var/run/puppetlabs/puppetserver" (:master-run-dir initialized-config))))))
 
 (deftest create-jruby-config-test
   (testing "provided values are not overriden"


### PR DESCRIPTION
When we moved to prefering server-* config variants we did not set
master-* variants if the server-* variants were set first. This will
cause a regression in those who programmatically use our config.

This should only cause issues for those who load puppetserver as a
library, which may only be pe-puppetserver-extensions.

This patch resolves server-* variants as usual and then sets the
master-* variants to the equivalent server-* values.