### PR TITLE
(SERVER-3114) Fix authority key ID and alt names of self-signed CA cert

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -652,12 +652,12 @@
 (schema/defn create-ca-extensions :- (schema/pred utils/extension-list?)
   "Create a list of extensions to be added to the CA certificate."
   [ca-name :- (schema/pred utils/valid-x500-name?)
-   ca-serial :- (schema/pred number?)
+   issuer-public-key :- (schema/pred utils/public-key?)
    ca-public-key :- (schema/pred utils/public-key?)]
   (vec
     (cons (utils/netscape-comment
            netscape-comment-value)
-          (->> (utils/create-ca-extensions ca-name ca-serial ca-public-key)
+          (->> (utils/create-ca-extensions issuer-public-key ca-public-key)
                (ensure-ext-list-has-cn-san (utils/x500-name->CN ca-name))))))
 
 (schema/defn read-infra-nodes
@@ -716,8 +716,10 @@
         x500-name   (utils/cn (:ca-name ca-settings))
         validity    (cert-validity-dates (:ca-ttl ca-settings))
         serial      (next-serial-number! (:serial ca-settings))
+        ;; Since this is a self-signed cert, the issuer key and the
+        ;; key for this cert are the same
         ca-exts     (create-ca-extensions x500-name
-                                          serial
+                                          public-key
                                           public-key)
         cacert      (utils/sign-certificate
                      x500-name

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -648,17 +648,14 @@
                   (utils/subject-dns-alt-names [cn] false))]
     (conj sans-san new-san)))
 
-
 (schema/defn create-ca-extensions :- (schema/pred utils/extension-list?)
   "Create a list of extensions to be added to the CA certificate."
-  [ca-name :- (schema/pred utils/valid-x500-name?)
-   issuer-public-key :- (schema/pred utils/public-key?)
+  [issuer-public-key :- (schema/pred utils/public-key?)
    ca-public-key :- (schema/pred utils/public-key?)]
   (vec
     (cons (utils/netscape-comment
            netscape-comment-value)
-          (->> (utils/create-ca-extensions issuer-public-key ca-public-key)
-               (ensure-ext-list-has-cn-san (utils/x500-name->CN ca-name))))))
+          (utils/create-ca-extensions issuer-public-key ca-public-key))))
 
 (schema/defn read-infra-nodes
     "Returns a list of infra nodes or infra node serials from the specified file organized as one item per line."
@@ -718,8 +715,7 @@
         serial      (next-serial-number! (:serial ca-settings))
         ;; Since this is a self-signed cert, the issuer key and the
         ;; key for this cert are the same
-        ca-exts     (create-ca-extensions x500-name
-                                          public-key
+        ca-exts     (create-ca-extensions public-key
                                           public-key)
         cacert      (utils/sign-certificate
                      x500-name

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -668,6 +668,8 @@
         (testing "has at least one expected extension - key usage"
           (let [key-usage (utils/get-extension-value cert "2.5.29.15")]
             (is (= #{:key-cert-sign :crl-sign} key-usage))))
+        (testing "does not have any SANs"
+          (is (nil? (utils/get-extension-value cert subject-alt-names-oid))))
         (testing "authority key identifier is SHA of public key"
           (let [ca-pub-key (-> settings :capub utils/pem->public-key)
                 pub-key-sha (pubkey-sha1 ca-pub-key)]
@@ -1429,15 +1431,11 @@
                                                :dns-alt-names dns-alt-names))))))
 
     (testing "basic extensions are created for a CA"
-      (let [exts          (create-ca-extensions subject-dn
-                                                subject-pub
+      (let [exts          (create-ca-extensions subject-pub
                                                 subject-pub)
             exts-expected [{:oid      "2.16.840.1.113730.1.13"
                             :critical false
                             :value    netscape-comment-value}
-                           {:oid       "2.5.29.17"
-                            :critical false
-                            :value    {:dns-name [subject]}}
                            {:oid      "2.5.29.35"
                             :critical false
                             :value    {:issuer-dn     nil

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -3,8 +3,9 @@
                     StringWriter
                     ByteArrayInputStream
                     ByteArrayOutputStream)
-           (java.security InvalidParameterException)
-           (com.puppetlabs.ssl_utils SSLUtils))
+           (com.puppetlabs.ssl_utils SSLUtils)
+           (java.security PublicKey MessageDigest)
+           (org.bouncycastle.asn1.x509 SubjectPublicKeyInfo))
   (:require [puppetlabs.puppetserver.certificate-authority :refer :all]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.ssl-utils.core :as utils]
@@ -152,6 +153,22 @@
   "Does the provided extension list contain an extensions with the given OID."
   [ext-list oid]
   (> (count (filter #(= oid (:oid %)) ext-list)) 0))
+
+;; TODO copied from jvm-ssl-utils testutils. That lib should be updated
+;; to expose its test jar so we can use this directly instead.
+(defn pubkey-sha1
+  "Gets the SHA-1 digest of the raw bytes of the provided publickey."
+  [pub-key]
+  {:pre [(utils/public-key? pub-key)]
+   :post [(vector? %)
+          (every? integer? %)]}
+  (let [bytes   (-> ^PublicKey
+                    pub-key
+                    .getEncoded
+                    SubjectPublicKeyInfo/getInstance
+                    .getPublicKeyData
+                    .getBytes)]
+    (vec (.digest (MessageDigest/getInstance "SHA1") bytes))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests


### PR DESCRIPTION
There are two fixes in this PR:

Firstly, for consistency, the auto CA generation code in puppetserver now creates its self-signed CA cert with a `keyid` authority key identifier. This is consistent with what the newer (recommended) chained CA generation code in the CLI tool does.

Secondly, it removes the subject alt names from the self-signed cert, since they're unnecessary, and the fact that its common name is not a valid DNS name caused issues with LibreSSL.