### PR TITLE
(SERVER-2841) Replace cemerick.url with lambdaisland.uri

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -120,12 +120,7 @@
                                         [ring-basic-authentication]
                                         [ring/ring-mock]
                                         [beckon]
-                                        [com.cemerick/url "0.1.1"]
-                                        ;; Pinned to fix CVE-2015-5237, overrides what's pulled
-                                        ;; in by cemerick/url, which is unmaintained.
-                                        ;; This pin should be removed when we can rip out
-                                        ;; cemerick/url, see SERVER-2959.
-                                        [com.google.protobuf/protobuf-java "3.4.0"]]}
+                                        [lambdaisland/uri "1.4.70"]]}
              :dev [:defaults
                    {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]}]
              :fips [:defaults

--- a/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_metrics_service_test.clj
@@ -26,7 +26,7 @@
             [puppetlabs.metrics :as metrics]
             [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.comidi :as comidi]
-            [cemerick.url :as url]
+            [lambdaisland.uri :as uri]
             [puppetlabs.testutils.task-coordinator :as coordinator]
             [puppetlabs.services.jruby.jruby-metrics-core :as jruby-metrics-core]
             [clojure.string :as str]
@@ -78,9 +78,9 @@
   ([coordinator request-id uri phase]
     ;; add the request id into the url as a query param
     ;; for use with the coordinator
-   (let [orig-url (url/url (str "http://localhost:8140" uri))
-         query (assoc (:query orig-url) "request-id" request-id)
-         url (assoc orig-url :query query)
+   (let [url (-> (str "http://localhost:8140" uri)
+                 uri/uri
+                 (uri/assoc-query :request-id request-id))
          ;; our request function to pass to the coordinator
          ;; is just a simple HTTP GET.
          req-fn (fn [] (http-get (str url)))]
@@ -140,8 +140,8 @@
                                   ;; the comidi handler can interact with the
                                   ;; test request coordinator
                                   (let [request-id (-> (:query-string request)
-                                                     url/query->map
-                                                     (get "request-id"))]
+                                                     uri/query-string->map
+                                                     (get :request-id))]
                                     ;; notify the coordinator that we've begun to handle the request
                                     (coordinator/notify-task-progress coordinator request-id :http-handler-invoked)
                                     ;; delegate to the jruby request handler


### PR DESCRIPTION
This commit replaces the `com.cemerick/url` dependency with `lambdaisland/uri`.
The former is unmaintained and has been archived upstream, so it no longer
receives security updates. Even though this dependency was only used for testing
purposes, our security scanner would still flag vulnerable transitive
dependencies that were included in the unmaintained `url` lib. This moves us to
a maintained lib, which should allow us to get clean security scans.