### PR TITLE
(maint) Update pupppetserver-ca GEM version to 1.11.2

### DIFF
--- a/ext/travisci/suppression.xml
+++ b/ext/travisci/suppression.xml
@@ -18,4 +18,11 @@
         <cve>CVE-2010-1330</cve>
         <cve>CVE-2011-4838</cve>
     </suppress>
+    <suppress>
+       <notes><![CDATA[
+       file name: core.cache-0.7.1.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.clojure/core\.cache@.*$</packageUrl>
+       <cve>CVE-2020-36448</cve>
+    </suppress>
 </suppressions>

--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.11.1
+puppetserver-ca 1.11.2


### PR DESCRIPTION
This GEM bump contains:
- Update to the output message for `puppetserver-ca revoke` to be more reassuring to users
- Update `puppetserver-ca list` to use the new certificate_status endpoint for better performance
when querying for CSRs only.