### PR TITLE
(SERVER-3058) Add "scripts" mount as a default mount

### DIFF
--- a/dev-resources/puppetlabs/services/master/master_core_test/bolt_projects/local_23/modules/helpers/scripts/yogurt.sh
+++ b/dev-resources/puppetlabs/services/master/master_core_test/bolt_projects/local_23/modules/helpers/scripts/yogurt.sh
@@ -1,0 +1,1 @@
+echo "Frozen, with sprinkles"

--- a/src/clj/puppetlabs/services/master/file_serving.clj
+++ b/src/clj/puppetlabs/services/master/file_serving.clj
@@ -254,7 +254,7 @@
   because we have to do additional routing after branching on the query
   parameter, which is not natively supported in bidi."
 
-  ["" {[[#"tasks|modules" :mount-point] "/" :module "/" [#".+" :file-path]] :basic
+  ["" {[[#"modules|scripts|tasks" :mount-point] "/" :module "/" [#".+" :file-path]] :basic
        [[#"plugins|pluginfacts" :mount-point] #"/?" [#".*" :file-path]] :pluginsync}])
 
 (defn make-file-content-response

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -277,7 +277,7 @@
                              "environment=test&code_id=foobar"))]
           (is (= 403 (:status response)))
           (is (= (str "Request Denied: A /static_file_content request must be "
-                      "a file within the files, lib, or tasks directory of a module.")
+                      "a file within the files, lib, scripts, or tasks directory of a module.")
                  (:body response)))))
       (testing "the /static_file_content endpoint returns an error (400) for attempted traversals"
         (let [response (testutils/get-static-file-content "modules/foo/files/bar/../../../..?environment=test&code_id=foobar")]

--- a/test/unit/puppetlabs/services/master/file_serving_test.clj
+++ b/test/unit/puppetlabs/services/master/file_serving_test.clj
@@ -23,6 +23,11 @@
         (is (= (fs/file (str bolt-projects-dir "/local_23/.modules/utilities/files/etc/greeting" ))
                (fs/file (find-project-file bolt-builtin-content-dir bolt-projects-dir "local_23" "modules" "utilities" "etc/greeting")))))
 
+    (testing "finding a script in a project"
+      (testing "in the scripts mount"
+        (is (= (fs/file (str bolt-projects-dir "/local_23/modules/helpers/scripts/yogurt.sh" ))
+               (fs/file (find-project-file bolt-builtin-content-dir bolt-projects-dir "local_23" "scripts" "helpers" "yogurt.sh"))))))
+
       (testing "returns nil when a component is not found"
         (is (= nil
                (find-project-file bolt-builtin-content-dir bolt-projects-dir "fake" "modules" "helpers" "marco.sh")))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -246,6 +246,8 @@
                      "modules/foo/files/bar/baz.txt"
                      "modules/foo/files/bar/more/path/elements/baz.txt"
                      "modules/foo/files/bar/%2E%2E/baz.txt"
+                     "modules/foo/scripts/qux.sh"
+                     "modules/foo/tasks/task.sh"
                      "environments/production/files/~/.bash_profile"
                      "dist/foo/files/bar.txt"
                      "site/foo/files/bar.txt"]
@@ -266,7 +268,7 @@
         valid-path-results (map check-valid-path valid-paths)
         invalid-path-results (map check-valid-path invalid-paths)
         get-validity (fn [{:keys [valid?]}] valid?)]
-    (testing "Only files in 'modules/*/files/**' are valid"
+    (testing "Only files in 'modules/*/(files | scripts | tasks)/**' are valid"
       (is (every? get-validity valid-path-results) (ks/pprint-to-string valid-path-results))
       (is (every? (complement get-validity) invalid-path-results) (ks/pprint-to-string invalid-path-results)))))
 


### PR DESCRIPTION
This adds a new default mount "scripts" which loads files from the
scripts directory of the specified module. The mount can be used by the
file_content and file_metadata APIs (or any other API that specifies a
mount) to load file metadata and content for scripts from modules.

Requires puppetlabs/puppet#8711