### PR TITLE
(maint) Specify cipher suites when testing TLS 1.3

### DIFF
--- a/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -287,7 +287,7 @@
   (testing "Can connect via TLSv1.3 by default"
     (with-webserver-with-protocols ["TLSv1.3"] nil
       (with-scripting-container sc
-        (with-http-client sc {}
+        (with-http-client sc {:cipher-suites ["TLS_AES_256_GCM_SHA384" "TLS_AES_128_GCM_SHA256"]}
           (let [url (str "https://localhost:10080")]
             (.runScriptlet sc (format "$response = $c.get(URI('%s'))" url))
             (is (= 200 (.runScriptlet sc "$response.code")))


### PR DESCRIPTION
This commit ensures that the test http client uses the appropriate cipher suites
when testing TLSv1.3. Previously, this test would fail with
`javax.net.ssl.SSLHandshakeException: Received fatal alert: protocol_version` on
newer Java 8 versions.