### PR TITLE
(PE-35641) promote inventory content safety

### DIFF
--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -1111,9 +1111,12 @@
   (testing "Certs can be written to an inventory file."
     (let [first-cert     (utils/pem->cert cacert)
           second-cert    (utils/pem->cert (ca/path-to-cert signeddir "localhost"))
-          inventory-file (str (ks/temp-file))]
-      (ca/write-cert-to-inventory! first-cert inventory-file)
-      (ca/write-cert-to-inventory! second-cert inventory-file)
+          inventory-file (str (ks/temp-file))
+          ca-settings (assoc
+                        (testutils/ca-settings cadir)
+                        :cert-inventory inventory-file)]
+      (ca/write-cert-to-inventory! first-cert ca-settings)
+      (ca/write-cert-to-inventory! second-cert ca-settings)
 
       (testing "The format of a cert in the inventory matches the existing
                 format used by the ruby puppet code."

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -5,7 +5,7 @@
             [puppetlabs.kitchensink.file :as ks-file]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils])
   (:import (java.io ByteArrayInputStream)
-           (java.util.concurrent.locks ReentrantReadWriteLock)))
+           (java.util.concurrent.locks ReentrantReadWriteLock ReentrantLock)))
 
 (defn assert-subject [o subject]
   (is (= subject (-> o .getSubjectX500Principal .getName))))
@@ -77,7 +77,9 @@
    :serial-lock                      (new ReentrantReadWriteLock)
    :serial-lock-timeout-seconds      5
    :crl-lock                         (new ReentrantReadWriteLock)
-   :crl-lock-timeout-seconds         5})
+   :crl-lock-timeout-seconds         5
+   :inventory-lock                   (new ReentrantLock)
+   :inventory-lock-timeout-seconds   5})
 
 (defn ca-sandbox!
   "Copy the `cadir` to a temporary directory and return


### PR DESCRIPTION
This adds a ReentrantLock that is used to protect multiple threads from writing to the inventory file at the same time.  This is important because the inventory update routine now has to read in the contents prior to appending a new entry. If two separate threads are updating the file at the same time, there is the possiblity that one of the entries would be lost.

Tests were updated as needed.