### PR TITLE
(SERVER-2941) Remove unused jackson-afterburner dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,6 @@
                  [liberator]
                  [org.apache.commons/commons-exec]
                  [io.dropwizard.metrics/metrics-core]
-                 [com.fasterxml.jackson.module/jackson-module-afterburner]
 
                  ;; We do not currently use this dependency directly, but
                  ;; we have documentation that shows how users can use it to


### PR DESCRIPTION
We pulled in this dependency when we though we were going to use
multijson/jrjackson for JSON parsing. When that wound up not being
feasible, we gave up on that effort, but left this dependency in. This
commit removes it.