### PR TITLE
(PE-33991) remove use of slurp to reduce memory footprint

### DIFF
--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -45,48 +45,32 @@
   "Converts a JRubyPuppetResponse instance to a map."
   [response]
   { :pre [(instance? JRubyPuppetResponse response)]
-    :post [(map? %)] }
-    { :status  (.getStatus response)
-      :body    (.getBody response)
-      :headers {"Content-Type"     (.getContentType response)
-                "X-Puppet-Version" (.getPuppetVersion response)}})
+    :post [(map? %)]}
+  { :status  (.getStatus response)
+    :body    (.getBody response)
+    :headers {"Content-Type"     (.getContentType response)
+              "X-Puppet-Version" (.getPuppetVersion response)}})
 
-(defn body-for-jruby
-  "Converts the body from a request into a String if it is a non-binary
-   content type.  Otherwise, just returns back the same body InputStream.
-   Non-binary request bodies are coerced per the appropriate encoding at
-   the Clojure layer.  Binary request bodies, however, need to be preserved
-   in the originating InputStream so that they can be converted at the Ruby
-   layer, where the raw bytes within the stream can be converted losslessly
-   to a Ruby ASCII-8BIT encoded String.  Java has no equivalent to ASCII-8BIT
-   for its Strings."
+
+(defn update-body-for-jruby
+  "Converts the body from a request into a String if it is a form encoding.
+   Otherwise, just returns back the same body InputStream."
   [request]
   (let [body         (:body request)
         content-type (if-let [raw-type (:content-type request)]
                        (string/lower-case raw-type))]
-    (case content-type
-      (nil "" "application/octet-stream" "application/x-msgpack") body
-      ; Treatment of the *default* encoding arguably should be much more
-      ; intelligent than just choosing UTF-8.  Basing the default on the
-      ; Content-Type would be an improvement although even this could lead to
-      ; some ambiguities.  For "text/*" Content-Types, for example,
-      ; different RFCs specified that either US-ASCII or ISO-8859-1 could
-      ; be applied - see https://tools.ietf.org/html/rfc6657.  Ideally, this
-      ; should be filled in with a broader list of the different Content-Types
-      ; that Puppet recognizes and the default encodings to use when typical
-      ; Puppet requests do not specify a corresponding charset.
-      (slurp body :encoding (or (:character-encoding request)
-                                "UTF-8")))))
-
+    (if (=  content-type "application/x-www-form-urlencoded")
+      (assoc request :body (slurp body :encoding (or (:character-encoding request)
+                                                     "UTF-8")))
+      request)))
 (defn wrap-params-for-jruby
   "Pull parameters from the URL query string and/or urlencoded form POST
    body into the ring request map.  Includes some special processing for
    a request destined for JRubyPuppet."
   [request]
-  (let [body-for-jruby (body-for-jruby request)]
-    (-> request
-        (assoc :body body-for-jruby)
-        pl-ring-params/params-request)))
+  (-> request
+      update-body-for-jruby
+      pl-ring-params/params-request))
 
 (def unauthenticated-client-info
   "Return a map with default info for an unauthenticated client"

--- a/src/ruby/puppetserver-lib/puppet/server/network/http/handler.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/network/http/handler.rb
@@ -36,7 +36,25 @@ module Puppet::Server::Network::HTTP::Handler
   def body(request)
     body = request["body"]
     if body.kind_of?(InputStream)
-      body.to_io.read()
+      io = body.to_io
+      content_type = ''
+      has_headers = request.key?('headers')
+      if has_headers && request['headers'].key?('content-type')
+         content_type = request['headers']['content-type']
+      end
+
+      case content_type
+      when nil, "", "application/octet-stream", "application/x-msgpack"
+        io.binmode
+      else
+        encoding = 'UTF-8'
+        if has_headers
+            encoding = request['headers'].fetch('content-encoding', 'UTF-8')
+        end
+        io.set_encoding(encoding)
+      end
+
+      io.read
     else
       body
     end

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -67,7 +67,7 @@
                              :content-type "text/plain"})]
       (is (= {} (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= "" (:body wrapped-request))
+      (is (= "" (slurp (:body wrapped-request)))
           "Unexpected body for jruby in wrapped request")))
   (testing "get with query parameters returns expected values"
     (let [wrapped-request (core/wrap-params-for-jruby
@@ -79,14 +79,14 @@
               :bogus ""}
              (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= "" (:body wrapped-request))
+      (is (= "" (slurp (:body wrapped-request)))
           "Unexpected body for jruby in wrapped request")))
   (testing "post with form parameters returns expected values"
     (let [body-string "one=1&two=2%202&arr[]=3&arr[]=4"
           wrapped-request (core/wrap-params-for-jruby
-                            {:body         (StringReader. body-string)
-                             :content-type "application/x-www-form-urlencoded"
-                             :params       {:bogus ""}})]
+                           {:body (StringReader. body-string)
+                            :content-type "application/x-www-form-urlencoded"
+                            :params {:bogus ""}})]
       (is (= {"one" "1", "two" "2 2", "arr[]" ["3" "4"]
               :bogus ""}
              (:params wrapped-request))
@@ -101,7 +101,7 @@
                              :params       {:bogus ""}})]
       (is (= {:bogus ""} (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= body-string (:body wrapped-request))
+      (is (= body-string (slurp (:body wrapped-request)))
           "Unexpected body for jruby in wrapped request")))
   (testing "post with plain text in UTF-16 returns expected values"
     (let [body-string-from-utf16 (String. (.getBytes
@@ -117,7 +117,7 @@
                              :params             {:bogus ""}})]
       (is (= {:bogus ""} (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= body-string-from-utf16 (:body wrapped-request))
+      (is (= body-string-from-utf16 (slurp (:body wrapped-request) :encoding "UTF-16"))
           "Unexpected body for jruby in wrapped request")))
   (testing "request with binary content type does not consume body"
     (let [body-string "some random text"]


### PR DESCRIPTION
This removes the use of slurp in the clojure code to instead
present the input stream to ruby to process. While ruby will
still read the string when the body is requested, this change
will prevent the clj layer from having a referenced string during
the lifetime of the request. This should help reduce memory overhead.