### PR TITLE
(maint) Update version towards 7.11.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "7.10.1-SNAPSHOT")
+(def ps-version "7.11.0-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
We previously tagged 7.10.0 in preparation for the Platform 7.24 release, however a late breaking issue was discovered that needed to be addressed. Consequently, we burned the 7.10.0 tag and will ship 7.11.0 to include a fix for cert regex matching that could be nonterminating.