### PR TITLE
(maint) Update puppetserver-ca GEM version to 1.11.4

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.11.3
+puppetserver-ca 1.11.4


### PR DESCRIPTION
This bump contains:
- A bug fix for the `prune` action to require the set module.  Without this module, the upgrade PE process will not prune correctly.