### PR TITLE
Run cert dumps as `puppet`

### DIFF
--- a/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
+++ b/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
@@ -21,10 +21,8 @@ altnames="-certopt no_subject,no_header,no_version,no_serial,no_signame,no_valid
 
 if [ -f "${SSLDIR}/certs/ca.pem" ]; then
   echo "CA Certificate:"
-  # shellcheck disable=SC2086 # $altnames shouldn't be quoted
-  openssl x509 -subject -issuer -text -noout -in "${SSLDIR}/certs/ca.pem" $altnames
+  su puppet -s /bin/sh -c "openssl x509 -subject -issuer -text -noout -in '${SSLDIR}/certs/ca.pem' ${altnames}"
 fi
 
 echo "Certificate ${certname}:"
-# shellcheck disable=SC2086 # $altnames shouldn't be quoted
-openssl x509 -subject -issuer -text -noout -in "${SSLDIR}/certs/${certname}" $altnames
+su puppet -s /bin/sh -c "openssl x509 -subject -issuer -text -noout -in '${SSLDIR}/certs/${certname}' ${altnames}"


### PR DESCRIPTION
For folks who are locking the certificates down, this should
make sure the puppet server user can read them as well as
list their content.

When running in "rootless" mode the fakeroot user is (correctly)
denied access.