### PR TITLE
(PE-34096) Certificate authority regexp

### DIFF
--- a/locales/eo.po
+++ b/locales/eo.po
@@ -76,7 +76,7 @@ msgid "Certificate names must be lower case."
 msgstr ""
 
 #: src/clj/puppetlabs/puppetserver/certificate_authority.clj
-msgid "Subject contains unprintable or non-ASCII characters"
+msgid "Subject hostname format is invalid"
 msgstr ""
 
 #: src/clj/puppetlabs/puppetserver/certificate_authority.clj

--- a/locales/puppetserver.pot
+++ b/locales/puppetserver.pot
@@ -77,7 +77,7 @@ msgid "Certificate names must be lower case."
 msgstr ""
 
 #: src/clj/puppetlabs/puppetserver/certificate_authority.clj
-msgid "Subject contains unprintable or non-ASCII characters"
+msgid "Subject hostname format is invalid"
 msgstr ""
 
 #: src/clj/puppetlabs/puppetserver/certificate_authority.clj

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -806,15 +806,15 @@
       {:kind :invalid-subject-name
        :msg  (i18n/tru "Certificate names must be lower case.")}))
 
-  (when-not (re-matches #"\A[ -.0-~]+\Z" subject)
-    (sling/throw+
-      {:kind :invalid-subject-name
-       :msg  (i18n/tru "Subject contains unprintable or non-ASCII characters")}))
-
   (when (.contains subject "*")
     (sling/throw+
       {:kind :invalid-subject-name
-       :msg  (i18n/tru "Subject contains a wildcard, which is not allowed: {0}" subject)})))
+       :msg  (i18n/tru "Subject contains a wildcard, which is not allowed: {0}" subject)}))
+  
+  (when-not (re-matches #"^([a-z0-9](?:(?:[a-z0-9\-_]*|(?<!-)\.(?![\-.]))*[a-z0-9]+)?)$" subject)
+    (sling/throw+
+      {:kind :invalid-subject-name
+       :msg  (i18n/tru "Subject hostname format is invalid")})))
 
 (schema/defn allowed-extension?
   "A predicate that answers if an extension is allowed or not.

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -450,7 +450,7 @@
                   response   (handle-put-certificate-request!
                               subject csr-stream settings)]
               (is (= 400 (:status response)))
-              (is (= "Subject contains unprintable or non-ASCII characters"
+              (is (= "Subject hostname format is invalid"
                      (:body response)))))))
 
       (testing "no wildcards allowed"


### PR DESCRIPTION
Updating certificate authority validation regexp to restrict hostname format. Originally our regex validation was simply checking that the hostname did not contain non ascii characters. As this allowed invalid hostnames and the potential for command injection, we have now updated the regex to reduce the allowed characters as well as follow  a hostname or domain format.