### PR TITLE
(PE-34508) Unpin bundler in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -183,7 +183,7 @@ namespace :spec do
       ## Line 2 programmatically runs 'gem install bundler' via the gem command that comes with JRuby
       gem_install_bundler = <<-CMD
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-      #{LEIN_PATH} gem install -i '#{TEST_GEMS_DIR}' bundler -v '< 2' --no-document --source '#{GEM_SOURCE}'
+      #{LEIN_PATH} gem install -i '#{TEST_GEMS_DIR}' bundler --no-document --source '#{GEM_SOURCE}'
       CMD
       sh gem_install_bundler
 


### PR DESCRIPTION
We previously pinned bundler to a version of 1.x because when 2.x was released it required a Ruby version compatible with 2.3 or greater but we were stuck support JRuby 1.7.

Those constraints are long gone and we need newer bundler versions to better handle dependency restrictions, particularly based on Ruby versions.