### PR TITLE
(maint) remove redundant file permissions checks

### DIFF
--- a/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.puppetserver.bootstrap-int-test
   (:require [clojure.test :refer :all]
+            [puppetlabs.kitchensink.file :as ks-file]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [puppetlabs.puppetserver.certificate-authority :as ca]
@@ -17,10 +18,10 @@
      (testing "Private keys have the correct permissions."
        (let [pk-dir (str bootstrap/server-conf-dir "/ssl/private_keys")
              pks (fs/find-files pk-dir #".*pem$")]
-         (is (= ca/private-key-dir-perms (ca/get-file-perms pk-dir)))
+         (is (= ca/private-key-dir-perms (ks-file/get-perms pk-dir)))
          (is (= ca/private-key-perms
-                (ca/get-file-perms (str bootstrap/server-conf-dir
+                (ks-file/get-perms (str bootstrap/server-conf-dir
                                         "/ca/ca_key.pem"))))
          (doseq [pk pks]
-           (is (= ca/private-key-perms (ca/get-file-perms (.getPath pk)))))))
+           (is (= ca/private-key-perms (ks-file/get-perms (.getPath pk)))))))
      (is (true? true)))))

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -13,6 +13,7 @@
             [puppetlabs.services.ca.ca-testutils :as testutils]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
             [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.kitchensink.file :as ks-file]
             [slingshot.test :refer :all]
             [schema.test :as schema-test]
             [clojure.test :refer :all]
@@ -764,20 +765,20 @@
   (testing (str "The CA private key has its permissions properly reset when "
                 ":manage-internal-file-permissions is true.")
     (let [settings (testutils/ca-sandbox! cadir)]
-      (set-file-perms (:cakey settings) "rw-r--r--")
+      (ks-file/set-perms (:cakey settings) "rw-r--r--")
       (logutils/with-test-logging
         (initialize! settings)
         (is (logged? #"/ca/ca_key.pem' was found to have the wrong permissions set as 'rw-r--r--'. This has been corrected to 'rw-r-----'."))
-        (is (= private-key-perms (get-file-perms (:cakey settings)))))))
+        (is (= private-key-perms (ks-file/get-perms (:cakey settings)))))))
 
   (testing (str "The CA private key's permissions are not reset if "
                 ":manage-internal-file-permissions is false.")
     (let [perms "rw-r--r--"
           settings (assoc (testutils/ca-sandbox! cadir)
                      :manage-internal-file-permissions false)]
-      (set-file-perms (:cakey settings) perms)
+      (ks-file/set-perms (:cakey settings) perms)
       (initialize! settings)
-      (is (= perms (get-file-perms (:cakey settings)))))))
+      (is (= perms (ks-file/get-perms (:cakey settings)))))))
 
 (deftest retrieve-ca-cert!-test
   (testing "CA file copied when it doesn't already exist"
@@ -1760,7 +1761,7 @@
       (let [tmp-file (fs/temp-name "ca-file-perms-test")
             perms (str u g o)]
         (create-file-with-perms tmp-file perms)
-        (is (= perms (get-file-perms tmp-file)))
+        (is (= perms (ks-file/get-perms tmp-file)))
         (fs/delete tmp-file))))
 
   (testing "Changing the perms of an already created file"
@@ -1773,8 +1774,8 @@
           (let [tmp-file (fs/temp-name "ca-file-perms-test")
                 [init-perm change-perm] (take 2 perms)]
             (create-file-with-perms tmp-file init-perm)
-            (set-file-perms tmp-file change-perm)
-            (is (= change-perm (get-file-perms tmp-file)))
+            (ks-file/set-perms tmp-file change-perm)
+            (is (= change-perm (ks-file/get-perms tmp-file)))
             (fs/delete tmp-file)
             (recur (nthnext perms 2))))))))
 

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [me.raynes.fs :as fs]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.puppetserver.certificate-authority :as ca]
+            [puppetlabs.kitchensink.file :as ks-file]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils])
   (:import (java.io ByteArrayInputStream)))
 
@@ -82,5 +82,5 @@
   (let [tmp-ssldir (ks/temp-dir)]
     (fs/copy-dir cadir tmp-ssldir)
     ;; This is to ensure no warnings are logged during tests
-    (ca/set-file-perms (str tmp-ssldir "/ca/ca_key.pem") "rw-r-----")
+    (ks-file/set-perms (str tmp-ssldir "/ca/ca_key.pem") "rw-r-----")
     (ca-settings (str tmp-ssldir "/ca"))))


### PR DESCRIPTION
As part of atomic-file work (https://github.com/puppetlabs/clj-kitchensink/commit/dffc88be0d5af0b126475bd925901999c67a1571) routines to convert strings to Path objects, get and set permissions were added to the clj-kitchensink project. There are similiar routines in the CA space. This removes those routines in favor of the routines in the kitchensink project.  Tests are updated as appropriate.