### PR TITLE
(SERVER-3015) Cache etag if cache was previously evicted

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -729,17 +729,16 @@
    content-version :- (schema/maybe schema/Int)]
   (let [body (json/encode info)
         tag (ks/utf8-string->sha256 body)]
+    (jruby-protocol/set-cache-info-tag!
+     jruby-service
+     env
+     svc-key
+     tag
+     content-version)
     (if (= tag request-tag)
       (not-modified-response tag)
-      (do
-        (jruby-protocol/set-cache-info-tag!
-         jruby-service
-         env
-         svc-key
-         tag
-         content-version)
-        (-> (response-with-etag body tag)
-            (rr/content-type "application/json"))))))
+      (-> (response-with-etag body tag)
+          (rr/content-type "application/json")))))
 
 (schema/defn ^:always-validate
   make-cacheable-handler :- IFn


### PR DESCRIPTION
Prior to this patch, if a request to the environment_classes endpoint contained
an If-None-Match header with an etag in it, but the cache had been evicted we
would compute the class info. If that class info's checksum matched the given etag
we would return a 304 but not cache the checksum. Because the cache was not
updated, subsequent requests that included an etag would still trigger class info
computation.

With this patch we will now cache the computed etag, allowing subsequent
requests that include the correct If-None-Match header to skip class info
computation.