### PR TITLE
(maint) Update puppetserver-ca GEM version to 1.11.3

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.11.2
+puppetserver-ca 1.11.3


### PR DESCRIPTION
What this GEM bump contains:
- Update to the `prune` action so that it only prune a single Puppet's CRL.
- Update logging information of the `prune` action to log the total number of certificates in Puppet's CRL.
- Fix a bug when not checking `:query` parameters to be `nil` when create a URL.