### PR TITLE
(maint) Respect PE in external cert test

### DIFF
--- a/acceptance/suites/tests/https/client_may_use_external_cert_chains.rb
+++ b/acceptance/suites/tests/https/client_may_use_external_cert_chains.rb
@@ -42,11 +42,12 @@ test_name "Ensure Puppet Server's HTTP client may use external cert chains" do
     server.start
 EOF
 
+  stores = master.is_pe? ? 'http,puppetdb' : 'http,store'
   enable_https_report_processor_config = {
     'master' => {
       'reporturl' => "https://#{master}:7777/",
       'report_include_system_store' => true,
-      'reports' => 'store,http',
+      'reports' => stores,
       'ssl_trust_store' => server_cert
     }
   }
@@ -66,7 +67,7 @@ EOF
   on master, wait_for_server
 
   with_puppet_running_on(master, enable_https_report_processor_config) do
-    on master, 'puppet agent -t'
+    on master, 'puppet agent -t', acceptable_exit_codes: [0,2]
   end
 
   report_content = on(master, "cat #{directory_to_serve}/#{master}").stdout.chomp


### PR DESCRIPTION
PE includes puppetdb as a report processor and, in some cases when
running this test, may still be configuring itself. To manage this we
include puppetdb as a report processor if we a PE install as well as
allow `puppet agent -t` to return `2`.