### PR TITLE
(PE-35007) Stop overriding jruby from clj-parent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,8 +51,7 @@
                  ;; send their logs to logstash, so we include it in the jar.
                  [net.logstash.logback/logstash-logback-encoder]
 
-                 [puppetlabs/jruby-deps "9.4.2.0-1"]
-                 [puppetlabs/jruby-utils :exclusions [puppetlabs/jruby-deps]]
+                 [puppetlabs/jruby-utils]
                  [puppetlabs/clj-shell-utils]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/trapperkeeper-webserver-jetty9]


### PR DESCRIPTION
We want to go back to using the jruby from clj-parent in the main branch. This commit updates the puppetserver project to use the version contained in clj-parent.