### PR TITLE
(SERVER-2842) Bump puppetserver-ca to 1.11.5

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 1.11.4
+puppetserver-ca 1.11.6


### PR DESCRIPTION
This commit bumps the puppetserver-ca gem to 1.11.5, which includes a `--force`
flag to be used with `puppetserver ca generate --ca-client` when we can't
determine if the puppetserver service is running or not.