### PR TITLE
fix docker build by forcing older version of public_suffix

### DIFF
--- a/docker/puppetserver/Dockerfile
+++ b/docker/puppetserver/Dockerfile
@@ -89,6 +89,7 @@ RUN apt-get update && \
     git config --global user.email "release@puppet.com" && \
     chmod 0755 /usr/local/bin/lein && \
     /usr/local/bin/lein && \
+    gem install --no-doc public_suffix -v 4.0.7 && \
     gem install --no-doc bundler fpm
 
 COPY . /puppetserver


### PR DESCRIPTION
Currently docker build fail with the following error:
```#12 41.61 ERROR:  Error installing fpm:
#12 41.61 	The last version of public_suffix (< 6.0, >= 2.0.2) to support your Ruby & RubyGems was 4.0.7. Try installing it with `gem install public_suffix -v 4.0.7` and then running the current command again
```
This PR fix this by forcing the public_suffix ruby gem to 4.0.7