### PR TITLE
(SERVER-3137) Update ezbake to 2.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -165,7 +165,7 @@
                                                [puppetlabs/jruby-utils]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9]]
-                      :plugins [[puppetlabs/lein-ezbake "2.2.4"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.3.0"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk15on]
                                       [puppetlabs/trapperkeeper-webserver-jetty9]]


### PR DESCRIPTION
This update brings in support for building Debian 11 Bullseye packages.