### PR TITLE
(SERVER-2993) Bump puppetserver-ca to 1.9.4

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.9.3
+puppetserver-ca 1.9.4


### PR DESCRIPTION
This commit bumps the puppetserver-ca gem to 1.9.4, which includes appropriate
settings detection for migrated CA directories.