### PR TITLE
(SERVER-2932) Update CA CLI gem to 1.9.5

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.9.4
+puppetserver-ca 1.9.5


### PR DESCRIPTION
This update contains some harmful terminology removals.