### PR TITLE
(PE-3288) remove redundant reader

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -637,7 +637,7 @@
 (schema/defn read-infra-nodes
     "Returns a list of infra nodes or infra node serials from the specified file organized as one item per line."
     [infra-file-reader :- Reader]
-    (line-seq (io/reader infra-file-reader)))
+    (line-seq infra-file-reader))
 
 (defn- write-infra-serials-to-writer
   [writer infra-nodes-path signeddir]


### PR DESCRIPTION
In previous work, the signature of read-infra-nodes was changed to pass in a reader. The intent was to remove the reader from the funciton so that the reader lifetime could be properly maintained. This updates the code to not create the redundant reader.