### PR TITLE
(maint) Humane test output for clojure tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -148,7 +148,12 @@
                     ;; use core.async and need more than eight threads to run
                     ;; properly; this setting overrides the default value.  Without
                     ;; it the metrics tests will hang.
-                    :jvm-opts ["-Dclojure.core.async.pool-size=50"]}
+                    :jvm-opts ["-Dclojure.core.async.pool-size=50"]
+                    ;; Use humane test output so you can actually see what the problem is 
+                    ;; when a test fails.
+                    :dependencies [[pjstadig/humane-test-output "0.8.3"]]
+                    :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
 
 
              :ezbake {:dependencies ^:replace [;; we need to explicitly pull in our parent project's


### PR DESCRIPTION
Use the pjstadig/humane-test-output library to pretty print test results as well as diffs between actual vs expected in assertion failures. This will help debugging failing tests from just the Travis logs instead of having to get a repl going locally just to understand what the difference between actual and expected is.