### PR TITLE
(maint) Conditionally open Java IO only for Java 17

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -237,15 +237,17 @@
             "irb" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.irb" "--config" "./dev/puppetserver.conf" "--"]
             "thread-test" ["trampoline" "run" "-b" "ext/thread_test/bootstrap.cfg" "--config" "./ext/thread_test/puppetserver.conf"]}
 
-  :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
-               "-XX:+UseG1GC"
-               ~(str "-Xms" (heap-size "1G"))
-               ~(str "-Xmx" (heap-size "2G"))
-               "-XX:+IgnoreUnrecognizedVMOptions"
-               "--add-opens"
-               "java.base/sun.nio.ch=ALL-UNNAMED"
-               "--add-opens"
-               "java.base/java.io=ALL-UNNAMED"]
+  :jvm-opts ~(let [version (System/getProperty "java.specification.version")
+                   [major minor _] (clojure.string/split version #"\.")]
+               (concat
+                 ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
+                  "-XX:+UseG1GC"
+                  (str "-Xms" (heap-size "1G"))
+                  (str "-Xmx" (heap-size "2G"))
+                  "-XX:+IgnoreUnrecognizedVMOptions"]
+                 (if (= 17 (java.lang.Integer/parseInt major))
+                   ["--add-opens" "java.base/sun.nio.ch=ALL-UNNAMED" "--add-opens" "java.base/java.io=ALL-UNNAMED"]
+                   [])))
 
   :repl-options {:init-ns dev-tools}
   :uberjar-exclusions  [#"META-INF/jruby.home/lib/ruby/stdlib/org/bouncycastle"


### PR DESCRIPTION
In a previous commit we began passing flags to the JVM that allows JRuby to access protected members of the Java IO subsystem, as is currently required by JRuby 9.3.8. However, this flag does not exist in (at least) Java 8 and so we must conditionally include these flags based on Java versions.

The conditional code is based on the existing conditional JVM flags passed in FIPS mode.