### PR TITLE
(SERVER-3033) Fix auth rule for CRL update endpoint

### DIFF
--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -74,7 +74,7 @@ authorization: {
         {
             match-request: {
                 path: "^/puppet-ca/v1/certificate_revocation_list$"
-                type: path
+                type: regex
                 method: put
             }
             allow: {


### PR DESCRIPTION
Prior to this change, all PUT requests to the `certificate_revocation_list`
endpoint would get denied, since the request path wouldn't exactly match the
string in the auth rule. Using type `regex` ensures that we can access this
endpoint appropriately.