### PR TITLE
(maint) Upgrade TravisCI docker version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ jobs:
         # necessary to prevent overwhelming TravisCI build output limits
         - DOCKER_BUILD_FLAGS="--progress plain"
       before_install:
+        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        - sudo apt-get update
+        - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce docker-ce-cli containerd.io
         - sudo rm /usr/local/bin/docker-compose
         - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
         - chmod +x docker-compose


### PR DESCRIPTION
Turns out it's much better to keep buildkit enabled if possible rather than trying to disable as is done in #2514. Hopefully a simple upgrade is the better solution.


 - This repo requires Docker buildkit to build containers in CI, which
   enables skipping optional stages in multi-stage builds (which skips
   building packages when not creating edge containers). Standard
   `docker build` does not support this, nor does it handle setting ARG
   valeus across stages as this Dockerfile needs.

 - Travis has been failing frequently with an error like:

   failed to solve with frontend dockerfile.v0: failed to build LLB:
   failed commit on ref "layer-sha256:XXX":
   unexpected commit size 0, expected 162: failed precondition

   This appears to be related to the version of Docker / Buildkit in
   use in Travis as this problem only shows up there.