### PR TITLE
(maint) Add single catalog compile script

### DIFF
--- a/ext/thread_test/environments/funky/manifests/init.pp
+++ b/ext/thread_test/environments/funky/manifests/init.pp
@@ -1,8 +1,8 @@
-notify {'hello': }
+notify { 'hello': }
 
 notify { threader::doit(): }
 
-notify { threader::futurist(): }
+notify { threader::color(): }
 
 notify { oldschool(): }
 

--- a/ext/thread_test/environments/funky/modules/threader/lib/puppet/functions/threader/color.rb
+++ b/ext/thread_test/environments/funky/modules/threader/lib/puppet/functions/threader/color.rb
@@ -1,0 +1,8 @@
+Puppet::Functions.create_function(:'threader::color') do
+  dispatch :color do
+  end
+
+  def color
+    "The funky color is #{Puppet[:color]}"
+  end
+end

--- a/ext/thread_test/environments/funky/modules/threader/lib/puppet/functions/threader/futurist.rb
+++ b/ext/thread_test/environments/funky/modules/threader/lib/puppet/functions/threader/futurist.rb
@@ -1,9 +1,0 @@
-Puppet::Functions.create_function(:'threader::futurist') do
-  dispatch :futurist do
-  end
-
-  def futurist
-    Puppet[:future_features] = true
-    "The funky future is #{Puppet[:future_features]}"
-  end
-end

--- a/ext/thread_test/environments/production/manifests/init.pp
+++ b/ext/thread_test/environments/production/manifests/init.pp
@@ -1,9 +1,15 @@
-notify { 'hello': }
+node default {
+  notify { 'hello': }
 
-notify { threader::doit(): }
+  notify { threader::doit(): }
 
-notify { threader::futurist(): }
+  notify { threader::color(): }
 
-notify { oldschool(): }
+  notify { oldschool(): }
 
-include threader::params_class
+  include threader::params_class
+}
+
+node 'testthree' {
+  notify { threader::other_func(): }
+}

--- a/ext/thread_test/environments/production/modules/threader/lib/puppet/functions/threader/color.rb
+++ b/ext/thread_test/environments/production/modules/threader/lib/puppet/functions/threader/color.rb
@@ -1,0 +1,9 @@
+Puppet::Functions.create_function(:'threader::color') do
+  dispatch :color do
+  end
+
+  def color
+    Puppet[:color] = false
+    "The production color is #{Puppet[:color]}"
+  end
+end

--- a/ext/thread_test/environments/production/modules/threader/lib/puppet/functions/threader/futurist.rb
+++ b/ext/thread_test/environments/production/modules/threader/lib/puppet/functions/threader/futurist.rb
@@ -1,8 +1,0 @@
-Puppet::Functions.create_function(:'threader::futurist') do
-  dispatch :futurist do
-  end
-
-  def futurist
-    "The production future is #{Puppet[:future_features]}"
-  end
-end

--- a/ext/thread_test/environments/production/modules/threader/lib/puppet/functions/threader/other_func.rb
+++ b/ext/thread_test/environments/production/modules/threader/lib/puppet/functions/threader/other_func.rb
@@ -1,0 +1,8 @@
+Puppet::Functions.create_function(:'threader::other_func') do
+  dispatch :other_func do
+  end
+
+  def other_func
+    "I'm a different function"
+  end
+end

--- a/ext/thread_test/parallel_test.rb
+++ b/ext/thread_test/parallel_test.rb
@@ -2,6 +2,8 @@ require 'net/http'
 require 'json'
 require 'rspec/expectations'
 
+iterations = 100
+processes_per_catalog = 2
 include RSpec::Matchers
 
 class CatalogTester
@@ -75,11 +77,31 @@ class CatalogThreeTester < CatalogTester
   end
 end
 
-# Use tester2 for funky env, and swap out for tester1 to use production instead,
-# or tester3 for a node in the production env with special classification.
-tester2 = CatalogTwoTester.new
-Process.fork do
-  tester2.run
+processes_per_catalog.times do
+  Process.fork do
+    tester = CatalogOneTester.new
+    iterations.times do
+      tester.run
+    end
+  end
+end
+
+processes_per_catalog.times do
+  Process.fork do
+    tester = CatalogTwoTester.new
+    iterations.times do
+      tester.run
+    end
+  end
+end
+
+processes_per_catalog.times do
+  Process.fork do
+    tester = CatalogThreeTester.new
+    iterations.times do
+      tester.run
+    end
+  end
 end
 
 exit_codes = Process.waitall


### PR DESCRIPTION
This commit puts the original thread test script into a `parallel_test`
script, and creates a new test script that just makes a single catalog
request. The former is good for testing races, while the latter is
better for inspecting an individual compile.

It also updates the fixtures to no longer use the `future_features`
setting, which has been removed.