### PR TITLE
(SERVER-3050) Bypass the fact cache in the v4 catalog endpoint

### DIFF
--- a/acceptance/scripts/generic/testrun.sh
+++ b/acceptance/scripts/generic/testrun.sh
@@ -8,7 +8,7 @@ do_init()
     exit -1;
   fi
 
-  bundle exec beaker-hostgenerator $GENCONFIG_LAYOUT > $BEAKER_CONFIG
+  bundle exec beaker-hostgenerator --hypervisor abs $GENCONFIG_LAYOUT > $BEAKER_CONFIG
 
   BEAKER_INIT="bundle exec beaker init --debug"
   BEAKER_INIT="$BEAKER_INIT --type aio"

--- a/src/ruby/puppetserver-lib/puppet/server/compiler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/compiler.rb
@@ -208,8 +208,10 @@ module Puppet
       end
 
       def get_facts_from_terminus(nodename, environment)
+        # Ignore the cache terminus, which is not guaranteed to store trusted facts
         facts = Puppet::Node::Facts.indirection.find(nodename,
-                                                     {environment: environment})
+                                                     {environment: environment,
+                                                      ignore_cache: true})
 
         # If no facts have been stored for the node, the terminus will return nil
         if facts.nil?


### PR DESCRIPTION
When we stopped explicitly querying the PuppetDB terminus for facts, we
inadventently started using the yaml cache terminus instead of PuppetDB,
even when PuppetDB was configured. However, trusted facts are not stored
in the yaml cache, and the primary use case for this endpoint requires
stored trusted facts to be retrieved from the system. So this commit
updates the fact retrieval to bypass the cache terminus for facts, going
instead directly to the primary terminus.

When PuppetDB is configured, this means we will query PDB for facts,
rather than the default yaml cache, and therefore retrieve its stored
trusted facts.