### PR TITLE
(PE-35786) allow trailing dot in subject validation

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -765,8 +765,8 @@
 
 
 (def pattern-match-dot #"\.")
-(def pattern-starts-with-alphanumeric #"^\p{Alnum}.*")
-(def pattern-matches-alphanumeric-with-symbols-string #"^[\p{Alnum}.\-_]+\p{Alnum}$")
+(def pattern-starts-with-alphanumeric-or-underscore #"^[\p{Alnum}_].*")
+(def pattern-matches-alphanumeric-with-symbols-string #"^[\p{Alnum}\-_]*[\p{Alnum}_]$")
 
 (schema/defn validate-subject!
   "Validate the CSR or certificate's subject name.  The subject name must:
@@ -795,15 +795,14 @@
       {:kind :invalid-subject-name
        :msg  (i18n/tru "Subject contains a wildcard, which is not allowed: {0}" subject)}))
 
-  (when (or (str/ends-with? subject ".")
-            (str/ends-with? subject "-"))
+  (when (str/ends-with? subject "-")
     (log/info (i18n/tru "Rejecting subject \"{0}\" as it ends with an invalid character" subject))
     (sling/throw+
      {:kind :invalid-subject-name
       :msg  (i18n/tru "Subject hostname format is invalid")}))
 
   (let [segments (str/split subject pattern-match-dot)]
-    (when-not (re-matches pattern-starts-with-alphanumeric (first segments))
+    (when-not (re-matches pattern-starts-with-alphanumeric-or-underscore (first segments))
       (log/info (i18n/tru "Rejecting subject \"{0}\" as it starts with an invalid character" subject))
       (sling/throw+
         {:kind :invalid-subject-name

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -1662,19 +1662,31 @@
          (ca/validate-subject!
           "rootca..example.org" "rootca..example.org"))))
 
-  (testing "an exception is thrown when the hostnames end in dot"
-    (is (thrown+?
-         [:kind :invalid-subject-name
-          :msg "Subject hostname format is invalid"]
-         (ca/validate-subject!
-          "rootca." "rootca."))))
-
-  (testing "PE-35786 an exception is thrown when hostname ends in a dot"
-    (is (thrown+?
-          [:kind :invalid-subject-name
-           :msg "Subject hostname format is invalid"]
+  (testing "subjects that end end in dot are valid"
+    (is (nil?
           (ca/validate-subject!
-            "aaa1a-aaaaaaaaaaaaa-aaaaa-aaaa00." "aaa1a-aaaaaaaaaaaaa-aaaaa-aaaa00."))))
+           "rootca." "rootca."))))
+
+  (testing "subjects that end in an underscore are valid"
+    (is (nil?
+          (ca/validate-subject!
+            "rootca_" "rootca_"))))
+
+  (testing "subjects that start in an underscore are valid"
+    (is (nil?
+          (ca/validate-subject!
+            "_x-puppet._tcp.example.com" "_x-puppet._tcp.example.com"))))
+
+  (testing "single letter segments are valid"
+    (is (nil?
+          (ca/validate-subject!
+            "a.example.com" "a.example.com")))
+    (is (nil?
+          (ca/validate-subject!
+            "_.example.com" "_.example.com")))
+    (is (nil?
+          (ca/validate-subject!
+            "foo.a.example.com" "foo.a.example.com"))))
 
   (testing "Single word hostnames are allowed"
     (is (nil?


### PR DESCRIPTION
This updates the validation to allow trailing dots, and the subjects to start with an underscore, and have segments that start or end in underscores.

Tests are updated to reflect the updated behaviors.