### PR TITLE
(SERVER-3166) Bump dropsonde to 0.0.7

### DIFF
--- a/resources/ext/build-scripts/dropsonde-gem.txt
+++ b/resources/ext/build-scripts/dropsonde-gem.txt
@@ -1,1 +1,1 @@
-dropsonde 0.0.6
+dropsonde 0.0.7


### PR DESCRIPTION
This commit updates dropsonde to 0.0.7, which includes a stable url for the
telemetry endpoint (updates.puppet.com).