### PR TITLE
(SERVER-3079) Run Dropsonde weekly

### DIFF
--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -8,6 +8,10 @@ product: {
            artifact-id: puppetserver}
 }
 
+dropsonde: {
+    enabled: false
+}
+
 webserver: {
     access-log-config: ./dev/request-logging-dev.xml
     client-auth: want

--- a/resources/ext/build-scripts/dropsonde-gem.txt
+++ b/resources/ext/build-scripts/dropsonde-gem.txt
@@ -1,0 +1,1 @@
+dropsonde 0.0.6

--- a/resources/ext/build-scripts/install-vendored-gems.sh
+++ b/resources/ext/build-scripts/install-vendored-gems.sh
@@ -3,6 +3,21 @@
 set -x
 set -e
 
+install_gems () {
+  gem_file=$1
+  additional_args=$2
+
+  gem_list=()
+  while read LINE
+  do
+    gem_name=$(echo $LINE |awk '{print $1}')
+    gem_version=$(echo $LINE |awk '{print $2}')
+    gem_list+=("$gem_name:$gem_version")
+  done < $gem_file
+
+  java -cp puppet-server-release.jar:jruby-9k.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install ${additional_args:+"$additional_args"} --no-document "${gem_list[@]}"
+}
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
@@ -16,16 +31,9 @@ cat "${DIR}/jruby-gem-list.txt"
 
 echo "jruby-puppet: { gem-home: ${DESTDIR}/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems }" > jruby.conf
 
-gem_list=()
-while read LINE
-do
-  gem_name=$(echo $LINE |awk '{print $1}')
-  gem_version=$(echo $LINE |awk '{print $2}')
-  gem_list+=("$gem_name:$gem_version")
-done < "${DIR}/jruby-gem-list.txt"
-java -cp puppet-server-release.jar:jruby-9k.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install --no-document "${gem_list[@]}"
+install_gems "${DIR}/jruby-gem-list.txt"
 
-# We need to ignore dependencies to prevent puppetserver from being installed
+# We need to ignore dependencies to prevent puppetserver-ca from being installed
 # with facter2 (from gem dependency resolution) and facter3 (from puppet-agent packages)
 # If puppetserver ever loses its dependency on puppet-agent or if puppet-agent ever loses
 # facter, this will probably explode.
@@ -40,11 +48,14 @@ cat "${DIR}/mri-gem-list-no-dependencies.txt"
 
 echo "jruby-puppet: { gem-home: ${DESTDIR}/opt/puppetlabs/puppet/lib/ruby/vendor_gems }" > jruby.conf
 
-gem_list=()
-while read LINE
-do
-  gem_name=$(echo $LINE |awk '{print $1}')
-  gem_version=$(echo $LINE |awk '{print $2}')
-  gem_list+=("$gem_name:$gem_version")
-done < "${DIR}/mri-gem-list-no-dependencies.txt"
-java -cp puppet-server-release.jar:jruby-9k.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install --no-document --ignore-dependencies "${gem_list[@]}"
+install_gems "${DIR}/mri-gem-list-no-dependencies.txt" "--ignore-dependencies"
+
+# We need to install Dropsonde into an isolated directory so that its dependencies
+# can be installed with it without relying on the gems otherwise shipped by
+# puppet-agent or by puppetserver.
+echo "Installing Dropsonde into an isolated directory, to prevent dependency conflicts"
+cat "${DIR}/dropsonde-gem.txt"
+
+echo "jruby-puppet: { gem-home: ${DESTDIR}/opt/puppetlabs/server/data/puppetserver/dropsonde }" > jruby.conf
+
+install_gems "${DIR}/dropsonde-gem.txt"

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -78,3 +78,12 @@ profiler: {
     # enable or disable profiling for the Ruby code; defaults to 'true'.
     #enabled: true
 }
+
+# settings related to submitting module metrics via Dropsonde
+dropsonde: {
+    #enabled: false
+
+    # How long, in seconds, to wait between dropsonde submissions
+    # Defaults to one week.
+    # interval: 604800
+}

--- a/src/clj/puppetlabs/services/analytics/analytics_service.clj
+++ b/src/clj/puppetlabs/services/analytics/analytics_service.clj
@@ -2,7 +2,8 @@
   (:require [clojure.tools.logging :as log]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
             [puppetlabs.i18n.core :as i18n]
-            [puppetlabs.dujour.version-check :as version-check]))
+            [puppetlabs.dujour.version-check :as version-check]
+            [puppetlabs.services.analytics.dropsonde :refer [run-dropsonde]]))
 
 (defprotocol AnalyticsService
   "Protocol placeholder for the analytics service.")
@@ -14,17 +15,28 @@
 
   (start
    [this context]
-   (let [config (get-config)
-         product-name (or (get-in config [:product :name])
-                          {:group-id "puppetlabs"
-                           :artifact-id "puppetserver"})
-         checkin-interval-millis (* 1000 60 60 24) ; once per day
-         update-server-url (get-in config [:product :update-server-url])
-         check-for-updates (get-in config [:product :check-for-updates] true)]
-     (if check-for-updates
-       (interspaced checkin-interval-millis
-                    (fn [] (version-check/check-for-updates!
-                            {:product-name product-name} update-server-url)))
-       (log/info (i18n/trs "Not checking for updates - opt-out setting exists"))))
-   (log/info (i18n/trs "Puppet Server Update Service has successfully started and will run in the background"))
+   (let [config (get-config)]
+     ;; Configure analytics
+     (let [product-name (or (get-in config [:product :name])
+                            {:group-id "puppetlabs"
+                             :artifact-id "puppetserver"})
+           checkin-interval-millis (* 1000 60 60 24) ; once per day
+           update-server-url (get-in config [:product :update-server-url])
+           check-for-updates (get-in config [:product :check-for-updates] true)]
+       (if check-for-updates
+         (interspaced checkin-interval-millis
+                      (fn [] (version-check/check-for-updates!
+                              {:product-name product-name} update-server-url)))
+         (log/info (i18n/trs "Not checking for updates - opt-out setting exists"))))
+     (log/info (i18n/trs "Puppet Server Update Service has successfully started and will run in the background"))
+
+     ;; Configure dropsonde
+     (let [dropsonde-enabled (get-in config [:dropsonde :enabled] false)
+           ;; once a week, config value is documented as seconds
+           dropsonde-interval-millis (* 1000 (get-in config [:dropsonde :interval]
+                                             (* 60 60 24 7)))]
+       (if dropsonde-enabled
+         (interspaced dropsonde-interval-millis #(run-dropsonde config))
+         (log/info (i18n/trs (str "Not submitting module metrics via Dropsonde -- submission is disabled. "
+                                  "Enable this feature by setting `dropsonde.enabled` to true in Puppet Server''s config."))))))
    context))

--- a/src/clj/puppetlabs/services/analytics/dropsonde.clj
+++ b/src/clj/puppetlabs/services/analytics/dropsonde.clj
@@ -1,18 +1,31 @@
 (ns puppetlabs.services.analytics.dropsonde
   (:require [clojure.java.shell :refer [sh]]
             [clojure.tools.logging :as log]
-            [puppetlabs.i18n.core :as i18n]))
+            [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet]))
 
 (def puppet-agent-ruby "/opt/puppetlabs/puppet/bin/ruby")
 (def dropsonde-dir "/opt/puppetlabs/server/data/puppetserver/dropsonde")
 (def dropsonde-bin (str dropsonde-dir "/bin/dropsonde"))
 
 (defn run-dropsonde
-  []
-  (let [result (sh puppet-agent-ruby dropsonde-bin "submit"
+  [config]
+  (let [confdir (get-in config [:jruby-puppet :master-conf-dir]
+                        jruby-puppet/default-master-conf-dir)
+        codedir (get-in config [:jruby-puppet :master-code-dir]
+                        jruby-puppet/default-master-code-dir)
+        vardir (get-in config [:jruby-puppet :master-var-dir]
+                       jruby-puppet/default-master-var-dir)
+        logdir (get-in config [:jruby-puppet :master-log-dir]
+                       jruby-puppet/default-master-log-dir)
+        result (sh puppet-agent-ruby dropsonde-bin "submit"
                    :env {"GEM_HOME" dropsonde-dir
                          "GEM_PATH" dropsonde-dir
-                         "HOME" dropsonde-dir})]
+                         "HOME" dropsonde-dir
+                         "PUPPET_CONFDIF" confdir
+                         "PUPPET_CODEDIR" codedir
+                         "PUPPET_VARDIR" vardir
+                         "PUPPET_LOGDIR" logdir})]
     (if (= 0 (:exit result))
       (log/info (i18n/trs "Successfully submitted module metrics via Dropsonde."))
       (log/warn (i18n/trs "Failed to submit module metrics via Dropsonde. Error: {0}"

--- a/src/clj/puppetlabs/services/analytics/dropsonde.clj
+++ b/src/clj/puppetlabs/services/analytics/dropsonde.clj
@@ -1,0 +1,19 @@
+(ns puppetlabs.services.analytics.dropsonde
+  (:require [clojure.java.shell :refer [sh]]
+            [clojure.tools.logging :as log]
+            [puppetlabs.i18n.core :as i18n]))
+
+(def puppet-agent-ruby "/opt/puppetlabs/puppet/bin/ruby")
+(def dropsonde-dir "/opt/puppetlabs/server/data/puppetserver/dropsonde")
+(def dropsonde-bin (str dropsonde-dir "/bin/dropsonde"))
+
+(defn run-dropsonde
+  []
+  (let [result (sh puppet-agent-ruby dropsonde-bin "submit"
+                   :env {"GEM_HOME" dropsonde-dir
+                         "GEM_PATH" dropsonde-dir
+                         "HOME" dropsonde-dir})]
+    (if (= 0 (:exit result))
+      (log/info (i18n/trs "Successfully submitted module metrics via Dropsonde."))
+      (log/warn (i18n/trs "Failed to submit module metrics via Dropsonde. Error: {0}"
+                          (:err result))))))


### PR DESCRIPTION
This installs the Dropsonde gem into an isolated directory during package 
install. This gem is meant to be run via MRI Ruby from the CLI, and uses
its own self-contained dependencies, not gems installed with either 
puppetserver or puppet-agent.

It also a new scheduled job to the analytics service, to submit
module metrics to dujour via dropsonde. This submission is managed by
the same service as the existing analytics submission, but is configured
separately and runs weekly instead of daily.

Submission is disabled by default. When enabled, metrics will be
collected and submitted when the server starts, and weekly thereafter.
A failed dropsonde invocation will log an error but otherwise cause no
issues.