### PR TITLE
(maint) Update acceptance test for git CVE-2022-24765

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -108,6 +108,7 @@ end
 
 step 'SETUP: Initialize the local git repository' do
   on master, "chown git #{git_local_repo}"
+  on master, "git config --global --add safe.directory #{git_local_repo}"
   on master, "cd #{git_local_repo} && git config --global user.name 'TestUser'"
   on master, "cd #{git_local_repo} && git config --global user.email 'you@example.com'"
   on master, "cd #{git_local_repo} && git init"


### PR DESCRIPTION
Following CVE-2022-24765 (see
https://github.blog/2022-04-12-git-security-vulnerability-announced/)
git will no longer trust repositories owned by another user without
being explicitly allowed. This fix is in Git 2.35.2.

The code_scripts.rb test has the git user own a test repositiory so
it may be served by a local git server. Once the repository is owned
by the git user the root user may not commit to it.

This commit marks the shared local repository as safe as soon as its
ownership is given to the git user.