### PR TITLE
(SERVER-2932) Update CA CLI gem to 2.1.0

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 2.0.2
+puppetserver-ca 2.1.0


### PR DESCRIPTION
This update contains removal of harmful terminology.