### PR TITLE
Use java.specification.version for version check

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -132,7 +132,7 @@
                     {:dependencies [[org.bouncycastle/bcpkix-fips]
                                     [org.bouncycastle/bc-fips]
                                     [org.bouncycastle/bctls-fips]]
-                     :jvm-opts ~(let [version (System/getProperty "java.version")
+                     :jvm-opts ~(let [version (System/getProperty "java.specification.version")
                                       [major minor _] (clojure.string/split version #"\.")
                                       unsupported-ex (ex-info "Unsupported major Java version. Expects 8 or 11."
                                                        {:major major


### PR DESCRIPTION
java.version on some platforms differs from what Puppetserver's project file tries to parse.
java.specification.version is however guaranteed to match the expected format.

On Debian openjdk-17-jre-headless's "java -XshowSettings:properties -version" is:
```
file.encoding = UTF-8
file.separator = /
java.class.path =
java.class.version = 61.0
java.home = /usr/lib/jvm/java-17-openjdk-amd64
java.io.tmpdir = /tmp
java.library.path = /usr/java/packages/lib
	/usr/lib/x86_64-linux-gnu/jni
	/lib/x86_64-linux-gnu
	/usr/lib/x86_64-linux-gnu
	/usr/lib/jni
	/lib
	/usr/lib
java.runtime.name = OpenJDK Runtime Environment
java.runtime.version = 17-ea+24-Debian-1
java.specification.name = Java Platform API Specification
java.specification.vendor = Oracle Corporation
java.specification.version = 17
java.vendor = Debian
java.vendor.url = https://tracker.debian.org/openjdk-17
java.vendor.url.bug = https://bugs.debian.org/openjdk-17
java.version = 17-ea
java.version.date = 2021-09-14
java.vm.compressedOopsMode = Zero based
java.vm.info = mixed mode, sharing
java.vm.name = OpenJDK 64-Bit Server VM
java.vm.specification.name = Java Virtual Machine Specification
java.vm.specification.vendor = Oracle Corporation
java.vm.specification.version = 17
java.vm.vendor = Debian
java.vm.version = 17-ea+24-Debian-1
jdk.debug = release
line.separator = \n
native.encoding = UTF-8
os.arch = amd64
os.name = Linux
os.version = 5.10.0-7-amd64
path.separator = :
sun.arch.data.model = 64
sun.boot.library.path = /usr/lib/jvm/java-17-openjdk-amd64/lib
sun.cpu.endian = little
sun.io.unicode.encoding = UnicodeLittle
sun.java.launcher = SUN_STANDARD
sun.jnu.encoding = UTF-8
sun.management.compiler = HotSpot 64-Bit Tiered Compilers
sun.stderr.encoding = UTF-8
sun.stdout.encoding = UTF-8
user.country = IE
user.dir = /opt/deb/puppetserver
user.home = /root
user.language = en
user.name = root
```

Which results in:
```
java.lang.Exception: Error loading /opt/deb/puppetserver/project.clj
 at leiningen.core.project$read_raw$fn__7634.invoke (project.clj:1046)
    leiningen.core.project$read_raw.invokeStatic (project.clj:1040)
    leiningen.core.project$read_raw.invoke (project.clj:1036)
    leiningen.core.project$read.invokeStatic (project.clj:1057)
    leiningen.core.project$read.invoke (project.clj:1054)
    leiningen.core.project$read.invokeStatic (project.clj:1058)
    leiningen.core.project$read.invoke (project.clj:1054)
    leiningen.core.main$_main$fn__7020.invoke (main.clj:447)
    leiningen.core.main$_main.invokeStatic (main.clj:442)
    leiningen.core.main$_main.doInvoke (main.clj:439)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.core$apply.invokeStatic (core.clj:665)
    clojure.main$main_opt.invokeStatic (main.clj:514)
    clojure.main$main_opt.invoke (main.clj:510)
    clojure.main$main.invokeStatic (main.clj:664)
    clojure.main$main.doInvoke (main.clj:616)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.main.main (main.java:40)
Caused by: clojure.lang.Compiler$CompilerException: Syntax error compiling at (/opt/deb/puppetserver/project.clj:25:1).
#:clojure.error{:phase :compile-syntax-check, :line 25, :column 1, :source "/opt/deb/puppetserver/project.clj"}
 at clojure.lang.Compiler.load (Compiler.java:7648)
    clojure.lang.Compiler.loadFile (Compiler.java:7574)
    clojure.lang.RT$3.invoke (RT.java:327)
    leiningen.core.project$read_raw$fn__7634.invoke (project.clj:1044)
    leiningen.core.project$read_raw.invokeStatic (project.clj:1040)
    leiningen.core.project$read_raw.invoke (project.clj:1036)
    leiningen.core.project$read.invokeStatic (project.clj:1057)
    leiningen.core.project$read.invoke (project.clj:1054)
    leiningen.core.project$read.invokeStatic (project.clj:1058)
    leiningen.core.project$read.invoke (project.clj:1054)
    leiningen.core.main$_main$fn__7020.invoke (main.clj:447)
    leiningen.core.main$_main.invokeStatic (main.clj:442)
    leiningen.core.main$_main.doInvoke (main.clj:439)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.core$apply.invokeStatic (core.clj:665)
    clojure.main$main_opt.invokeStatic (main.clj:514)
    clojure.main$main_opt.invoke (main.clj:510)
    clojure.main$main.invokeStatic (main.clj:664)
    clojure.main$main.doInvoke (main.clj:616)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.main.main (main.java:40)
Caused by: java.lang.NumberFormatException: For input string: "17-ea"
 at java.lang.NumberFormatException.forInputString (NumberFormatException.java:67)
    java.lang.Integer.parseInt (Integer.java:668)
    java.lang.Integer.parseInt (Integer.java:786)
    leiningen.core.project$eval664.invokeStatic (project.clj:140)
    leiningen.core.project$eval664.invoke (project.clj:25)
    clojure.lang.Compiler.eval (Compiler.java:7177)
    clojure.lang.Compiler.load (Compiler.java:7636)
    clojure.lang.Compiler.loadFile (Compiler.java:7574)
    clojure.lang.RT$3.invoke (RT.java:327)
    leiningen.core.project$read_raw$fn__7634.invoke (project.clj:1044)
    leiningen.core.project$read_raw.invokeStatic (project.clj:1040)
    leiningen.core.project$read_raw.invoke (project.clj:1036)
    leiningen.core.project$read.invokeStatic (project.clj:1057)
    leiningen.core.project$read.invoke (project.clj:1054)
    leiningen.core.project$read.invokeStatic (project.clj:1058)
    leiningen.core.project$read.invoke (project.clj:1054)
    leiningen.core.main$_main$fn__7020.invoke (main.clj:447)
    leiningen.core.main$_main.invokeStatic (main.clj:442)
    leiningen.core.main$_main.doInvoke (main.clj:439)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.core$apply.invokeStatic (core.clj:665)
    clojure.main$main_opt.invokeStatic (main.clj:514)
    clojure.main$main_opt.invoke (main.clj:510)
    clojure.main$main.invokeStatic (main.clj:664)
    clojure.main$main.doInvoke (main.clj:616)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.main.main (main.java:40)
```