### PR TITLE
(maint) Stop testing with PuppetDB on EL6 for now

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -64,7 +64,6 @@ module PuppetServerExtensions
     [
       /debian-8/,
       /debian-9/,
-      /el-6/,
       /el-7/,
       /ubuntu-16.04/,
       /ubuntu-18.04/

--- a/acceptance/suites/pre_suite/foss/10_update_ca_certs.rb
+++ b/acceptance/suites/pre_suite/foss/10_update_ca_certs.rb
@@ -1,6 +1,6 @@
 step 'Update CA certs on Centos' do
   hosts.each do |host|
-    if host.platform =~ /el/
+    if host.platform =~ /el-7/
       on(host, 'yum update -y ca-certificates')
     elsif host.platform =~ /debian|ubuntu/
       on(host, 'apt-get update')


### PR DESCRIPTION
The recent root certificate expiration has made it difficult to install
postgres on EL6. RedHat did not issue an update of the `ca-certificates`
package for this EOL platform, so avoiding the expired cert is much more
complicated. Since we will soon be dropping support for EL6, we decided
to instead stop testing the PDB integration on this platform. This
commit removes it from the list of PDB master platforms. If a good
workaround is found, we can put this back.