### PR TITLE
(SERVER-3050) Allow retrieving facts from any terminus

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/compiler_spec.rb
@@ -93,11 +93,11 @@ describe Puppet::Server::Compiler do
 
         it 'requests facts from pdb after classifying and attempts to classify again' do
           allow(Puppet::Node::Facts.indirection.terminus).to receive(:name).and_return(:puppetdb)
-          expect(compiler).to receive(:get_facts_from_pdb)
+          expect(compiler).to receive(:get_facts_from_terminus)
                   .with(certname, 'fancy')
                   .ordered
                   .and_return(Puppet::Node::Facts.new(certname))
-          expect(compiler).to receive(:get_facts_from_pdb)
+          expect(compiler).to receive(:get_facts_from_terminus)
                   .with(certname, 'production')
                   .ordered
                   .and_return(Puppet::Node::Facts.new(certname))
@@ -114,7 +114,7 @@ describe Puppet::Server::Compiler do
           end
 
           allow(Puppet::Node::Facts.indirection.terminus).to receive(:name).and_return(:puppetdb)
-          allow(compiler).to receive(:get_facts_from_pdb).and_return(Puppet::Node::Facts.new(certname))
+          allow(compiler).to receive(:get_facts_from_terminus).and_return(Puppet::Node::Facts.new(certname))
 
           expect(Puppet::Node.indirection).to receive(:find).and_return(
             Puppet::Node.new(certname, environment: 'production')

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -59,7 +59,7 @@ module Puppet
             end
 
             environment = node.environment
-            facts = get_facts_from_pdb(certname, environment.to_s)
+            facts = get_facts_from_terminus(certname, environment.to_s)
             node = Puppet.override(trusted_information: trusted_facts) do
               Puppet::Node.indirection.find(certname,
                                             environment: environment,
@@ -175,11 +175,9 @@ module Puppet
 
       def extract_facts(request_data)
         if request_data['facts'].nil?
-          if Puppet::Node::Facts.indirection.terminus.name.to_s == "puppetdb"
-            facts = get_facts_from_pdb(request_data['certname'], request_data['environment'])
-          else
-            raise(Puppet::Error, "PuppetDB not configured, please provide facts with your catalog request.")
-          end
+          Puppet.debug _("No facts submitted with request, retrieving from %{terminus_name}.") % { terminus_name: Puppet::Node::Facts.indirection.terminus.name.to_s }
+          facts = get_facts_from_terminus(request_data['certname'],
+                                          request_data['environment'])
         else
           facts_from_request = request_data['facts']
 
@@ -209,16 +207,11 @@ module Puppet
         trusted_facts ||= {}
       end
 
-      def get_facts_from_pdb(nodename, environment)
-        pdb_terminus = Puppet::Node::Facts::Puppetdb.new
-        request = Puppet::Indirector::Request.new(pdb_terminus.class.name,
-                                                  :find,
-                                                  nodename,
-                                                  nil,
-                                                  :environment => environment)
-        facts = pdb_terminus.find(request)
+      def get_facts_from_terminus(nodename, environment)
+        facts = Puppet::Node::Facts.indirection.find(nodename,
+                                                     {environment: environment})
 
-        # If no facts have been stored for the node, PDB will return nil
+        # If no facts have been stored for the node, the terminus will return nil
         if facts.nil?
           # Create an empty facts object
           facts = Puppet::Node::Facts.new(nodename)


### PR DESCRIPTION
Previously, the v4 catalog endpoint would only fetch facts (as opposed
to requiring them in the request) if the PuppetDB facts terminus was
configured. This caused issues for people wanting to use extensions of
the PDB terminus, like satellite, because the endpoint would error
claiming that PDB wasn't configured.

This commit removes the restriction on the fact retrieval logic. Now, if
facts are not supplied in the request body, puppetserver will attempt to
fetch them from whatever facts terminus is configured, whether that is
yaml/json (default), PuppetDB, or some custom terminus. So long as the
terminus implements `find`, this will succeed.