### PR TITLE
(PE-35706) add certificate validity function

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1987,3 +1987,14 @@
                     (format-date-time))))
             {}
             crl-chain)))
+(schema/defn cert-authority-id-match-ca-subject-id? :- schema/Bool
+  "Given a certificate, and the ca-cert, validate that the certificate was signed by the CA provided"
+  [incoming-cert :- X509Certificate
+   ca-cert :- X509Certificate]
+  (let [incoming-key-id (utils/get-extension-value incoming-cert utils/authority-key-identifier-oid)
+        ca-key-id (utils/get-extension-value ca-cert utils/subject-key-identifier-oid)]
+    (if incoming-key-id
+      ;; incoming are byte-arrays, convert to seq for simple comparisons
+      (= (seq (:key-identifier incoming-key-id)) (seq ca-key-id))
+      false)))
+


### PR DESCRIPTION
This adds a new function `cert-authority-id-match-ca-subject-id?` that validates that for a given cert and a ca-cert, that the cert was issued by the ca-cert.

Tests were added to demonstrate the behavior.