### PR TITLE
(PE-35786) improve performance and reliability of subject validation

### DIFF
--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -1669,6 +1669,13 @@
          (ca/validate-subject!
           "rootca." "rootca."))))
 
+  (testing "PE-35786 an exception is thrown when hostname ends in a dot"
+    (is (thrown+?
+          [:kind :invalid-subject-name
+           :msg "Subject hostname format is invalid"]
+          (ca/validate-subject!
+            "aaa1a-aaaaaaaaaaaaa-aaaaa-aaaa00." "aaa1a-aaaaaaaaaaaaa-aaaaa-aaaa00."))))
+
   (testing "Single word hostnames are allowed"
     (is (nil?
          (ca/validate-subject!


### PR DESCRIPTION
In the CA host validation code a complex regular expression was being used that involved looping, and in some circumstances would create performance issues.

This replaces the complex regular expression with a series of simple steps to validate the subject against specific criteria.

Additionally, info level logging was added to help diagnose issues with particular host requests being rejected.

An issue was found in the clj-i18n logging routine where multiple arguments are not handled correctly, and substitution is not being done. A defect has been raised about that issue, and as a stop-gap the logging and error messages for the ca-signing that use multiple arguments were altered to not use the i18n routines.