### PR TITLE
(maint) Ensure needed container directories are owned by puppet

### DIFF
--- a/docker/puppetserver/docker-entrypoint.d/30-set-permissions.sh
+++ b/docker/puppetserver/docker-entrypoint.d/30-set-permissions.sh
@@ -2,3 +2,5 @@
 
 chown -R puppet:puppet /etc/puppetlabs/puppet/
 chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver/
+chown -R puppet:puppet /etc/puppetlabs/puppetserver/
+chown -R puppet:puppet /var/log/puppetlabs/puppetserver/


### PR DESCRIPTION
The container is created with the puppet user owning these directories
and if a user causes the UID of the puppet user to change than they will
not be readable.

This forces those directories to be owned by the puppet user regardless
of UID on start up.

h/t to jay7x who originally proposed this.