### PR TITLE
(PUP-11540) Update all-tasks-response! to read private/description

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -327,6 +327,8 @@
    jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)]
   (let [format-task (fn [task-object]
                       {:name (:name task-object)
+                       :private (get-in task-object [:metadata :private] false)
+                       :description (get-in task-object [:metadata :description] "")
                        :environment [{:name environment
                                       :code_id nil}]})]
     (->> (map format-task info-from-jruby)

--- a/test/integration/puppetlabs/services/jruby/tasks_test.clj
+++ b/test/integration/puppetlabs/services/jruby/tasks_test.clj
@@ -111,8 +111,9 @@
 
 (defn expected-tasks-info
   [tasks]
-  (map (fn [{:keys [name module-name]}]
+  (map (fn [{:keys [name module-name metadata]}]
          {:module {:name module-name}
+          :metadata (clojure.walk/keywordize-keys metadata)
           :name (if (= "init" name)
                   module-name
                   (str module-name "::" name))})

--- a/test/integration/puppetlabs/services/master/tasks_int_test.clj
+++ b/test/integration/puppetlabs/services/master/tasks_int_test.clj
@@ -79,7 +79,7 @@
       (do
         (testutils/write-tasks-files "apache" "announce" "echo 'Hi!'" (json/encode { "private" true 
                                                                                      "description" "the apache module" }))
-        (testutils/write-tasks-files "graphite" "install" "wheeee")
+        (testutils/write-tasks-files "graphite" "install" "wheeee" (json/encode {}))
         (let [expected-response '({"name" "apache::announce"
                                    "environment" [{"name" "production"
                                                    "code_id" nil}]

--- a/test/integration/puppetlabs/services/master/tasks_int_test.clj
+++ b/test/integration/puppetlabs/services/master/tasks_int_test.clj
@@ -77,14 +77,19 @@
       app
       puppet-config
       (do
-        (testutils/write-tasks-files "apache" "announce" "echo 'Hi!'")
+        (testutils/write-tasks-files "apache" "announce" "echo 'Hi!'" (json/encode { "private" true 
+                                                                                     "description" "the apache module" }))
         (testutils/write-tasks-files "graphite" "install" "wheeee")
         (let [expected-response '({"name" "apache::announce"
                                    "environment" [{"name" "production"
-                                                   "code_id" nil}]}
+                                                   "code_id" nil}]
+                                   "private" true
+                                   "description" "the apache module"}
                                   {"name" "graphite::install"
                                    "environment" [{"name" "production"
-                                                   "code_id" nil}]})
+                                                   "code_id" nil}]
+                                   "private" false
+                                   "description" ""})
               response (get-all-tasks "production")]
           (testing "a successful status code is returned"
             (is (= 200 (:status response))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -28,7 +28,9 @@
   [task-name]
   (let [[module _] (split task-name #"::")]
     {:module {:name module}
-     :name task-name}))
+     :name task-name
+     :private false
+     :description "test description"}))
 
 (defn build-ring-handler
   [request-handler puppet-version jruby-service]
@@ -378,7 +380,9 @@
             response-format (fn [task-name]
                                  {:name task-name
                                   :environment [{:name "production"
-                                                 :code_id nil}]})
+                                                 :code_id nil}]
+                                  :private false
+                                  :description "test description"})
             expected-response (fn [task-names]
                                 (map response-format task-names))
             task-names ["apache" "apache::configure" "mongodb::uninstall"]]

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -29,8 +29,7 @@
   (let [[module _] (split task-name #"::")]
     {:module {:name module}
      :name task-name
-     :private false
-     :description "test description"}))
+     :metadata {:private false :description "test description"}}))
 
 (defn build-ring-handler
   [request-handler puppet-version jruby-service]


### PR DESCRIPTION
Updates the master_core service to return "private" and "description"
keys from tasks when hitting the /v3/tasks API. Depends on
https://github.com/puppetlabs/puppet/pull/8921