### PR TITLE
(maint) Bump version to 6.20.0-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "6.19.1-SNAPSHOT")
+(def ps-version "6.20.0-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
The next puppetserver 6.x release includes some new features (already shipped in
puppetserver 7.8.0), so this prepares us for a Y release.