### PR TITLE
(maint) Bump snapshot version to prep for 7.4.0 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "7.3.1-SNAPSHOT")
+(def ps-version "7.4.0-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
We have landed support for TLS 1.3, so this commit bumps the snapshot version
so that we can do a Y release with this feature.