### PR TITLE
allow to install Ruby gems before puppetserver starts

### DIFF
--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -22,6 +22,7 @@ ENV PUPPERWARE_ANALYTICS_TRACKING_ID="UA-132486246-4" \
     PUPPERWARE_ANALYTICS_APP_NAME="puppetserver" \
     PUPPERWARE_ANALYTICS_ENABLED=false \
     PUPPETSERVER_JAVA_ARGS="-Xms512m -Xmx512m" \
+    PUPPETSERVER_GEMS="" \
     PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH \
     SSLDIR=/etc/puppetlabs/puppet/ssl \
     LOGDIR=/var/log/puppetlabs/puppetserver \

--- a/docker/puppetserver/README.md
+++ b/docker/puppetserver/README.md
@@ -43,6 +43,7 @@ The following environment variables are supported:
 | **PUPPETSERVER_MAX_ACTIVE_INSTANCES**      | The maximum number of JRuby instances allowed<br><br>`1`                                                                                                                                |
 | **PUPPETSERVER_MAX_REQUESTS_PER_INSTANCE** | The maximum HTTP requests a JRuby instance will handle in its lifetime (disable instance flushing)<br><br>`0`                                                                           | 
 | **PUPPETSERVER_JAVA_ARGS**                 | Arguments passed directly to the JVM when starting the service<br><br>`-Xms512m -Xmx512m`                                                                                               |
+| **PUPPETSERVER_GEMS**                      | Space-separated list of Ruby gems to be installed before puppetserver starts<br><br>Defaults to unset.                                                                                  |
 | **PUPPERWARE_ANALYTICS_ENABLED**           | Set to `true` to enable Google Analytics<br><br>`false`                                                                                                                                 |
 
 ## Initialization Scripts

--- a/docker/puppetserver/docker-entrypoint.d/65-install-gems.sh
+++ b/docker/puppetserver/docker-entrypoint.d/65-install-gems.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Install gems before puppetserver starts
+# PUPPETSERVER_GEMS="debouncer vault"
+if test -n "${PUPPETSERVER_GEMS}" ; then
+  puppetserver gem install --no-document ${PUPPETSERVER_GEMS}
+fi


### PR DESCRIPTION
I'm running puppetserver from kubernetes and require the vault gem (and dependencies) to be installed before puppetserver starts. This PR allows me to hook into the start process and install those gems.