### PR TITLE
(maint) Bump jruby

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
                  ;; send their logs to logstash, so we include it in the jar.
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-deps "9.4.1.0-1"]
+                 [puppetlabs/jruby-deps "9.4.2.0-1"]
                  [puppetlabs/jruby-utils :exclusions [puppetlabs/jruby-deps]]
                  [puppetlabs/clj-shell-utils]
                  [puppetlabs/trapperkeeper]

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -162,8 +162,6 @@ class Puppet::Server::Master
 
   def terminate
     Puppet::Server::Config.terminate_puppet_server
-    # See https://github.com/jruby/jruby/issues/7349
-    Timeout.instance_variable_get(:@timeout_thread)&.exit
   end
 
    # @return [Array, nil] an array of hashes describing tasks


### PR DESCRIPTION

(maint) Update to JRuby 9.4.2

---

(maint) Remove unneeded Timeout module workaround

In JRuby 9.4.0 & 9.4.1 there was an issue when shutting down threads,
if JRuby encountered an adopted thread it would stop its thread shutdown
procedure and any abandoned threads would be leaked.

This was particularly problematic because the Timeout module does not
attempt to shutdown its watcher thread and Puppet Server adopts a Jetty
thread as part of processing incoming requests, so we would consistently
leak Timeout threads when flushing a JRuby.

To work around this issue while we tested our JRuby upgrade we manually
killed the Timeout watcher thread. This was not a vialable solution to
ship with, but allowed us to see how much work the move to a Ruby 3
compatible interpreter would be.

With JRuby 9.4.2 the issue is resolved and we can remove the workaround.