### PR TITLE
(PE-35638) make crl file manipulation routines thread safe

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -106,7 +106,11 @@
    ;; Infra CRL would be enabled by default.
    :enable-infra-crl                 schema/Bool
    :serial-lock                      ReentrantReadWriteLock
-   :serial-lock-timeout-seconds      PosInt})
+   :serial-lock-timeout-seconds      PosInt
+   :crl-lock                         ReentrantReadWriteLock
+   :crl-lock-timeout-seconds         PosInt
+   :infra-crl-lock                   ReentrantReadWriteLock
+   :infra-crl-lock-timeout-seconds   PosInt})
 
 (def DesiredCertificateState
   "The pair of states that may be submitted to the certificate
@@ -175,6 +179,12 @@
 (def default-serial-lock-timeout-seconds
   5)
 
+(def default-crl-lock-timeout-seconds
+  5)
+
+(def default-infra-crl-lock-timeout-seconds
+  5)
+
 (schema/defn ^:always-validate initialize-ca-config
   "Adds in default ca config keys/values, which may be overwritten if a value for
   any of those keys already exists in the ca-data"
@@ -186,7 +196,9 @@
                   :enable-infra-crl false
                   :allow-subject-alt-names default-allow-subj-alt-names
                   :allow-authorization-extensions default-allow-auth-extensions
-                  :serial-lock-timeout-seconds default-serial-lock-timeout-seconds}]
+                  :serial-lock-timeout-seconds default-serial-lock-timeout-seconds
+                  :crl-lock-timeout-seconds default-crl-lock-timeout-seconds
+                  :infra-crl-lock-timeout-seconds default-infra-crl-lock-timeout-seconds}]
     (merge defaults ca-data)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -336,7 +348,11 @@
                     :gem-path
                     :enable-infra-crl
                     :serial-lock-timeout-seconds
-                    :serial-lock)]
+                    :serial-lock
+                    :crl-lock-timeout-seconds
+                    :crl-lock
+                    :infra-crl-lock-timeout-seconds
+                    :infra-crl-lock)]
     (if (:enable-infra-crl ca-settings)
       settings'
       (dissoc settings' :infra-crl-path :infra-node-serials-path))))
@@ -486,6 +502,14 @@
 (def serial-lock-descriptor
   "Text used in exceptions to help identify locking issues"
   "serial-file")
+
+(def crl-lock-descriptor
+  "Text used in exceptions to help identify locking issues"
+  "crl-file")
+
+(def infra-crl-lock-descriptor
+  "Text used in exceptions to help identify locking issues"
+  "infra-crl-file")
 
 (schema/defn parse-serial-number :- schema/Int
   "Parses a serial number from its format on disk.  See `format-serial-number`
@@ -1207,7 +1231,9 @@
                                  (:gem-path jruby-puppet))
              :access-control (select-keys certificate-authority
                                           [:certificate-status])
-             :serial-lock (ReentrantReadWriteLock.))))
+             :serial-lock (new ReentrantReadWriteLock)
+             :crl-lock (new ReentrantReadWriteLock)
+             :infra-crl-lock (new ReentrantReadWriteLock))))
 
 (schema/defn ^:always-validate
   config->master-settings :- MasterSettings
@@ -1567,30 +1593,34 @@
   all CRLs are currently valid."
   [incoming-crls :- [X509CRL]
    crl-path :- schema/Str
-   cert-chain-path :- schema/Str]
+   cert-chain-path :- schema/Str
+   lock :- ReentrantReadWriteLock
+   lock-descriptor :- schema/Str
+   lock-timeout :- PosInt]
   (log/info (i18n/trs "Processing update to CRL at {0}" crl-path))
-  (let [current-crls (utils/pem->crls crl-path)
-        cert-chain (utils/pem->certs cert-chain-path)
-        ca-cert-key (utils/get-extension-value (first cert-chain)
-                                               utils/subject-key-identifier-oid)
-        external-crl-chain (remove #(= ca-cert-key
-                                       (:key-identifier (utils/get-extension-value % utils/authority-key-identifier-oid)))
-                                   current-crls)
-        ca-crl (first (filter
-                       #(= ca-cert-key
-                           (:key-identifier (utils/get-extension-value % utils/authority-key-identifier-oid)))
-                       current-crls))
-        incoming-crls-by-key-id (->> incoming-crls
-                                     ;; just in case we're given multiple copies
-                                     ;; of the same CRL, deduplicate so we can
-                                     ;; identify the newest CRL
-                                     set
-                                     (group-by get-auth-key-id))
-        new-ext-crl-chain (cons ca-crl (map #(maybe-replace-crl % incoming-crls-by-key-id)
-                                            external-crl-chain))]
-    (validate-certs-and-crls cert-chain new-ext-crl-chain)
-    (write-crls new-ext-crl-chain crl-path)
-    (log/info (i18n/trs "Successfully updated CRL at {0}" crl-path))))
+  (common/with-safe-write-lock lock lock-descriptor lock-timeout
+    (let [current-crls (utils/pem->crls crl-path)
+          cert-chain (utils/pem->certs cert-chain-path)
+          ca-cert-key (utils/get-extension-value (first cert-chain)
+                                                 utils/subject-key-identifier-oid)
+          external-crl-chain (remove #(= ca-cert-key
+                                         (:key-identifier (utils/get-extension-value % utils/authority-key-identifier-oid)))
+                                     current-crls)
+          ca-crl (first (filter
+                         #(= ca-cert-key
+                             (:key-identifier (utils/get-extension-value % utils/authority-key-identifier-oid)))
+                         current-crls))
+          incoming-crls-by-key-id (->> incoming-crls
+                                       ;; just in case we're given multiple copies
+                                       ;; of the same CRL, deduplicate so we can
+                                       ;; identify the newest CRL
+                                       set
+                                       (group-by get-auth-key-id))
+          new-ext-crl-chain (cons ca-crl (map #(maybe-replace-crl % incoming-crls-by-key-id)
+                                              external-crl-chain))]
+      (validate-certs-and-crls cert-chain new-ext-crl-chain)
+      (write-crls new-ext-crl-chain crl-path)
+      (log/info (i18n/trs "Successfully updated CRL at {0}" crl-path)))))
 
 (schema/defn ensure-directories-exist!
   "Create any directories used by the CA if they don't already exist."

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1522,9 +1522,13 @@
   get-crl-last-modified :- DateTime
   "Given the value of the 'cacrl' setting from Puppet, return
   a Joda DateTime instance of when the CRL file was last modified."
-  [cacrl :- schema/Str]
-  (let [last-modified-milliseconds (.lastModified (io/file cacrl))]
-       (time-coerce/from-long last-modified-milliseconds)))
+  [cacrl :- schema/Str
+   lock :- ReentrantReadWriteLock
+   lock-descriptor :- schema/Str
+   lock-timeout :- PosInt]
+  (common/with-safe-read-lock lock lock-descriptor lock-timeout
+    (let [last-modified-milliseconds (.lastModified (io/file cacrl))]
+         (time-coerce/from-long last-modified-milliseconds))))
 
 (schema/defn ^:always-validate reject-delta-crl
   [crl :- CertificateRevocationList]

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1511,8 +1511,12 @@
   get-certificate-revocation-list :- schema/Str
   "Given the value of the 'cacrl' setting from Puppet,
   return the CRL from the .pem file on disk."
-  [cacrl :- schema/Str]
-  (slurp cacrl))
+  [cacrl :- schema/Str
+   lock :- ReentrantReadWriteLock
+   lock-descriptor :- schema/Str
+   lock-timeout :- PosInt]
+  (common/with-safe-read-lock lock lock-descriptor lock-timeout
+    (slurp cacrl)))
 
 (schema/defn ^:always-validate
   get-crl-last-modified :- DateTime

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -13,6 +13,7 @@
    [puppetlabs.ssl-utils.core :as ssl-utils]
    [puppetlabs.puppetserver.certificate-authority :as ca]
    [puppetlabs.services.ca.certificate-authority-core :refer [handle-get-certificate-revocation-list]]
+   [puppetlabs.services.ca.ca-testutils :as ca-test-utils]
    [ring.mock.request :as mock]
    [clj-time.format :as time-format]
    [clj-time.core :as time]
@@ -455,15 +456,18 @@
 
             (testing "Verify correct CRL is returned depending on enable-infra-crl"
               (let [request (mock/request :get "/v1/certificate_revocation_list/mynode")
+                    ca-settings (ca-test-utils/ca-settings "")
                     infra-crl-response (handle-get-certificate-revocation-list
-                                        request {:cacrl ca-crl
-                                                 :infra-crl-path infra-crl
-                                                 :enable-infra-crl true})
+                                        request (assoc ca-settings
+                                                  :cacrl ca-crl
+                                                  :infra-crl-path infra-crl
+                                                  :enable-infra-crl true))
                     infra-crl-response-body (:body infra-crl-response)
                     full-crl-response (handle-get-certificate-revocation-list
-                                       request {:cacrl ca-crl
-                                                :infra-crl-path infra-crl
-                                                :enable-infra-crl false})
+                                        request (assoc ca-settings
+                                                 :cacrl ca-crl
+                                                 :infra-crl-path infra-crl
+                                                 :enable-infra-crl false))
                     full-crl-response-body (:body full-crl-response)]
                 (is (map? infra-crl-response))
                 (is (= 200 (:status infra-crl-response)))

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -5,6 +5,7 @@
                     ByteArrayOutputStream)
            (com.puppetlabs.ssl_utils SSLUtils)
            (java.security PublicKey MessageDigest)
+           (java.util.concurrent.locks ReentrantReadWriteLock)
            (org.joda.time DateTime Period)
            (org.bouncycastle.asn1.x509 SubjectPublicKeyInfo))
   (:require [puppetlabs.puppetserver.certificate-authority :as ca]
@@ -578,13 +579,16 @@
   (let [update-crl-fixture-dir (str test-resources-dir "/update_crls/")
         cert-chain-path (str update-crl-fixture-dir "ca_crt.pem")
         crl-path (str update-crl-fixture-dir "ca_crl.pem")
-        crl-backup-path (str update-crl-fixture-dir "ca_crl.pem.bak")]
+        crl-backup-path (str update-crl-fixture-dir "ca_crl.pem.bak")
+        crl-lock (ReentrantReadWriteLock.)
+        crl-lock-descriptor "test-crl"
+        crl-lock-timeout 1]
     (logutils/with-test-logging
      (testing "a single newer CRL is used"
        (let [new-crl-path (str update-crl-fixture-dir "new_root_crl.pem")
              incoming-crls (utils/pem->crls new-crl-path)]
          (testutils/with-backed-up-crl crl-path crl-backup-path
-           (ca/update-crls incoming-crls crl-path cert-chain-path)
+           (ca/update-crls incoming-crls crl-path cert-chain-path crl-lock crl-lock-descriptor crl-lock-timeout)
            (let [old-crls (utils/pem->crls crl-backup-path)
                  new-crls (utils/pem->crls crl-path)
                  old-number (utils/get-crl-number (last old-crls))
@@ -594,7 +598,7 @@
        (let [multiple-new-crls-path (str update-crl-fixture-dir "multiple_new_root_crls.pem")
              incoming-crls (utils/pem->crls multiple-new-crls-path)]
          (testutils/with-backed-up-crl crl-path crl-backup-path
-           (ca/update-crls incoming-crls crl-path cert-chain-path)
+           (ca/update-crls incoming-crls crl-path cert-chain-path crl-lock crl-lock-descriptor crl-lock-timeout)
            (let [old-crls (utils/pem->crls crl-backup-path)
                  new-crls (utils/pem->crls crl-path)
                  old-number (utils/get-crl-number (last old-crls))
@@ -607,7 +611,7 @@
              three-newer-crls-path (str update-crl-fixture-dir "three_newer_crl_chain.pem")
              incoming-crls (utils/pem->crls three-newer-crls-path)]
          (testutils/with-backed-up-crl three-crl-path crl-backup-path
-           (ca/update-crls incoming-crls three-crl-path three-cert-path)
+           (ca/update-crls incoming-crls three-crl-path three-cert-path crl-lock crl-lock-descriptor crl-lock-timeout)
            (let [old-crls (utils/pem->crls crl-backup-path)
                  new-crls (utils/pem->crls three-crl-path)]
              (is (> (utils/get-crl-number (.get new-crls 2))
@@ -621,7 +625,7 @@
        (let [new-and-unrelated-crls-path (str update-crl-fixture-dir "new_crls_and_unrelated_crls.pem")
              incoming-crls (utils/pem->crls new-and-unrelated-crls-path)]
          (testutils/with-backed-up-crl crl-path crl-backup-path
-           (ca/update-crls incoming-crls crl-path cert-chain-path)
+           (ca/update-crls incoming-crls crl-path cert-chain-path crl-lock crl-lock-descriptor crl-lock-timeout)
            (let [old-crls (utils/pem->crls crl-backup-path)
                  new-crls (utils/pem->crls crl-path)]
                (is (> (utils/get-crl-number (last new-crls))
@@ -638,7 +642,7 @@
        (let [unrelated-crls-path (str update-crl-fixture-dir "unrelated_crls.pem")
              incoming-crls (utils/pem->crls unrelated-crls-path)]
          (testutils/with-backed-up-crl crl-path crl-backup-path
-           (ca/update-crls incoming-crls crl-path cert-chain-path)
+           (ca/update-crls incoming-crls crl-path cert-chain-path crl-lock crl-lock-descriptor crl-lock-timeout)
            (let [old-crls (utils/pem->crls crl-backup-path)
                  new-crls (utils/pem->crls crl-path)]
              (is (= (count old-crls) (count new-crls)))
@@ -648,10 +652,23 @@
              old-root-crl-path (str update-crl-fixture-dir "old_root_crl.pem")
              incoming-crls (utils/pem->crls old-root-crl-path)]
          (testutils/with-backed-up-crl new-root-crl-chain-path crl-backup-path
-           (ca/update-crls incoming-crls new-root-crl-chain-path cert-chain-path)
+           (ca/update-crls incoming-crls new-root-crl-chain-path cert-chain-path crl-lock crl-lock-descriptor crl-lock-timeout)
            (let [old-crls (utils/pem->crls crl-backup-path)
                  new-crls (utils/pem->crls new-root-crl-chain-path)]
                (is (= (set new-crls) (set old-crls)))))))
+     (testing "update-crls will timeout if lock is held"
+       (let [new-root-crl-chain-path (str update-crl-fixture-dir "chain_with_new_root.pem")
+             old-root-crl-path (str update-crl-fixture-dir "old_root_crl.pem")
+             incoming-crls (utils/pem->crls old-root-crl-path)
+             lock (.writeLock crl-lock)]
+         (.lock lock)
+         (testutils/with-backed-up-crl new-root-crl-chain-path crl-backup-path
+           (is (thrown+?
+                 [:kind :lock-acquisition-timeout]
+                 ;; execute the request in a separate thread as the same thread will allow the lock
+                 @(future (ca/update-crls incoming-crls new-root-crl-chain-path cert-chain-path crl-lock crl-lock-descriptor crl-lock-timeout)))))
+         (.unlock lock)))
+
      (let [multiple-newest-crls-path (str update-crl-fixture-dir "multiple_newest_root_crls.pem")
            delta-crl-path (str test-resources-dir "/update_crls/delta_crl.pem")
            missing-auth-id-crl-path (str test-resources-dir "/update_crls/missing_auth_id_crl.pem")
@@ -663,7 +680,7 @@
            (let [incoming-crls (utils/pem->crls path)]
              (testutils/with-backed-up-crl crl-path crl-backup-path
                (is (thrown-with-msg? IllegalArgumentException error-message
-                                     (ca/update-crls incoming-crls crl-path cert-chain-path)))
+                                     (ca/update-crls incoming-crls crl-path cert-chain-path crl-lock crl-lock-descriptor crl-lock-timeout)))
                (let [old-crls (utils/pem->crls crl-backup-path)
                      new-crls (utils/pem->crls crl-path)]
                  (is (= (set old-crls) (set new-crls))))))))))))

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -550,7 +550,10 @@
       (is (true? (revoked? cert2))))))
 
 (deftest filter-already-revoked-serials-test
-  (let [crl (-> (ca/get-certificate-revocation-list cacrl)
+  (let [lock (new ReentrantReadWriteLock)
+        descriptor "test-crl"
+        timeout 1
+        crl (-> (ca/get-certificate-revocation-list cacrl lock descriptor timeout)
                 StringReader.
                 utils/pem->crl)]
    (testing "Return an empty vector when all supplied serials are already in CRL"
@@ -570,7 +573,10 @@
 
 (deftest get-certificate-revocation-list-test
   (testing "`get-certificate-revocation-list` returns a valid CRL file."
-    (let [crl (-> (ca/get-certificate-revocation-list cacrl)
+    (let [lock (new ReentrantReadWriteLock)
+          descriptor "test-crl"
+          timeout 1
+          crl (-> (ca/get-certificate-revocation-list cacrl lock descriptor timeout)
                   StringReader.
                   utils/pem->crl)]
       (testutils/assert-issuer crl "CN=Puppet CA: localhost"))))
@@ -1888,7 +1894,10 @@
       (is (= "2016-10-11T06:40:47UTC" (get expiration-map "intermediateca.example.org"))))))
 
 (deftest get-cert-or-csr-statuses-test
-  (let [crl (-> (ca/get-certificate-revocation-list cacrl)
+  (let [lock (new ReentrantReadWriteLock)
+        descriptor "test-crl"
+        timeout 1
+        crl (-> (ca/get-certificate-revocation-list cacrl lock descriptor timeout)
                 StringReader.
                 utils/pem->crl)]
     (testing "returns a collection of 'requested' statuses when queried for CSR"

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -77,9 +77,7 @@
    :serial-lock                      (new ReentrantReadWriteLock)
    :serial-lock-timeout-seconds      5
    :crl-lock                         (new ReentrantReadWriteLock)
-   :crl-lock-timeout-seconds         5
-   :infra-crl-lock                   (new ReentrantReadWriteLock)
-   :infra-crl-lock-timeout-seconds   5})
+   :crl-lock-timeout-seconds         5})
 
 (defn ca-sandbox!
   "Copy the `cadir` to a temporary directory and return

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -75,7 +75,11 @@
    :infra-crl-path                   (str cadir "/infra_crl.pem")
    :enable-infra-crl                 false
    :serial-lock                      (new ReentrantReadWriteLock)
-   :serial-lock-timeout-seconds      5})
+   :serial-lock-timeout-seconds      5
+   :crl-lock                         (new ReentrantReadWriteLock)
+   :crl-lock-timeout-seconds         5
+   :infra-crl-lock                   (new ReentrantReadWriteLock)
+   :infra-crl-lock-timeout-seconds   5})
 
 (defn ca-sandbox!
   "Copy the `cadir` to a temporary directory and return


### PR DESCRIPTION
This updates the ca-settings to have two new locks, one for the crl, and one for the infra-crl along with appropriate timeouts for each.  The locks are used in the routines that read and write the crl files to ensure they are only read when they aren't being written. 

Tests are updated as appropriate.  See individual commits comments for more details.