### PR TITLE
(SERVER-3170) make dropsonde opt-out by default

### DIFF
--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -75,7 +75,7 @@ profiler: {
 
 # settings related to submitting module metrics via Dropsonde
 dropsonde: {
-    #enabled: false
+    # enabled: true
 
     # How long, in seconds, to wait between dropsonde submissions
     # Defaults to one week.

--- a/src/clj/puppetlabs/services/analytics/analytics_service.clj
+++ b/src/clj/puppetlabs/services/analytics/analytics_service.clj
@@ -30,11 +30,11 @@
          (log/info (i18n/trs "Not checking for updates - opt-out setting exists"))))
      (log/info (i18n/trs "Puppet Server Update Service has successfully started and will run in the background"))
 
-     ;; Configure dropsonde
-     (let [dropsonde-enabled (get-in config [:dropsonde :enabled] false)
+     ;; Configure dropsonde, enabled by default if not specified
+     (let [dropsonde-enabled (get-in config [:dropsonde :enabled] true)
            ;; once a week, config value is documented as seconds
            dropsonde-interval-millis (* 1000 (get-in config [:dropsonde :interval]
-                                             (* 60 60 24 7)))]
+                                               (* 60 60 24 7)))]
        (if dropsonde-enabled
          (interspaced dropsonde-interval-millis #(run-dropsonde config))
          (log/info (i18n/trs (str "Not submitting module metrics via Dropsonde -- submission is disabled. "


### PR DESCRIPTION
This changes dropsonde to be opt-out by default if the configuration value is
not specified per this announcement:

https://puppet.com/blog/the-next-step-in-puppet-content-telemetry/