### PR TITLE
(maint) Update ca-certificates

### DIFF
--- a/acceptance/suites/pre_suite/foss/10_update_ca_certs.rb
+++ b/acceptance/suites/pre_suite/foss/10_update_ca_certs.rb
@@ -1,0 +1,10 @@
+step 'Update CA certs on Centos' do
+  hosts.each do |host|
+    if host.platform =~ /el/
+      on(host, 'yum update -y ca-certificates')
+    elsif host.platform =~ /debian|ubuntu/
+      on(host, 'apt-get update')
+      on(host, 'apt-get install -y ca-certificates libgnutls30')
+    end
+  end
+end


### PR DESCRIPTION
Recently a major root certificate expired and had to be replaced. This
caused postgres to fail to install, on platforms where we install PDB.
This commit adds a step to our presuite that fetches new CA certificates,
to ensure that next time a cert is rotated, we will fetch it automatically.