### PR TITLE
(SERVER-3079) Use updated terminology for puppet settings

### DIFF
--- a/resources/ext/build-scripts/dropsonde-gem.txt
+++ b/resources/ext/build-scripts/dropsonde-gem.txt
@@ -1,1 +1,2 @@
 dropsonde 0.0.6
+scanf 1.0.0

--- a/src/clj/puppetlabs/services/analytics/dropsonde.clj
+++ b/src/clj/puppetlabs/services/analytics/dropsonde.clj
@@ -11,14 +11,15 @@
 
 (defn run-dropsonde
   [config]
-  (let [confdir (get-in config [:jruby-puppet :master-conf-dir]
-                        jruby-puppet/default-master-conf-dir)
-        codedir (get-in config [:jruby-puppet :master-code-dir]
-                        jruby-puppet/default-master-code-dir)
-        vardir (get-in config [:jruby-puppet :master-var-dir]
-                       jruby-puppet/default-master-var-dir)
-        logdir (get-in config [:jruby-puppet :master-log-dir]
-                       jruby-puppet/default-master-log-dir)
+  ;; process config to ensure default resolution of these settings
+  (let [puppet-config (jruby-puppet/initialize-puppet-config
+                       {}
+                       (jruby-puppet/extract-puppet-config (:jruby-puppet config))
+                       false)
+        confdir (:server-conf-dir puppet-config)
+        codedir (:server-code-dir puppet-config)
+        vardir (:server-var-dir puppet-config)
+        logdir (:server-log-dir puppet-config)
         result (shell-utils/execute-command puppet-agent-ruby
                                             {:args [dropsonde-bin "submit"]
                                              :env {"GEM_HOME" dropsonde-dir


### PR DESCRIPTION
In Puppet Server 7 we renamed several settings from `master-*` to
`server-*`. This commit updates our reading of these settings to use the
existing default resolution logic, which check both values before
falling back to the hard-coded default.