### PR TITLE
(SERVER-3133) Remove deprecated JRuby function

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -100,7 +100,7 @@ class Puppet::Server::Master
 
   def compileAST(compile_options, boltlib_path)
     ruby_compile_options = convert_java_args_to_ruby(compile_options)
-    ruby_boltlib_path = boltlib_path.java_kind_of?(Java::JavaUtil::List) ? boltlib_path.to_a : nil
+    ruby_boltlib_path = boltlib_path.kind_of?(Java::JavaUtil::List) ? boltlib_path.to_a : nil
     Puppet::Server::ASTCompiler.compile(ruby_compile_options, ruby_boltlib_path)
   end
 
@@ -210,9 +210,9 @@ class Puppet::Server::Master
   # the value. 
   def resolve_java_objects_from_list(list)
     list.map do |value|
-      if value.java_kind_of?(Java::ClojureLang::IPersistentMap)
+      if value.kind_of?(Java::ClojureLang::IPersistentMap)
         convert_java_args_to_ruby(value)
-      elsif value.java_kind_of?(Java::JavaUtil::List)
+      elsif value.kind_of?(Java::JavaUtil::List)
         resolve_java_objects_from_list(value)
       else
         value
@@ -223,9 +223,9 @@ class Puppet::Server::Master
   def convert_java_args_to_ruby(hash)
     Hash[hash.collect do |key, value|
       # Stolen and heavily modified from params_to_ruby in handler.rb
-      if value.java_kind_of?(Java::ClojureLang::IPersistentMap)
+      if value.kind_of?(Java::ClojureLang::IPersistentMap)
         [key, convert_java_args_to_ruby(value)]
-      elsif value.java_kind_of?(Java::JavaUtil::List)
+      elsif value.kind_of?(Java::JavaUtil::List)
         [key, resolve_java_objects_from_list(value)]
       else
         [key, value]

--- a/src/ruby/puppetserver-lib/puppet/server/network/http/handler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/network/http/handler.rb
@@ -35,7 +35,7 @@ module Puppet::Server::Network::HTTP::Handler
 
   def body(request)
     body = request["body"]
-    if body.java_kind_of?(InputStream)
+    if body.kind_of?(InputStream)
       body.to_io.read()
     else
       body
@@ -87,7 +87,7 @@ module Puppet::Server::Network::HTTP::Handler
       # value of '["one", "two"]' as a Clojure PersistentVector.  This
       # PersistentVector needs to be converted into a Ruby Array before
       # proceeding with the request processing.
-      [key, value.java_kind_of?(Java::JavaUtil::List) ? value.to_a : value]
+      [key, value.kind_of?(Java::JavaUtil::List) ? value.to_a : value]
     end]
   end
 


### PR DESCRIPTION
JRuby deprecated `java_kind_of?` many years ago and finally removed it
in 9.3. This commit switches to the general replacement `kind_of?` in
preparation for upgrade to JRuby 9.3.