### PR TITLE
(maint) Update CA CLI gem to 2.0.2

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 2.0.1
+puppetserver-ca 2.0.2


### PR DESCRIPTION
This update ensures that ca-client certs will also be signed with the CN
as a SAN.