### PR TITLE
(SERVER-1381) Create puppet user with uid/gid 52

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -90,6 +90,7 @@
   :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"
                        :group "puppet"
+                       :numeric-uid-gid 52
                        :build-type "foss"
                        :java-args ~(str "-Xms2g -Xmx2g "
                                      "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger")


### PR DESCRIPTION
Support for fixed UIDs/GIDs was added to ezbake way back in
EZ-128 (puppetlabs/ezbake#512)

This commit uses this feature to use the reserved UID of 52 when the
`puppet` user is created when the puppetserver RPM is first installed.