### PR TITLE
(PE-32484) Update ast_compiler to work for projects

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/ast_compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/ast_compiler_spec.rb
@@ -15,12 +15,26 @@ def generate_ast(code)
   end
 end
 
-def request(code)
+def environment_request(code)
   {"certname" => "localhost",
    "facts" => {"values" => {"my_fact" => "fact_value"}},
    "trusted_facts" => {"values" => {"my_trusted" => "trusted_value"}},
    "options" => {"capture_logs" => false},
    "environment" => "production",
+   "code_ast" => generate_ast(code).to_json,
+   "variables" => {"values" => {"foo" => "bar"}}}
+end
+
+def project_request(code)
+  {"certname" => "localhost",
+   "facts" => {"values" => {"my_fact" => "fact_value"}},
+   "trusted_facts" => {"values" => {"my_trusted" => "trusted_value"}},
+   "options" => {"capture_logs" => false, "compile_for_plan" => true},
+   "versioned_project" => "fakeproject_GITSHA",
+   "project_root" => "/etc/puppetlabs/puppetserver/projects",
+   "modulepath" => ['/etc/puppetlabs/puppetserver/projects/fakeproject_GITSHA', '/etc/puppetlabs/puppetserver/projects/fakeproject_GITSHA/.modules'],
+   "hiera_config" => ['/etc/puppetlabs/puppetserver/projects/fakeproject_GITSHA/hiera.yaml'],
+   "project_name" => 'fakeproject',
    "code_ast" => generate_ast(code).to_json,
    "variables" => {"values" => {"foo" => "bar"}}}
 end
@@ -37,42 +51,42 @@ describe Puppet::Server::ASTCompiler do
     let(:boltlib_path) { nil }
 
     it 'handles basic resources' do
-      response = Puppet::Server::ASTCompiler.compile(request("notify { 'my_notify': }"), boltlib_path)
+      response = Puppet::Server::ASTCompiler.compile(environment_request("notify { 'my_notify': }"), boltlib_path)
       notify = find_notify(response[:catalog])
       expect(notify).not_to be_nil
       expect(notify['title']).to eq("my_notify")
     end
 
     it 'correctly interpolates supplied variables' do
-      response = Puppet::Server::ASTCompiler.compile(request('notify { "$foo": }'), boltlib_path)
+      response = Puppet::Server::ASTCompiler.compile(environment_request('notify { "$foo": }'), boltlib_path)
       notify = find_notify(response[:catalog])
       expect(notify).not_to be_nil
       expect(notify['title']).to eq("bar")
     end
 
     it 'correctly interpolates supplied facts' do
-      response = Puppet::Server::ASTCompiler.compile(request('notify { "$my_fact": }'), boltlib_path)
+      response = Puppet::Server::ASTCompiler.compile(environment_request('notify { "$my_fact": }'), boltlib_path)
       notify = find_notify(response[:catalog])
       expect(notify).not_to be_nil
       expect(notify['title']).to eq("fact_value")
     end
 
     it 'correctly interpolates supplied trusted facts' do
-      response = Puppet::Server::ASTCompiler.compile(request('notify { "${trusted[\'my_trusted\']}": }'), boltlib_path)
+      response = Puppet::Server::ASTCompiler.compile(environment_request('notify { "${trusted[\'my_trusted\']}": }'), boltlib_path)
       notify = find_notify(response[:catalog])
       expect(notify).not_to be_nil
       expect(notify['title']).to eq("trusted_value")
     end
 
     it 'fails gracefully when boltlib is not found when request requires bolt types' do
-      bolt_request = request('notify { "${trusted[\'my_trusted\']}": }')
+      bolt_request = environment_request('notify { "${trusted[\'my_trusted\']}": }')
       bolt_request.merge!({'options' => { 'compile_for_plan' => true } })
       expect {
         Puppet::Server::ASTCompiler.compile(bolt_request, boltlib_path)
       }.to raise_error(Puppet::Error, /the path to boltlib modules must be provided/)
     end
 
-    context 'when compiling for a plan with fact and plan/target variable collisions' do
+    context 'when compiling for an environment plan with fact and plan/target variable collisions' do
       let(:boltlib_path) { [] }
 
       it 'properly shadows the relevant variables' do
@@ -111,7 +125,7 @@ notify { "plan_var_fact": message => $plan_var_fact }
 notify { "target_var_fact": message => $target_var_fact }
 notify { "plan_var_plain":  message => $plan_var_plain }
 CODE
-        bolt_request = request(code)
+        bolt_request = environment_request(code)
         bolt_request.merge!(
           'facts'            => facts,
           'variables'        => variables,
@@ -132,6 +146,42 @@ CODE
           notify = find_notify(catalog, title: var)
           expect(notify).not_to be_nil
           expect(notify['parameters']['message']).to eql(expected_value)
+        end
+      end
+    end
+
+    context 'when running a project plan' do
+      let(:boltlib_path) { [] }
+      context 'single threaded' do
+        it 'returns puppet settings back to normal' do
+          # TODO: This is a temporary stub of the Bolt requires to get this
+          # test to pass. We should figure out how to properly load Bolt code
+          # later for the tests.
+          allow(Puppet::Server::ASTCompiler).to receive(:load_bolt)
+          mock_apply_inventory_class = double('Bolt::ApplyInventory')
+          allow(mock_apply_inventory_class).to receive(:new).with(anything).and_return(double('mock'))
+          stub_const("Bolt::ApplyInventory", mock_apply_inventory_class)
+
+          original_settings = {
+            'vardir' => Puppet[:vardir],
+            'confdir' => Puppet[:confdir],
+            'logdir' => Puppet[:logdir],
+            'codedir' => Puppet[:codedir],
+            'basemodulepath' => Puppet[:basemodulepath],
+            'vendormoduledir' => Puppet[:vendormoduledir],
+            'hiera_config' => Puppet[:hiera_config]
+          }
+
+          # Use a simple resource, since we aren't testing the compilation itself
+          # but rather ensuring the compilation does not interfere with global state
+          response = Puppet::Server::ASTCompiler.compile(project_request("notify { 'my_notify': }"), boltlib_path)
+          notify = find_notify(response[:catalog])
+          expect(notify).not_to be_nil
+          expect(notify['title']).to eq("my_notify")
+
+          original_settings.each do |setting_name, original_setting|
+            expect(Puppet[setting_name]).to eq(original_setting)
+          end
         end
       end
     end

--- a/spec/puppet-server-lib/puppet/jvm/ast_compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/ast_compiler_spec.rb
@@ -152,37 +152,21 @@ CODE
 
     context 'when running a project plan' do
       let(:boltlib_path) { [] }
-      context 'single threaded' do
-        it 'returns puppet settings back to normal' do
-          # TODO: This is a temporary stub of the Bolt requires to get this
-          # test to pass. We should figure out how to properly load Bolt code
-          # later for the tests.
-          allow(Puppet::Server::ASTCompiler).to receive(:load_bolt)
-          mock_apply_inventory_class = double('Bolt::ApplyInventory')
-          allow(mock_apply_inventory_class).to receive(:new).with(anything).and_return(double('mock'))
-          stub_const("Bolt::ApplyInventory", mock_apply_inventory_class)
+      it 'returns puppet settings back to normal' do
+        # TODO: This is a temporary stub of the Bolt requires to get this
+        # test to pass. We should figure out how to properly load Bolt code
+        # later for the tests.
+        allow(Puppet::Server::ASTCompiler).to receive(:load_bolt)
+        mock_apply_inventory_class = double('Bolt::ApplyInventory')
+        allow(mock_apply_inventory_class).to receive(:new).with(anything).and_return(double('mock'))
+        stub_const("Bolt::ApplyInventory", mock_apply_inventory_class)
 
-          original_settings = {
-            'vardir' => Puppet[:vardir],
-            'confdir' => Puppet[:confdir],
-            'logdir' => Puppet[:logdir],
-            'codedir' => Puppet[:codedir],
-            'basemodulepath' => Puppet[:basemodulepath],
-            'vendormoduledir' => Puppet[:vendormoduledir],
-            'hiera_config' => Puppet[:hiera_config]
-          }
-
-          # Use a simple resource, since we aren't testing the compilation itself
-          # but rather ensuring the compilation does not interfere with global state
-          response = Puppet::Server::ASTCompiler.compile(project_request("notify { 'my_notify': }"), boltlib_path)
-          notify = find_notify(response[:catalog])
-          expect(notify).not_to be_nil
-          expect(notify['title']).to eq("my_notify")
-
-          original_settings.each do |setting_name, original_setting|
-            expect(Puppet[setting_name]).to eq(original_setting)
-          end
-        end
+        # Use a simple resource, since we aren't testing the compilation itself
+        # but rather ensuring the compilation does not interfere with global state
+        response = Puppet::Server::ASTCompiler.compile(project_request("notify { 'my_notify': }"), boltlib_path)
+        notify = find_notify(response[:catalog])
+        expect(notify).not_to be_nil
+        expect(notify['title']).to eq("my_notify")
       end
     end
   end

--- a/src/ruby/puppetserver-lib/puppet/server/ast_compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/ast_compiler.rb
@@ -24,7 +24,14 @@ module Puppet
       end
 
       def self.compile_ast(code, compile_options, boltlib_path)
-        # If the request requires that bolt be loaded we assume we are in a properly 
+        # Save the original node_name_value, to be put back later
+        original_node_name_value = Puppet[:node_name_value]
+        # Set node_name_value directly. All types of compilation
+        # including project/environment and plan/non-plan compiles
+        # will need to have this set.
+        Puppet[:node_name_value] = compile_options['certname']
+
+        # If the request requires that bolt be loaded we assume we are in a properly
         # configured PE environment
         if compile_options.dig('options', 'compile_for_plan')
           unless boltlib_path
@@ -34,91 +41,172 @@ module Puppet
           end
 
           load_bolt()
-
-          Puppet[:node_name_value] = compile_options['certname']
-
-          # Prior to PE-29443 variables were in a hash. Serialization between ruby/clojure/json did
-          # not preserver hash order necessary for deserialization. The data strucutre is now stored
-          # in a list for moving data and the list is used to construct an ordered ruby hash.
-          plan_variables = if compile_options['variables']['values'].is_a?(Array)
-                        compile_options['variables']['values'].each_with_object({}) do |param_hash, acc|
-                          acc[param_hash.keys.first] = param_hash.values.first
-                        end
-                      else
-                        compile_options['variables']['values']
-                      end
-
-          target_variables = compile_options.dig('target_variables', 'values') || {}
-
-          variables = {
-            variables: plan_variables,
-            target_variables: target_variables,
-          }
-
-          env_conf = {
-            pre_modulepath: boltlib_path,
-            envpath: Puppet[:environmentpath],
-            facts: compile_options['facts']['values'],
-          }
-
-          # Use the existing environment with the requested name
-          Puppet::Pal.in_environment(compile_options['environment'], env_conf) do |pal|
-            # TODO: Given we hide this from plan authors this current iteration has only
-            # the "required" data for now. Once we can get https://github.com/puppetlabs/bolt/pull/1770
-            # merged and promoted we can just use an empty hash.
-            fake_config = {
-              'transport' => 'redacted',
-              'transports' => {
-                'redacted' => 'redacted'
-              }
-            }
-            bolt_inv = Bolt::ApplyInventory.new(fake_config)
-            Puppet.override(bolt_inventory: bolt_inv) do
-              Puppet.lookup(:pal_current_node).trusted_data = compile_options['trusted_facts']['values']
-              # This compiler has been configured with a node containing
-              # the requested environment, facts, and variables, and is used
-              # to compile a catalog in that context from the supplied AST.
-              pal.with_catalog_compiler(**variables) do |compiler|
-                # TODO: PUP-10476 Explore setting these as default in PAL. They are the defaults in Puppet
-                Puppet[:strict] = :warning
-                Puppet[:strict_variables] = false
-
-                ast = build_program(code)
-                compiler.evaluate(ast)
-                compiler.evaluate_ast_node
-                compiler.compile_additions
-                compiler.catalog_data_hash
-              end
-            end
+          if compile_options.has_key?('versioned_project')
+            compile_for_project_plan(code, compile_options, boltlib_path)
+          else
+            compile_for_environment_plan(code, compile_options, boltlib_path)
           end
         else
-          # When we do not need to load bolt we assume there are no Bolt types to resolve in
-          # AST compilation.
-          Puppet[:node_name_value] = compile_options['certname']
+          compile_for_environment(code, compile_options, boltlib_path)
+        end
+      ensure
+        Puppet[:node_name_value] = original_node_name_value
+      end
+      private_class_method :compile_ast
 
-          # Use the existing environment with the requested name
-          Puppet::Pal.in_environment(compile_options['environment'],
-                                     envpath: Puppet[:environmentpath],
-                                     facts: compile_options['facts']['values'],
-                                     variables: compile_options['variables']['values']) do |pal|
+      def self.compile_for_project_plan(code, compile_options, boltlib_path)
+
+        # Save the original hiera_config value, to be put back later
+        original_hiera_config = Puppet[:hiera_config]
+        # hiera_config is set directly here rather than passing it to
+        # Puppet.override below. For some reason passing it to .override
+        # does not correctly force it to update and compilation does not
+        # correctly use the updated setting. We decided not to continue
+        # pursuing debugging that behavior, and instead just set it
+        # directly here and return hiera_config to it's original value
+        # below.
+        #                               - Sean P. McDonald 8/3/2021
+        #
+        Puppet[:hiera_config] = compile_options['hiera_config']
+
+        # Modulepath needs to be combined "manually" here because there is no
+        # equivalent to pre_modulepath for in_tmp_environment
+        env_conf = {
+          modulepath: Array(boltlib_path) + Array(compile_options['modulepath']),
+          facts: compile_options['facts']['values'],
+        }
+
+        plan_variables = ordered_plan_vars(compile_options)
+        target_variables = compile_options.dig('target_variables', 'values') || {}
+        variables = {
+          variables: plan_variables,
+          target_variables: target_variables,
+        }
+
+        # TODO: Given we hide this from plan authors this current iteration has only
+        # the "required" data for now. Once we can get https://github.com/puppetlabs/bolt/pull/1770
+        # merged and promoted we can just use an empty hash.
+        fake_config = {
+          'transport' => 'redacted',
+          'transports' => {
+            'redacted' => 'redacted'
+          }
+        }
+        bolt_inv = Bolt::ApplyInventory.new(fake_config)
+        bolt_project = Struct.new(:name, :path, :load_as_module?).new(compile_options['project_name'],
+                                                                      compile_options['project_root'],
+                                                                      true)
+        puppet_overrides = {
+          bolt_inventory:  bolt_inv,
+          bolt_project:    bolt_project,
+        }
+        Puppet::Pal.in_tmp_environment('bolt_catalog', **env_conf) do |pal|
+          Puppet.override(puppet_overrides) do
             Puppet.lookup(:pal_current_node).trusted_data = compile_options['trusted_facts']['values']
+            pal.with_catalog_compiler(**variables) do |compiler|
+              Puppet[:strict] = :warning
+              Puppet[:strict_variables] = false
 
+              ast = build_program(code)
+              compiler.evaluate(ast)
+              compiler.evaluate_ast_node
+              compiler.compile_additions
+              compiler.catalog_data_hash
+            end
+          end
+        end
+      ensure
+        # Return hiera_config to it's original state
+        Puppet[:hiera_config] = original_hiera_config
+      end
+      private_class_method :compile_for_project_plan
+
+      def self.compile_for_environment_plan(code, compile_options, boltlib_path)
+        plan_variables = ordered_plan_vars(compile_options)
+        target_variables = compile_options.dig('target_variables', 'values') || {}
+        variables = {
+          variables: plan_variables,
+          target_variables: target_variables,
+        }
+
+        env_conf = {
+          pre_modulepath: boltlib_path,
+          envpath: Puppet[:environmentpath],
+          facts: compile_options['facts']['values'],
+        }
+
+        # Use the existing environment with the requested name
+        Puppet::Pal.in_environment(compile_options['environment'], env_conf) do |pal|
+          # TODO: Given we hide this from plan authors this current iteration has only
+          # the "required" data for now. Once we can get https://github.com/puppetlabs/bolt/pull/1770
+          # merged and promoted we can just use an empty hash.
+          fake_config = {
+            'transport' => 'redacted',
+            'transports' => {
+              'redacted' => 'redacted'
+            }
+          }
+          bolt_inv = Bolt::ApplyInventory.new(fake_config)
+          Puppet.override(bolt_inventory: bolt_inv) do
+            Puppet.lookup(:pal_current_node).trusted_data = compile_options['trusted_facts']['values']
             # This compiler has been configured with a node containing
             # the requested environment, facts, and variables, and is used
             # to compile a catalog in that context from the supplied AST.
-            pal.with_catalog_compiler do |compiler|
-              # We have to parse the AST inside the compiler block, because it
-              # initializes the necessary type loaders for us.
-              ast = Puppet::Pops::Serialization::FromDataConverter.convert(code)
+            pal.with_catalog_compiler(**variables) do |compiler|
+              # TODO: PUP-10476 Explore setting these as default in PAL. They are the defaults in Puppet
+              Puppet[:strict] = :warning
+              Puppet[:strict_variables] = false
 
+              ast = build_program(code)
               compiler.evaluate(ast)
+              compiler.evaluate_ast_node
               compiler.compile_additions
               compiler.catalog_data_hash
             end
           end
         end
       end
-      private_class_method :compile_ast
+      private_class_method :compile_for_environment_plan
+
+      # When we do not need to load bolt we assume there are no Bolt types to resolve in
+      # AST compilation.
+      def self.compile_for_environment(code, compile_options, boltlib_path)
+        # Use the existing environment with the requested name
+        Puppet::Pal.in_environment(compile_options['environment'],
+                                    envpath: Puppet[:environmentpath],
+                                    facts: compile_options['facts']['values'],
+                                    variables: compile_options['variables']['values']) do |pal|
+          Puppet.lookup(:pal_current_node).trusted_data = compile_options['trusted_facts']['values']
+
+          # This compiler has been configured with a node containing
+          # the requested environment, facts, and variables, and is used
+          # to compile a catalog in that context from the supplied AST.
+          pal.with_catalog_compiler do |compiler|
+            # We have to parse the AST inside the compiler block, because it
+            # initializes the necessary type loaders for us.
+            ast = Puppet::Pops::Serialization::FromDataConverter.convert(code)
+
+            compiler.evaluate(ast)
+            compiler.compile_additions
+            compiler.catalog_data_hash
+          end
+        end
+      end
+      private_class_method :compile_for_environment
+
+      # Prior to PE-29443 variables were in a hash. Serialization between ruby/clojure/json did
+      # not preserve hash order necessary for deserialization. The data strucutre is now stored
+      # in a list for moving data and the list is used to construct an ordered ruby hash.
+      def self.ordered_plan_vars(compile_options)
+        if compile_options['variables']['values'].is_a?(Array)
+          compile_options['variables']['values'].each_with_object({}) do |param_hash, acc|
+            acc[param_hash.keys.first] = param_hash.values.first
+          end
+        else
+          compile_options['variables']['values']
+        end
+      end
+      private_class_method :ordered_plan_vars
 
       def self.load_bolt()
         # TODO: PE-28677 Develop entrypoint for loading bits of bolt we need here.

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -405,7 +405,7 @@
                           (compile-ast [_ _ _ _] {:cool "catalog"}))
           handler (fn ([req] {:request req}))
           app (build-ring-handler handler "1.2.3" jruby-service)]
-      (testing "compile endpoint"
+      (testing "compile endpoint for environments"
         (let [response (app (-> {:request-method :post
                                  :uri "/v3/compile"
                                  :content-type "application/json"}
@@ -415,7 +415,43 @@
                                                               :facts {:values {}}
                                                               :trusted_facts {:values {}}
                                                               :variables {:values {}}}))))]
-          (is (= 200 (:status response))))))))
+          (is (= 200 (:status response)))))
+      (testing "compile endpoint for projects"
+        (let [response (app (-> {:request-method :post
+                                 :uri "/v3/compile"
+                                 :content-type "application/json"}
+                                (ring-mock/body (json/encode {:certname "foo"
+                                                              :versioned_project "fake_project"
+                                                              :code_ast "{\"__pcore_something\": \"Foo\"}"
+                                                              :facts {:values {}}
+                                                              :trusted_facts {:values {}}
+                                                              :variables {:values {}}
+                                                              :options {:compile_for_plan true}}))))]
+          (is (= 200 (:status response)))))
+      (testing "compile endpoint fails with no environment or versioned_project"
+        (let [response (app (-> {:request-method :post
+                                 :uri "/v3/compile"
+                                 :content-type "application/json"}
+                                (ring-mock/body (json/encode {:certname "foo"
+                                                              :code_ast "{\"__pcore_something\": \"Foo\"}"
+                                                              :facts {:values {}}
+                                                              :trusted_facts {:values {}}
+                                                              :variables {:values {}}
+                                                              :options {:compile_for_plan true}}))))]
+          (is (= 400 (:status response)))))
+      (testing "compile endpoint fails with both environment and versioned_project"
+        (let [response (app (-> {:request-method :post
+                                 :uri "/v3/compile"
+                                 :content-type "application/json"}
+                                (ring-mock/body (json/encode {:certname "foo"
+                                                              :environment "production"
+                                                              :versioned_project "fake_project"
+                                                              :code_ast "{\"__pcore_something\": \"Foo\"}"
+                                                              :facts {:values {}}
+                                                              :trusted_facts {:values {}}
+                                                              :variables {:values {}}
+                                                              :options {:compile_for_plan true}}))))]
+          (is (= 400 (:status response))))))))
 
 (deftest v4-routes-test
   (with-redefs [jruby-core/borrow-from-pool-with-timeout (fn [_ _ _] {:jruby-puppet (Object.)})


### PR DESCRIPTION
This commit adds logic to the compile endpoint to support compiling AST for a
bolt project rather than an environment. Mostly project compiles are the same
as environment compiles (after all, we are still just compiling puppet code)
with a few important differences:
* We pass some additional data about the project to the compile operation
  (this is mostly data about the project name and where it's located on disk)
* The context of project compiles requires us to use `in_tmp_environment`
  instead of `in_environment` so that we can 1. ensure that we are not loading
  things from environment.conf and 2. that we can control the entirety of the
  modulepath for the compile (projects do not make use of
  basemodulepath/vendormodulepath and we need to ensure we have only exactly
  the modulepath passed in by the project)