### PR TITLE
(maint) Merge '6.x' into 'main'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,32 +25,6 @@ jobs:
       env:
         - JAVA_VERSION=11
         - MULTITHREADED=true
-    - stage: puppetserver container tests
-      dist: focal
-      language: ruby
-      rvm: 2.6.5
-      env:
-        - DOCKER_COMPOSE_VERSION=1.28.6
-        - DOCKER_BUILDX_VERSION=0.5.1
-        # necessary to prevent overwhelming TravisCI build output limits
-        - DOCKER_BUILD_FLAGS="--progress plain"
-      before_install:
-        - sudo rm /usr/local/bin/docker-compose
-        - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
-        - chmod +x docker-compose
-        - sudo mv docker-compose /usr/local/bin
-        - mkdir -vp ~/.docker/cli-plugins
-        - curl --location https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
-        - chmod +x ~/.docker/cli-plugins/docker-buildx
-        - docker buildx create --name travis_builder --use
-      script:
-        - set -e
-        - cd $TRAVIS_BUILD_DIR/docker
-        - make lint
-        - make build
-        - make test
-      after_script:
-        - docker buildx rm travis_builder
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ def location_for(place, fake_version = nil)
   end
 end
 
+# The public_suffix gem used in the dependencies for the packaging gem no longer supports Ruby 2.5
+# and bundler is not smart enough to realize that an older version would work in the mix.
+gem 'public_suffix', '= 4.0.7'
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 gem 'rake', :group => [:development, :test]
 

--- a/ext/travisci/install-java.sh
+++ b/ext/travisci/install-java.sh
@@ -6,5 +6,6 @@ echo "Installing Java $JAVA_VERSION"
 
 sudo rm -rf /usr/local/lib/jvm/
 sudo rm -rf /usr/lib/jvm/openjdk-$JAVA_VERSION
+sudo apt-get update
 sudo apt-get install -y openjdk-$JAVA_VERSION-jdk-headless
 export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION-openjdk-amd64/

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
 
                  [slingshot]
                  [clj-commons/clj-yaml]
-                 [org.yaml/snakeyaml]
+                 [org.yaml/snakeyaml "1.31"]
                  [commons-lang]
                  [commons-io]
 

--- a/resources/ext/build-scripts/dropsonde-gem.txt
+++ b/resources/ext/build-scripts/dropsonde-gem.txt
@@ -1,2 +1,2 @@
-dropsonde 0.0.7
+dropsonde 0.0.8
 scanf 1.0.0


### PR DESCRIPTION
Resolved options in favor of main, brought along the dropsonde bump

Conflicts:
 - acceptance/config/beaker/options.rb
 - resources/ext/build-scripts/dropsonde-gem.txt