### PR TITLE
(maint) Stop testing TLS 1.0 and 1.1

### DIFF
--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -103,7 +103,7 @@ jruby-puppet: {
 # configured with these settings automatically.
 http-client: {
     # A list of acceptable protocols for making HTTP requests
-    #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]
+    #ssl-protocols: [TLSv1.2]
 
     # A list of acceptable cipher suites for making HTTP requests
     #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,

--- a/docker/puppetserver/puppetserver.conf
+++ b/docker/puppetserver/puppetserver.conf
@@ -60,7 +60,7 @@ jruby-puppet: {
 # settings related to HTTPS client requests made by Puppet Server
 http-client: {
     # A list of acceptable protocols for making HTTPS requests
-    #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]
+    #ssl-protocols: [TLSv1.2]
 
     # A list of acceptable cipher suites for making HTTPS requests
     #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,

--- a/ext/thread_test/puppetserver.conf
+++ b/ext/thread_test/puppetserver.conf
@@ -98,7 +98,7 @@ jruby-puppet: {
 # configured with these settings automatically.
 http-client: {
     # A list of acceptable protocols for making HTTP requests
-    #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]
+    #ssl-protocols: [TLSv1.2]
 
     # A list of acceptable cipher suites for making HTTP requests
     #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -61,7 +61,7 @@ jruby-puppet: {
 # settings related to HTTPS client requests made by Puppet Server
 http-client: {
     # A list of acceptable protocols for making HTTPS requests
-    #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]
+    #ssl-protocols: [TLSv1.2]
 
     # A list of acceptable cipher suites for making HTTPS requests
     #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,

--- a/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -273,23 +273,6 @@ jruby-config :- jruby-schemas/JRubyConfig
               (catch EvalFailedException e
                 (is (instance? ex-class (.getCause e)))))))))))
 
-  (when-not (SSLUtils/isFIPS)
-    (testing "Can connect via TLSv1 by default"
-      (with-webserver-with-protocols ["TLSv1"] ["TLS_RSA_WITH_AES_128_CBC_SHA"]
-        (with-scripting-container sc
-          (with-http-client sc 10080 {:use-ssl true}
-            (.runScriptlet sc "$response = $c.get('/', {})")
-            (is (= "200" (.runScriptlet sc "$response.code")))
-            (is (= "hi" (.runScriptlet sc "$response.body")))))))
-
-    (testing "Can connect via TLSv1.1 by default"
-      (with-webserver-with-protocols ["TLSv1.1"] ["TLS_RSA_WITH_AES_128_CBC_SHA"]
-        (with-scripting-container sc
-          (with-http-client sc 10080 {:use-ssl true}
-            (.runScriptlet sc "$response = $c.get('/', {})")
-            (is (= "200" (.runScriptlet sc "$response.code")))
-            (is (= "hi" (.runScriptlet sc "$response.body"))))))))
-
   (testing "Can connect via TLSv1.2 by default"
     (with-webserver-with-protocols ["TLSv1.2"] nil
       (with-scripting-container sc


### PR DESCRIPTION
This commit removes the HTTP client tests for TLS 1.0 and TLS 1.1. These
protocols are no longer considered secure and, as such, have been disabled in
certain operating systems, including Debian 10 (buster), which is what the
jenkins workers now use. Previously, these tests were failing since the jenkins
workers were recently upgraded.