### PR TITLE
(SERVER-3063) Update supression notes for scan failure

### DIFF
--- a/ext/travisci/suppression.xml
+++ b/ext/travisci/suppression.xml
@@ -19,10 +19,13 @@
         <cve>CVE-2011-4838</cve>
     </suppress>
     <suppress>
-       <notes><![CDATA[
-       file name: core.cache-0.7.1.jar
-       ]]></notes>
-       <packageUrl regex="true">^pkg:maven/org\.clojure/core\.cache@.*$</packageUrl>
-       <cve>CVE-2020-36448</cve>
+        <notes><![CDATA[
+        This suppresses a medium vulnerability that was found in a cache crate for
+        Rust.  It is a false positive on the Java package core.cache-0.7.1 since
+        the Java package that we use does not have any relation to Rust.
+        The file name that causes the false positive: core.cache-0.7.1.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.clojure/core\.cache@.*$</packageUrl>
+        <cve>CVE-2020-36448</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
This commit includes the suppression message for the false positive detected with core.cache-0.7.1.jar since the previous commit that was merged did not include a clear note.