### PR TITLE
(maint) Allow using JRuby 9.3

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -163,7 +163,7 @@ class Puppet::Server::Master
   def terminate
     Puppet::Server::Config.terminate_puppet_server
     # See https://github.com/jruby/jruby/issues/7349
-    Timeout.instance_variable_get(:@timeout_thread).exit
+    Timeout.instance_variable_get(:@timeout_thread)&.exit
   end
 
    # @return [Array, nil] an array of hashes describing tasks


### PR DESCRIPTION
The Puppet::Server::Master#terminate code was updated to support JRuby 9.4 and only JRuby 9.4. And in FOSS we only allow users to use the vendored JRuby, but in PE we allow users to swap out JRuby jars. We are also delaying upgrading JRuby to 9.4 in PE for the time being, so it is advantageous to support multiple JRuby versions in this code now.

The thread leakages that necessitated the old shutdown code was supposedly fixed in JRuby 9.3.8 (we currently use JRuby 9.3.9) but the old private code we handled was removed in 9.4.0.

JRuby users will experience the thread leakages we saw in 9.4 _if_ they update the timeout stdlib module. If they do not update our new code will fail. This change will resolve the thread leakage if using the new timeout module.