### PR TITLE
(maint) Update to latest puppet/puppet-agent pins

### DIFF
--- a/acceptance/config/beaker/options.rb
+++ b/acceptance/config/beaker/options.rb
@@ -11,4 +11,4 @@
  "puppetserver-confdir"=>"/etc/puppetlabs/puppetserver/conf.d",
  "puppetserver-config"=>
   "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
- :puppet_build_version=>"16a38db50a1a9f8a48f3aa9b841f186550acc83f"}
+ :puppet_build_version=>"95850001d873ff36d06c0a1a293529a18ad59ae3"}


### PR DESCRIPTION
This commit updates our pins for puppet and puppet-agent to the release
candidates for the upcoming 7.11.0 release, in order to get validation
started before those have officially promoted.