### PR TITLE
(maint) Fix ca-certificates update for el6; re-enable PDB

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -64,6 +64,7 @@ module PuppetServerExtensions
     [
       /debian-8/,
       /debian-9/,
+      /el-6/,
       /el-7/,
       /ubuntu-16.04/,
       /ubuntu-18.04/

--- a/acceptance/suites/pre_suite/foss/10_update_ca_certs.rb
+++ b/acceptance/suites/pre_suite/foss/10_update_ca_certs.rb
@@ -1,6 +1,12 @@
 step 'Update CA certs on Centos' do
   hosts.each do |host|
-    if host.platform =~ /el-7/
+    if host.platform =~ /el-6/
+      # Our EL6 images do not have recent enough repos to pull down the updated ca-certificates package,
+      # so we need to edit their configs before attempting to upgrade it
+      on(host, 'rm -f /etc/yum.repos.d/localmirror-extras.repo /etc/yum.repos.d/localmirror-optional.repo')
+      on(host, "sed -i 's/68/610/' /etc/yum.repos.d/localmirror-os.repo")
+      on(host, 'yum update -y ca-certificates')
+    elsif host.platform =~ /el-7/
       on(host, 'yum update -y ca-certificates')
     elsif host.platform =~ /debian|ubuntu/
       on(host, 'apt-get update')


### PR DESCRIPTION
This commit edits the yum repos on RHEL6 to allow us to install a newer
`ca-certificates` package that avoids the expired Let's Encrypt root
cert. This allows us to successfully install postgres, which in turn
allows this commit to also re-enable testing with PDB on EL6.