### PR TITLE
(SERVER-3032) Always allow SAN that matches CSR subject

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1314,18 +1314,27 @@
 (schema/defn ensure-subject-alt-names-allowed!
   "Throws an exception if the CSR contains subject-alt-names AND the user has
    chosen to disallow subject-alt-names. Subject alt names can be allowed by
-   setting allow-subject-alt-names to true in the ca.conf file."
+   setting allow-subject-alt-names to true in the ca.conf file. Always allows
+   a single subject alt name that matches the CSR subject, which may be
+   present to comply with RFC 2818 (see SERVER-2338)."
   [csr :- CertificateRequest
    allow-subject-alt-names :- schema/Bool]
   (when-let [subject-alt-names (not-empty (subject-alt-names csr))]
     (if (false? allow-subject-alt-names)
-      (let [subject (get-csr-subject csr)]
-        (sling/throw+
-          {:kind :disallowed-extension
-           :msg (format "%s %s %s"
-                        (i18n/tru "CSR ''{0}'' contains subject alternative names ({1}), which are disallowed." subject (str/join ", " subject-alt-names))
-                        (i18n/tru "To allow subject alternative names, set allow-subject-alt-names to true in your ca.conf file.")
-                        (i18n/tru "Then restart the puppetserver and try signing this certificate again."))})))))
+      (let [subject (get-csr-subject csr)
+            cn-alt-name (str "DNS:" subject)]
+        (if (and (= 1 (count subject-alt-names))
+                 (= (first subject-alt-names) cn-alt-name))
+          (log/debug "Allowing subject alt name that matches CSR subject.")
+          (let [disallowed-alt-names (filter #(not (= cn-alt-name %))
+                                             subject-alt-names)]
+            (sling/throw+
+             {:kind :disallowed-extension
+              :msg (format "%s %s %s"
+                           (i18n/tru "CSR ''{0}'' contains extra subject alternative names ({1}), which are disallowed."
+                                     subject (str/join ", " disallowed-alt-names))
+                           (i18n/tru "To allow subject alternative names, set allow-subject-alt-names to true in your ca.conf file.")
+                           (i18n/tru "Then restart the puppetserver and try signing this certificate again."))})))))))
 
 (schema/defn ^:always-validate process-csr-submission!
   "Given a CSR for a subject (typically from the HTTP endpoint),

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -1139,7 +1139,7 @@
             (doseq [[policy subject csr-file expected]
                     [["subject alt name extension exists" "hostwithaltnames" "hostwithaltnames.pem"
                       #(= {:kind :disallowed-extension
-                           :msg (str "CSR 'hostwithaltnames' contains subject alternative names "
+                           :msg (str "CSR 'hostwithaltnames' contains extra subject alternative names "
                                    "(DNS:altname1, DNS:altname2, DNS:altname3), which are disallowed. "
                                    "To allow subject alternative names, set allow-subject-alt-names to "
                                    "true in your ca.conf file. Then restart the puppetserver "
@@ -1461,6 +1461,44 @@
 (deftest netscape-comment-value-test
   (testing "Netscape comment constant has expected value"
     (is (= "Puppet Server Internal Certificate" netscape-comment-value))))
+
+(deftest ensure-alt-names-allowed-test
+  (let [subject-keys (utils/generate-key-pair 512)
+        subject "new-cert"
+        subject-dn (utils/cn subject)]
+    (logutils/with-test-logging
+     (testing "when allow-subject-alt-names is false"
+       (testing "rejects alt names that don't match the subject"
+         (let [alt-name-ext {:oid utils/subject-alt-name-oid
+                             :value {:dns-name ["bad-name"]}
+                             :critical false}
+               csr (utils/generate-certificate-request subject-keys subject-dn [alt-name-ext])]
+           (is (thrown+-with-msg?
+                [:kind :disallowed-extension]
+                #".*new-cert.*subject alternative names.*bad-name.*"
+                (ensure-subject-alt-names-allowed! csr false))))
+         (let [alt-name-ext {:oid utils/subject-alt-name-oid
+                             :value {:dns-name ["bad-name" subject]}
+                             :critical false}
+               csr (utils/generate-certificate-request subject-keys subject-dn [alt-name-ext])]
+           (is (thrown+-with-msg?
+                [:kind :disallowed-extension]
+                #".*new-cert.*subject alternative names.*bad-name.*"
+                (ensure-subject-alt-names-allowed! csr false)))))
+       (testing "allows a single alt name matching the subject"
+         (let [alt-name-ext {:oid utils/subject-alt-name-oid
+                             :value {:dns-name [subject]}
+                             :critical false}
+               csr (utils/generate-certificate-request subject-keys subject-dn [alt-name-ext])]
+           (is (nil? (ensure-subject-alt-names-allowed! csr false)))
+           (is (logutils/logged? #"Allowing subject alt name" :debug))))))
+    (testing "when allow-subject-alt-names is true"
+      (testing "allows all alt names"
+        (let [alt-name-ext {:oid utils/subject-alt-name-oid
+                            :value {:dns-name [subject "another-name"]}
+                            :critical false}
+              csr (utils/generate-certificate-request subject-keys subject-dn [alt-name-ext])]
+          (is (nil? (ensure-subject-alt-names-allowed! csr true))))))))
 
 (deftest ensure-no-authorization-extensions!-test
   (testing "when checking a csr for authorization extensions"


### PR DESCRIPTION
Previously, when `allow-subject-alt-names` was set to false, we rejected
any and all SANs on CSRs. However, now that we are adding the CSR's
subject as an alt name when generating CSRs, per RFC 2818, we need to
make an exception, so as to not block all internally generated CSRs.
This affects, for example, the `puppetserver ca generate` command. This
commit updates the validation function to allow a single alt name
matching the CSR's subject, even when `allow-subject-alt-names` is
false.