### PR TITLE
(maint) fix packaging gem installation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ def location_for(place, fake_version = nil)
   end
 end
 
+# The public_suffix gem used in the dependencies for the packaging gem no longer supports Ruby 2.5
+# and bundler is not smart enough to realize that an older version would work in the mix.
+gem 'public_suffix', '= 4.0.7'
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 gem 'rake', :group => [:development, :test]
 


### PR DESCRIPTION
v5.x of the public_suffix gem no longer supports ruby 2.5 which
causes installation failures during the bundle install. This commit
pins public_suffix to v4.0.7, which is compatible. Note this is not
needed for main branch which is running jruby 9.3.x (compatible with
Ruby 2.6.x).