### PR TITLE
(maint) Update build_defaults.yaml to puppet8

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,5 +1,5 @@
 ---
 project: 'puppetserver'
 
-repo_name: 'puppet7'
-nonfinal_repo_name: 'puppet7-nightly'
+repo_name: 'puppet8'
+nonfinal_repo_name: 'puppet8-nightly'


### PR DESCRIPTION
There has been confusion for a few major releases about what this file does. Apparently it controls where the `packaging` gem ships the packages publicly. The setting in `project.clj`
controls where ezbake puts the packages after it builds them (internally).

This was not updated so puppetserver 8 was shipped to puppet7.

This should be rectified, and the repo setting should be controlled in a single place, but for now this will ship puppetserver 8.y.z to the proper public destination.