### PR TITLE
(maint) Filter scanned certs in container startup

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,7 +9,7 @@ hadolint_container := ghcr.io/hadolint/hadolint:latest
 export BUNDLE_PATH = $(PWD)/.bundle/gems
 export BUNDLE_BIN = $(PWD)/.bundle/bin
 export GEMFILE = $(PWD)/Gemfile
-export DOCKER_BUILDKIT = 1
+export DOCKER_BUILDKIT ?= 1
 PUPPERWARE_ANALYTICS_STREAM ?= dev
 
 ifeq ($(IS_RELEASE),true)

--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -54,7 +54,7 @@ COPY docker/puppetserver/docker-entrypoint.sh \
       /
 COPY docker/puppetserver/docker-entrypoint.d /docker-entrypoint.d
 # k8s uses livenessProbe, startupProbe, readinessProbe and ignores HEALTHCHECK
-HEALTHCHECK --interval=10s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=20s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]
 
 # no need to pin versions or clear apt cache as its still being used
 # hadolint ignore=DL3008,DL3009

--- a/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
+++ b/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
@@ -6,7 +6,7 @@ echo "System configuration values:"
 echo "* HOSTNAME: '${HOSTNAME}'"
 echo "* hostname -f: '$(hostname -f)'"
 echo "* PUPPETSERVER_HOSTNAME:PUPPET_MASTERPORT: '${PUPPETSERVER_HOSTNAME}:${PUPPET_MASTERPORT}'"
-certname=$(ls "${SSLDIR}/certs" | grep --invert-match ca.pem)
+certname=$(cd "${SSLDIR}/certs" && ls *.pem | grep --invert-match ca.pem)
 echo "* Generated certname: '${certname}'"
 echo "* DNS_ALT_NAMES: '${DNS_ALT_NAMES}'"
 echo "* SSLDIR: '${SSLDIR}'"
@@ -19,6 +19,6 @@ if [ -f "${SSLDIR}/certs/ca.pem" ]; then
   openssl x509 -subject -issuer -text -noout -in "${SSLDIR}/certs/ca.pem" $altnames
 fi
 
-echo "Certificate:"
+echo "Certificate ${certname}:"
 # shellcheck disable=SC2086 # $altnames shouldn't be quoted
 openssl x509 -subject -issuer -text -noout -in "${SSLDIR}/certs/${certname}" $altnames

--- a/docker/puppetserver/healthcheck.sh
+++ b/docker/puppetserver/healthcheck.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-certname=$(ls "${SSLDIR}/certs" | grep --invert-match ca.pem) && \
+certname=$(cd "${SSLDIR}/certs" && ls *.pem | grep --invert-match ca.pem) && \
 hostname=$(basename $certname .pem) && \
 hostprivkey="${SSLDIR}/private_keys/$certname" && \
 hostcert="${SSLDIR}/certs/$certname" && \


### PR DESCRIPTION
 - With cert preloading added to test suites, there is a server.crt
   present alongside puppet.pem. This entrypoint script errors and
   prevents the container from starting and the healthcheck fails
   because of the existence of server.crt, so update the filter to be
   more sensible

   This fix is not visible to this test suite as this suite will
   always generate certificates - but it will be visible elsewhere in
   suites like puppetdb, pupperware, etc

 - Log the certname as well
 - Allow `DOCKER_BUILDKIT` to be overridden (even though we need buildkit)
 - Refactors container healthcheck to be similar to PE variant
     - curl --no-progress-meter cleans up livenessprobe logs
     - Readiness probes in Kubernetes that use exec ignore timeout and
       require the command itself to enforce a timeout. Use `curl --max-time`
       to timeout if the request takes too long. Make it configurable so we
       can tune it as necessary.

       Also increases the healthcheck interval in Docker. Retry interval
       should be longer than the timeout.