### PR TITLE
(maint) Provide a reasonable default for bolt-projects dir

### DIFF
--- a/docker/puppetserver/puppetserver.conf
+++ b/docker/puppetserver/puppetserver.conf
@@ -72,6 +72,12 @@ http-client: {
     #metrics-enabled: true
 }
 
+# Provide a reasonable default here. Use case is mounting a valid projects volume to have PS serve files from there even if 
+# CM did not actually put them there.
+bolt: {
+  projects-dir: "/etc/puppetlabs/code/projects"
+}
+
 # settings related to profiling the puppet Ruby code
 profiler: {
     # enable or disable profiling for the Ruby code; defaults to 'true'.


### PR DESCRIPTION
For some testing it is desireable for puppetserver to serve some project content from some pre-defined project content. By setting a bolt-projects dir we can enable puppetserver to serve project content assuming it is in a proper structure even if it is not actually managed with code manager/file sync.