### PR TITLE
Update 90-log-config.sh

### DIFF
--- a/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
+++ b/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
@@ -25,6 +25,8 @@ if [ -f "${SSLDIR}/certs/ca.pem" ]; then
   openssl x509 -subject -issuer -text -noout -in "${SSLDIR}/certs/ca.pem" $altnames
 fi
 
-echo "Certificate ${certname}:"
-# shellcheck disable=SC2086 # $altnames shouldn't be quoted
-openssl x509 -subject -issuer -text -noout -in "${SSLDIR}/certs/${certname}" $altnames
+if [ -f "${certname}" ]; then
+  echo "Certificate ${certname}:"
+  # shellcheck disable=SC2086 # $altnames shouldn't be quoted
+  openssl x509 -subject -issuer -text -noout -in "${SSLDIR}/certs/${certname}" $altnames
+fi

--- a/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
+++ b/docker/puppetserver/docker-entrypoint.d/90-log-config.sh
@@ -25,7 +25,7 @@ if [ -f "${SSLDIR}/certs/ca.pem" ]; then
   openssl x509 -subject -issuer -text -noout -in "${SSLDIR}/certs/ca.pem" $altnames
 fi
 
-if [ -f "${certname}" ]; then
+if [ -f "${SSLDIR}/certs/${certname}" ]; then
   echo "Certificate ${certname}:"
   # shellcheck disable=SC2086 # $altnames shouldn't be quoted
   openssl x509 -subject -issuer -text -noout -in "${SSLDIR}/certs/${certname}" $altnames


### PR DESCRIPTION
Bringing up a new Puppetserver 7.8.0 container that has a CA present, but not a signed cert will see the container exit due to `openssl` errors when attempting to read a non-existent file. This happens as the cert is not yet signed when bringing up the server, but will be signed by the CA once it is up and running.

Log certificate information only if cert is actually present.