### PR TITLE
(maint) Disable BUILDKIT for Travis containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
       language: ruby
       rvm: 2.6.5
       env:
+        - DOCKER_BUILDKIT=0
         - DOCKER_COMPOSE_VERSION=1.28.6
         # necessary to prevent overwhelming TravisCI build output limits
         - DOCKER_BUILD_FLAGS="--progress plain"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,7 +9,7 @@ hadolint_container := ghcr.io/hadolint/hadolint:latest
 export BUNDLE_PATH = $(PWD)/.bundle/gems
 export BUNDLE_BIN = $(PWD)/.bundle/bin
 export GEMFILE = $(PWD)/Gemfile
-export DOCKER_BUILDKIT = 1
+DOCKER_BUILDKIT ?= 1
 PUPPERWARE_ANALYTICS_STREAM ?= dev
 
 ifeq ($(IS_RELEASE),true)
@@ -53,7 +53,7 @@ else
 endif
 
 build: prep
-	docker build \
+	DOCKER_BUILDKIT=${DOCKER_BUILDKIT} docker build \
 		${DOCKER_BUILD_FLAGS} \
 		--pull \
 		--build-arg build_type=$(BUILD_TYPE) \


### PR DESCRIPTION
 - Travis has been failing frequently with an error like:

   failed to solve with frontend dockerfile.v0: failed to build LLB:
   failed commit on ref "layer-sha256:XXX":
   unexpected commit size 0, expected 162: failed precondition

   This appears to be related to the version of Docker / Buildkit in
   use in Travis as this problem only shows up there.