### PR TITLE
Log config fails on multiple certificates

### DIFF
--- a/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
+++ b/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
@@ -10,7 +10,11 @@ if test -n "${PUPPETSERVER_HOSTNAME}"; then
   certname=${PUPPETSERVER_HOSTNAME}.pem
 else
   echo "* PUPPETSERVER_HOSTNAME: unset"
-  certname=$(cd "${SSLDIR}/certs" && ls *.pem | grep --invert-match ca.pem)
+  # choose first certificate found
+  for certname in "$SSLDIR/certs"/*.pem ; do
+    certname=${certname##*/}
+    [ "$certname" != ca.pem ] && break
+  done
 fi
 echo "* PUPPET_MASTERPORT: '${PUPPET_MASTERPORT}'"
 echo "* Certname: '${certname}'"


### PR DESCRIPTION
This PR prevents this script from failing, when there are multiple certificates found in `$SSLDIR`. It just picks the first one and ignores any other certificates.