### PR TITLE
(maint) Update explanation for skipping external cert chain test on FIPS

### DIFF
--- a/acceptance/suites/tests/https/client_may_use_external_cert_chains.rb
+++ b/acceptance/suites/tests/https/client_may_use_external_cert_chains.rb
@@ -1,6 +1,6 @@
 test_name "Ensure Puppet Server's HTTP client may use external cert chains" do
 
-  ## This test currently relies on WEBrick/OpenSSL, which is not supported on FIPS
+  ## This test currently fails on FIPS (see PE-34102). Remove this once that is resolved.
   skip_test if master.fips_mode?
 
   reports_tmpdir = master.tmpdir('external-reports')


### PR DESCRIPTION
The previous comment was not accurate - we use the agent's Ruby, so we should
have access to OpenSSL.