### PR TITLE
(PE-32070) Use BCFKS key factory in FIPS mode

### DIFF
--- a/dev-resources/java.security.jdk11-fips
+++ b/dev-resources/java.security.jdk11-fips
@@ -319,7 +319,7 @@ security.overridePropertiesFile=true
 # Determines the default key and trust manager factory algorithms for
 # the javax.net.ssl package.
 #
-ssl.KeyManagerFactory.algorithm=PKIX
+ssl.KeyManagerFactory.algorithm=BCFKS
 ssl.TrustManagerFactory.algorithm=PKIX
 
 #

--- a/dev-resources/java.security.jdk8-fips
+++ b/dev-resources/java.security.jdk8-fips
@@ -288,7 +288,7 @@ security.overridePropertiesFile=true
 # Determines the default key and trust manager factory algorithms for
 # the javax.net.ssl package.
 #
-ssl.KeyManagerFactory.algorithm=PKIX
+ssl.KeyManagerFactory.algorithm=BCFKS
 ssl.TrustManagerFactory.algorithm=PKIX
 
 #


### PR DESCRIPTION
The PKIX factory is correct for non-FIPS BC, but in FIPS mode we want to
use BCFKS.