### PR TITLE
(maint) Define `clj-parent-version`

### DIFF
--- a/jenkins/mergeup.sh
+++ b/jenkins/mergeup.sh
@@ -61,7 +61,7 @@ while [[ "$num_conflicts" -gt 0 ]]; do
     elif echo $line_content | grep "ps-version" ; then
       echo "ps-version, keep ours"
     # check if it's a clj-parent bump and keep ours
-    elif echo $line_content | grep "puppetlabs/clj-parent" ; then
+    elif echo $line_content | grep "clj-parent-version" ; then
       echo "clj-parent bump, keep ours"
     # check for matching lines, since identical lines sometimes still get caught in conflicts, if they're near enough real conflicts
     # potential for error if the line content happens to match something else that isn't just a single line??

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
 (def ps-version "6.20.1-SNAPSHOT")
+(def clj-parent-version "4.11.2")
 
 (defn deploy-info
   [url]
@@ -27,7 +28,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.11.2"]
+  :parent-project {:coords [puppetlabs/clj-parent ~clj-parent-version]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit adds a `clj-parent-version` definition to be used instead of declaring the clj-parent version directly in the dependency. This will facilitate automatic mergeups and matches what some other projects do and what is done for some other dependency versions.