### PR TITLE
(SERVER-3219) Exclude JRuby stdlib dependencies from uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -243,6 +243,8 @@
                "-XX:+IgnoreUnrecognizedVMOptions"]
 
   :repl-options {:init-ns dev-tools}
+  :uberjar-exclusions  [#"META-INF/jruby.home/lib/ruby/stdlib/org/bouncycastle"
+                        #"META-INF/jruby.home/lib/ruby/stdlib/org/yaml/snakeyaml"]
 
   ;; This is used to merge the locales.clj of all the dependencies into a single
   ;; file inside the uberjar


### PR DESCRIPTION
We provide our own versions of these libraries and it's best to only have one of each on the classpath.