### PR TITLE
(maint) Pin bundler to '< 2.4' for the 6.x branch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -183,7 +183,7 @@ namespace :spec do
       ## Line 2 programmatically runs 'gem install bundler' via the gem command that comes with JRuby
       gem_install_bundler = <<-CMD
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-      #{LEIN_PATH} gem install -i '#{TEST_GEMS_DIR}' bundler --no-document --source '#{GEM_SOURCE}'
+      #{LEIN_PATH} gem install -i '#{TEST_GEMS_DIR}' bundler --version='< 2.4' --no-document --source '#{GEM_SOURCE}'
       CMD
       sh gem_install_bundler
 


### PR DESCRIPTION
Bunlder released a Christmas surprise in 2.4 which required Ruby 3.0.1 or greater. Later 2.4.x releases relaxed that to >= 2.6 but regardless the 2.3.x series of Bundler is the last to support Ruby < 2.6.

So for the 6.x series we need to pin Bundler to less than 2.4.