### PR TITLE
(maint) Bump to ezbake 2.2.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -165,7 +165,7 @@
                                                [puppetlabs/jruby-utils]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9]]
-                      :plugins [[puppetlabs/lein-ezbake "2.2.2"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.2.4"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk15on]
                                       [puppetlabs/trapperkeeper-webserver-jetty9]]


### PR DESCRIPTION
This commit bumps the version of ezbake to include updated jenkins urls.