### PR TITLE
(PE-35637) add explicit read/write locking to serial file use

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1,14 +1,14 @@
 (ns puppetlabs.puppetserver.certificate-authority
-  (:import (java.util.concurrent.locks ReentrantReadWriteLock)
-           [org.apache.commons.io IOUtils]
-           (org.bouncycastle.pkcs PKCS10CertificationRequest)
-           [java.util Date]
-           [java.io InputStream ByteArrayOutputStream ByteArrayInputStream File StringReader IOException]
-           [java.nio.file Files]
-           [java.nio.file.attribute FileAttribute PosixFilePermissions]
+  (:import (java.io InputStream ByteArrayOutputStream ByteArrayInputStream File StringReader IOException)
+           (java.nio.file Files)
+           (java.nio.file.attribute FileAttribute PosixFilePermissions)
            (java.security PrivateKey PublicKey)
-           (org.joda.time DateTime)
-           (java.security.cert X509Certificate CRLException CertPathValidatorException X509CRL))
+           (java.security.cert X509Certificate CRLException CertPathValidatorException X509CRL)
+           (java.util Date)
+           (java.util.concurrent.locks ReentrantReadWriteLock)
+           (org.apache.commons.io IOUtils)
+           (org.bouncycastle.pkcs PKCS10CertificationRequest)
+           (org.joda.time DateTime))
   (:require [me.raynes.fs :as fs]
             [schema.core :as schema]
             [clojure.string :as str]
@@ -173,6 +173,7 @@
 
 (def default-serial-lock-timeout-seconds
   5)
+
 (schema/defn ^:always-validate initialize-ca-config
   "Adds in default ca config keys/values, which may be overwritten if a value for
   any of those keys already exists in the ca-data"

--- a/src/clj/puppetlabs/puppetserver/common.clj
+++ b/src/clj/puppetlabs/puppetserver/common.clj
@@ -1,6 +1,9 @@
 (ns puppetlabs.puppetserver.common
-  (:require [schema.core :as schema]
-            [puppetlabs.i18n.core :as i18n]))
+  (:require [clojure.tools.logging :as log]
+            [schema.core :as schema]
+            [puppetlabs.i18n.core :as i18n]
+            [slingshot.slingshot :as sling])
+  (:import (java.util.concurrent TimeUnit)))
 
 (def Environment
   "Schema for environment names. Alphanumeric and _ only."
@@ -21,3 +24,48 @@
   (i18n/tru "Invalid code-id ''{0}''. Must contain only alpha-numerics and ''-'', ''_'', '';'', or '':''"
             code-id))
 
+(defmacro with-safe-read-lock
+  "Given a ReentrantReadWriteLock, acquire the read lock, and hold it for the length of the execution of the body.
+  If the lock can't be acquired, throw an exception to indicate a timeout.  Log behaviors at trace level to aid with
+  supportability"
+  [read-write-lock descriptor timeout-in-seconds & body]
+  `(let [l# (.readLock ~read-write-lock)
+         descriptor# ~descriptor
+         timeout# ~timeout-in-seconds]
+     (log/trace (i18n/trs "Attempt to acquire read lock \"{0}\"" descriptor#))
+     (if (.tryLock l# timeout# TimeUnit/SECONDS)
+       (try
+         (log/trace (i18n/trs "Acquired read lock \"{0}\"" descriptor#))
+         (do
+           ~@body)
+         (finally
+           (.unlock l#)
+           (log/trace (i18n/trs "Released read lock \"{0}\"" descriptor#))))
+       (do
+         (log/info (i18n/trs "Read Lock acquisition timed out \"{0}\"" descriptor#))
+         (sling/throw+
+           {:kind :lock-acquisition-timeout
+            :msg (i18n/tru "Failed to acquire read lock \"{0}\" within {1} seconds" descriptor# timeout#)})))))
+
+(defmacro with-safe-write-lock
+  "Given a ReentrantReadWriteLock, acquire the write lock, and hold it for the length of the execution of the body.
+  If the lock can't be acquired, throw an exception to indicate a timeout.  Log behaviors at trace level to aid with
+  supportability"
+  [read-write-lock descriptor timeout-in-seconds & body]
+  `(let [l# (.writeLock ~read-write-lock)
+         descriptor# ~descriptor
+         timeout# ~timeout-in-seconds]
+     (log/trace (i18n/trs "Attempt to acquire write lock \"{0}\"" descriptor#))
+     (if (.tryLock l# timeout# TimeUnit/SECONDS)
+       (try
+         (log/trace (i18n/trs "Acquired write lock \"{0}\"" descriptor#))
+         (do
+           ~@body)
+         (finally
+           (.unlock l#)
+           (log/trace (i18n/trs "Released write lock \"{0}\"" descriptor#))))
+       (do
+         (log/info (i18n/trs "Write Lock acquisition timed out \"{0}\"" descriptor#))
+         (sling/throw+
+           {:kind :lock-acquisition-timeout
+            :msg (i18n/tru "Failed to acquire write lock \"{0}\" within {1} seconds" descriptor# timeout#)})))))

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -4,7 +4,8 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.kitchensink.file :as ks-file]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils])
-  (:import (java.io ByteArrayInputStream)))
+  (:import (java.io ByteArrayInputStream)
+           (java.util.concurrent.locks ReentrantReadWriteLock)))
 
 (defn assert-subject [o subject]
   (is (= subject (-> o .getSubjectX500Principal .getName))))
@@ -72,7 +73,9 @@
    :infra-nodes-path                 (str cadir "/ca/infra_inventory.txt")
    :infra-node-serials-path          (str cadir "/infra_serials")
    :infra-crl-path                   (str cadir "/infra_crl.pem")
-   :enable-infra-crl                 false})
+   :enable-infra-crl                 false
+   :serial-lock                      (new ReentrantReadWriteLock)
+   :serial-lock-timeout-seconds      5})
 
 (defn ca-sandbox!
   "Copy the `cadir` to a temporary directory and return


### PR DESCRIPTION
In preparation for future changes coming to the CA endpoints, this adds explicit read/write locking to the management of the serial file.

This also adds the ability for the serial lock acquisition to timeout preventing potential locking issues. The default timeout is 5 seconds.

The locks are added to the ca-settings, and schemas updated as appropriate.