### PR TITLE
(docs) Just a little note about server persistence across restarts

### DIFF
--- a/docker/puppetserver/README.md
+++ b/docker/puppetserver/README.md
@@ -50,6 +50,10 @@ The following environment variables are supported:
 If you would like to do additional initialization, add a directory called `/docker-custom-entrypoint.d/` and fill it with `.sh` scripts.
 These scripts will be executed at the end of the entrypoint script, before the service is ran.
 
+## Persistance 
+
+If you plan to use the in-server CA, restarting the container can cause the server's keys and certificates to change, causing agents and the server to stop trusting each other. To prevent this, you can persist the default ssldir, `/etc/puppetlabs/puppet/ssl`. For example, `docker run -v $PWD/ca-ssl:/etc/puppetlabs/puppet/ssl puppetlabs/puppetserver:latest`.
+
 ## Analytics Data Collection
 
 The puppetserver container collects usage data. This is disabled by default. You can enable it by passing `--env PUPPERWARE_ANALYTICS_ENABLED=true`

--- a/docker/puppetserver/README.md
+++ b/docker/puppetserver/README.md
@@ -52,7 +52,7 @@ These scripts will be executed at the end of the entrypoint script, before the s
 
 ## Persistance 
 
-If you plan to use the in-server CA, restarting the container can cause the server's keys and certificates to change, causing agents and the server to stop trusting each other. To prevent this, you can persist the default ssldir, `/etc/puppetlabs/puppet/ssl`. For example, `docker run -v $PWD/ca-ssl:/etc/puppetlabs/puppet/ssl puppetlabs/puppetserver:latest`.
+If you plan to use the in-server CA, restarting the container can cause the server's keys and certificates to change, causing agents and the server to stop trusting each other. To prevent this, you can persist the default cadir, `/etc/puppetlabs/puppetserver/ca`. For example, `docker run -v $PWD/ca-ssl:/etc/puppetlabs/puppetserver/ca puppetlabs/puppetserver:latest`.
 
 ## Analytics Data Collection
 


### PR DESCRIPTION
IMO, the easiest way to get started with puppetserver is using docker. I wasn't familiar with what would be required from to have a puppetserver that could survive across a container restart, so I had to look at some other sources. 

This just a little note that would help a person trying to get started with puppetserver by using the docker deployment. Please feel free to change any thing or reject it - this is just an idea that would have helped me get started slightly easier.