### PR TITLE
(PE-33240) Properly serve task files from a module called "tasks"

### DIFF
--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -344,6 +344,19 @@
       (assert-failure-msg #"/etc/default/puppetserver"
                           "points the user to the debian config location"))))
 
+(deftest task-file-uri-components-test
+  (is (= ["modules" "mymodule" "tasks" "foo.sh"] (task-file-uri-components "foo.sh" "/path/to/environment/modules/mymodule/tasks/foo.sh")))
+  (is (= ["modules" "mymodule" "scripts" "foo.sh"] (task-file-uri-components "mymodule/scripts/foo.sh" "/path/to/environment/modules/mymodule/scripts/foo.sh")))
+  (testing "works with nested files"
+      (is (= ["modules" "mymodule" "lib" "baz/bar/foo.sh"]
+             (task-file-uri-components "mymodule/lib/baz/bar/foo.sh" "/path/to/environment/modules/mymodule/lib/baz/bar/foo.sh"))))
+  (testing "when the module name is the same as a module subdirectory"
+    (doseq [module ["tasks" "scripts" "files" "lib"]
+            subdir ["tasks" "scripts" "files" "lib"]
+            :let [file-name (if (= subdir "tasks") "foo.sh" (format "%s/%s/foo.sh" module subdir))]]
+      (is (= ["modules" module subdir "foo.sh"]
+             (task-file-uri-components file-name (format "/path/to/environment/modules/%s/%s/foo.sh" module subdir)))))))
+
 (deftest all-tasks-response-test
   (testing "all-tasks query"
     (with-redefs [jruby-core/borrow-from-pool-with-timeout (fn [_ _ _] {:jruby-puppet (Object.)})


### PR DESCRIPTION
Previously, the URLs generated for certain task files were incorrect and
led to those tasks not being runnable. Task files can be loaded from the
`tasks`, `scripts`, `files` or `lib` directory of a module. If the
module itself had any of those names, the URL generated was incorrect.

The trouble was that we were trying to determine the module and
subdirectory of the file purely based on its absolute path on disk,
without knowing the modulepath or the module name. Without that
information, it's impossible to accurately interpret the file path in
all cases.

We now use the additional "file name" field which has the information we
need in a much easier to parse form. Specifically, the file name is
supplied in one of two forms:

* the basename for a task implementation file, in which case we know
  that it must be at the top-level of the `tasks/` directory of its
  module (because tasks can't be nested), and we can use that
  information to find the module name from the absolute path
* <module>/<module subdir>/<path to the file>, which are simply the
  exact three fields we need

Given the module name, the file "type" (tasks/, scripts/, etc) and the
path within that subdirectory, we can build the appropriate file serving
URL.

The one wrinkle is for static file serving, where we instead use the
verbatim path on disk relative to the root of the environment. Since we
don't have the root of the environment available, we use the fields we
previously computed to deduce it from the absolute path.