### PR TITLE
(maint) Update ntp module to 9.1.0

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -170,7 +170,7 @@ YAML
 forge 'forge.puppetlabs.com'
 
 # Forge Modules
-mod 'puppetlabs/ntp', '4.1.0'
+mod 'puppetlabs/ntp', '9.1.0'
 mod 'puppetlabs/stdlib'
 EOF
   create_remote_file(master, "#{git_local_repo}/Puppetfile", puppetfile)


### PR DESCRIPTION
This commit updates the ntp module that we use in acceptance tests to version
9.1.0. This test started failing when we added support for sles-15-x86_64
because ntp 4.1.0 does not support that platform. 9.1.0 is the latest version
of the ntp module and includes support for a more up-to-date set of operating
systems.