### PR TITLE
(PE-35325) Update Puppet Server to include the requester's info

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -68,7 +68,8 @@
                  [puppetlabs/dujour-version-check]
                  [puppetlabs/http-client]
                  [puppetlabs/comidi]
-                 [puppetlabs/i18n]]
+                 [puppetlabs/i18n]
+                 [puppetlabs/rbac-client]]
 
   :main puppetlabs.trapperkeeper.main
 
@@ -123,7 +124,8 @@
                                         [ring-basic-authentication]
                                         [ring/ring-mock]
                                         [beckon]
-                                        [lambdaisland/uri "1.4.70"]]}
+                                        [lambdaisland/uri "1.4.70"]
+                                        [puppetlabs/rbac-client :classifier "test" :scope "test"]]}
              :dev [:defaults
                    {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}]
              :fips [:defaults

--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -65,8 +65,7 @@
           real-ca-service? (= (namespace (tk-services/service-symbol ca-service))
                               "puppetlabs.services.ca.certificate-authority-service")
           ca-settings (ca/config->ca-settings (get-config))
-          ca-route-handler (-> ca-settings
-                               (ca-core/web-routes)
+          ca-route-handler (-> (ca-core/web-routes ca-settings nil)
                                ((partial comidi/context path))
                                comidi/routes->handler)
           ca-handler-info (when


### PR DESCRIPTION
Added an optional dependency for the ActivityReportingService, as well as new functionality for attempting to extract CA signee data from requests to sign and revoke certificates. With preference for RBAC user details, but will fall back to the name linked to the certificate used to sign, and defaulting to the “CA” signee if no other information is available. When a certificate event occurs, log messages will now include information on who signed the certificate. Additionally, if the activity service is available, the information will be submitted there as well.

Added tests checking updated log messages and also mocked activity service to check logged activities.

Manually tested signing, plus revoking individual and multiple.
