### PR TITLE
(maint) Docker consistency updates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,10 @@ jobs:
       - run: gem install bundler
       - name: Build container
         working-directory: docker
-        run: make lint build test
+        run: |
+          docker system prune --all --force --volumes
+          docker builder prune --force --keep-storage=10GB
+          make lint build test
       - name: Publish container
         working-directory: docker
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       language: ruby
       rvm: 2.6.5
       env:
-        - DOCKER_COMPOSE_VERSION=1.25.5
+        - DOCKER_COMPOSE_VERSION=1.28.6
         # necessary to prevent overwhelming TravisCI build output limits
         - DOCKER_BUILD_FLAGS="--progress plain"
       before_install:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,7 +4,7 @@ vcs_ref := $(shell git rev-parse HEAD)
 build_date := $(shell date -u +%FT%T)
 hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
 hadolint_command := hadolint
-hadolint_container := hadolint/hadolint:latest
+hadolint_container := ghcr.io/hadolint/hadolint:latest
 
 export BUNDLE_PATH = $(PWD)/.bundle/gems
 export BUNDLE_BIN = $(PWD)/.bundle/bin

--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -58,7 +58,7 @@ HEALTHCHECK --interval=10s --timeout=15s --retries=12 --start-period=3m CMD ["/h
 
 # no need to pin versions or clear apt cache as its still being used
 # hadolint ignore=DL3008,DL3009
-RUN chmod +x /docker-entrypoint.sh /healthcheck.sh && \
+RUN chmod +x /docker-entrypoint.sh /healthcheck.sh /docker-entrypoint.d/*.sh && \
     apt-get update && \
     apt-get install -y --no-install-recommends $PACKAGES && \
     dpkg -i dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \

--- a/docker/puppetserver/docker-entrypoint.sh
+++ b/docker/puppetserver/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# bash is required to pass ENV vars with dots as sh cannot
 
 set -e
 

--- a/docker/puppetserver/docker-entrypoint.sh
+++ b/docker/puppetserver/docker-entrypoint.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-chmod +x /docker-entrypoint.d/*.sh
-# sync prevents aufs from sometimes returning EBUSY if you exec right after a chmod
-sync
 for f in /docker-entrypoint.d/*.sh; do
     echo "Running $f"
     "$f"


### PR DESCRIPTION
- Bump docker-compose to 1.28.6 (necessary for moving away from deprecated -no-ansi flag)
- Pull hadolint from gchr.io to avoid rate-limiting on Docker Hub
- Set +x on entrypoints at build time to be a better non-root citizen in k8s (more non-root work required on this container)
- Add note about why the entrypoint should always use `/bin/bash` and not `/bin/sh`
- Prune containers on the builder to prevent disk related build /publish failures