### PR TITLE
(SERVER-2797) Bump puppetserver-ca to 2.3.6

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 2.3.5
+puppetserver-ca 2.3.6


### PR DESCRIPTION
The `puppetserver ca list` command will now exit 1 when run on a non-CA server.