### PR TITLE
(SERVER-3079) add Dropsonde wrapper script

### DIFF
--- a/resources/ext/cli/dropsonde.erb
+++ b/resources/ext/cli/dropsonde.erb
@@ -9,7 +9,7 @@ export GEM_PATH=${DROPSONDE_DIR}
 
 if [[ -f "$DROPSONDE_BIN" && -x "$DROPSONDE_BIN" ]]
 then
-    $DROPSONDE_BIN "$@"
+    $PUPPET_AGENT_RUBY $DROPSONDE_BIN "$@"
 else
     echo "Dropsonde does not appear to be installed properly."
 fi

--- a/resources/ext/cli/dropsonde.erb
+++ b/resources/ext/cli/dropsonde.erb
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+PUPPET_AGENT_RUBY="/opt/puppetlabs/puppet/bin/ruby"
+DROPSONDE_DIR="/opt/puppetlabs/server/data/puppetserver/dropsonde"
+DROPSONDE_BIN="${DROPSONDE_DIR}/bin/dropsonde"
+
+export GEM_HOME=${DROPSONDE_DIR}
+export GEM_PATH=${DROPSONDE_DIR}
+
+if [[ -f "$DROPSONDE_BIN" && -x "$DROPSONDE_BIN" ]]
+then
+    $DROPSONDE_BIN "$@"
+else
+    echo "Dropsonde does not appear to be installed properly."
+fi
+


### PR DESCRIPTION
This allows users to invoke Dropsonde as `puppetserver dropsonde` and
access the local functionality such as generating reports for their own
usage or to validate what data will be submitted.
