### PR TITLE
(maint) Remove trailing whitespace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -149,7 +149,7 @@
                     ;; properly; this setting overrides the default value.  Without
                     ;; it the metrics tests will hang.
                     :jvm-opts ["-Dclojure.core.async.pool-size=50"]
-                    ;; Use humane test output so you can actually see what the problem is 
+                    ;; Use humane test output so you can actually see what the problem is
                     ;; when a test fails.
                     :dependencies [[pjstadig/humane-test-output "0.8.3"]]
                     :injections [(require 'pjstadig.humane-test-output)


### PR DESCRIPTION
This causes automatic mergeups to fail, since it thinks that conflict markers
were not cleaned up appropriately.