### PR TITLE
(SERVER-2740) Update GEM version to 1.11.1

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.11.0
+puppetserver-ca 1.11.1


### PR DESCRIPTION
This GEM bump contains the bug fixes and changes made to Puppetserver's CA CLI prune action.
Bug fixes:
  - Correctly update the CRL number instead of updating the CRL protocol number.
  
Changes:
  - Make sure that the CRL does not get update if there was no duplicated cert to prune.
  - Output to the user the amount of duplicated certs pruned once the action is complete.