### PR TITLE
(maint) Use clj-parent snakeyaml version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
 
                  [slingshot]
                  [clj-commons/clj-yaml]
-                 [org.yaml/snakeyaml "1.31"]
+                 [org.yaml/snakeyaml]
                  [commons-lang]
                  [commons-io]
 


### PR DESCRIPTION
Now that this pin is in clj-parent it is causing leiningen to fail to resolve dependencies.