### PR TITLE
(maint) fix i18n issues

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -779,10 +779,11 @@
   (log/debug (i18n/trs "Checking \"{0}\" for validity" subject))
 
   (when-not (= hostname subject)
-    (log/infof "Rejecting subject \"%s\" because it doesn't match hostname \"%s\"" subject hostname)
+    ;; see https://github.com/puppetlabs/clj-i18n/blob/main/README.md#single-quotes-in-messages for reasoning with double quote
+    (log/info (i18n/tru "Rejecting subject \"{0}\" because it doesn''t match hostname \"{1}\"" subject hostname))
     (sling/throw+
       {:kind :hostname-mismatch
-       :msg  (format "Instance name \"%s\" does not match requested key \"%s\"" subject hostname)}))
+       :msg  (i18n/tru "Instance name \"{0}\" does not match requested key \"{1}\"" subject hostname)}))
 
   (when (contains-uppercase? hostname)
     (log/info (i18n/tru "Rejecting subject \"{0}\" because all characters must be lowercase" subject))


### PR DESCRIPTION
In a previous commit https://github.com/puppetlabs/puppetserver/commit/a029e7762c07d1d47947edcef6485e5fcd59c2c2 some new strings were added to improve supportability.  While bench testing those issues, it was observed that some strings were not expanded correctly with multiple arguments. The issue turned out to be an escape issue with a single quote.  This resolves that issue, and replaces the use of `format` from that previous commit with the more appropriate i18n translation functions.