### PR TITLE
PE-34952 PE-34951 Use puppetserver-ca gem with updated prune and delete

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 2.4.0
+puppetserver-ca 2.5.0


### PR DESCRIPTION
Upgrade puppetserver-ca gem to 2.5.0 with a new 'delete' command to delete signed certificates from disk and additional options to existing 'prune' command.
Delete command has following options:
  --expired - Delete expired signed certificates
  --revoked - Delete certs that are already revoked
  --all - Delete all signed certs on disk
Prune command will now has three options:
  --remove-duplicates - Remove duplicates(default)
  --remove-expired - Remove expired entries from CRL
  --remove-entries - Remove given entries(serialnumbers or certnames)
                      from CRL