### PR TITLE
(PE-33991) remove use of slurp to reduce memory footprint

### DIFF
--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -67,7 +67,7 @@
                              :content-type "text/plain"})]
       (is (= {} (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= "" (:body wrapped-request))
+      (is (= "" (slurp (:body wrapped-request)))
           "Unexpected body for jruby in wrapped request")))
   (testing "get with query parameters returns expected values"
     (let [wrapped-request (core/wrap-params-for-jruby
@@ -79,14 +79,14 @@
               :bogus ""}
              (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= "" (:body wrapped-request))
+      (is (= "" (slurp (:body wrapped-request)))
           "Unexpected body for jruby in wrapped request")))
   (testing "post with form parameters returns expected values"
     (let [body-string "one=1&two=2%202&arr[]=3&arr[]=4"
           wrapped-request (core/wrap-params-for-jruby
-                            {:body         (StringReader. body-string)
-                             :content-type "application/x-www-form-urlencoded"
-                             :params       {:bogus ""}})]
+                           {:body (StringReader. body-string)
+                            :content-type "application/x-www-form-urlencoded"
+                            :params {:bogus ""}})]
       (is (= {"one" "1", "two" "2 2", "arr[]" ["3" "4"]
               :bogus ""}
              (:params wrapped-request))
@@ -101,7 +101,7 @@
                              :params       {:bogus ""}})]
       (is (= {:bogus ""} (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= body-string (:body wrapped-request))
+      (is (= body-string (slurp (:body wrapped-request)))
           "Unexpected body for jruby in wrapped request")))
   (testing "post with plain text in UTF-16 returns expected values"
     (let [body-string-from-utf16 (String. (.getBytes
@@ -117,7 +117,7 @@
                              :params             {:bogus ""}})]
       (is (= {:bogus ""} (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= body-string-from-utf16 (:body wrapped-request))
+      (is (= body-string-from-utf16 (slurp (:body wrapped-request) :encoding "UTF-16"))
           "Unexpected body for jruby in wrapped request")))
   (testing "request with binary content type does not consume body"
     (let [body-string "some random text"]


### PR DESCRIPTION
This removes the use of slurp in the clojure code to instead present the input stream to ruby to process. While ruby will still read the string when the body is requested, this change will prevent the clj layer from having a referenced string during the lifetime of the request. This should help reduce memory overhead.