### PR TITLE
(PE-35709) add in renew-certificate function

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -38,10 +38,10 @@
           report-activity (if-let [activity-reporting-service (maybe-get-service this :ActivityReportingService)]
                             (fn [& payload]
                               (try
-                                (activity-proto/report-activity! activity-reporting-service (first payload))
-                              (catch Exception e
-                                (log/error
-                                  (i18n/trs "Reporting CA event failed with: {0}\nPayload: {1}"
+                                  (activity-proto/report-activity! activity-reporting-service (first payload))
+                                (catch Exception e
+                                  (log/error
+                                    (i18n/trs "Reporting CA event failed with: {0}\nPayload: {1}"
                                             (.getMessage e)
                                             (first payload))))))
                             (constantly nil))]


### PR DESCRIPTION
In the first commit:

This simplifies the mechanism for activity reporting to centralize the message creation and reporting into a separate function that can be called with the subjects and type of reporting without having to pass the request around. It simplifies the testing required, and creates reuse.

In the second commit:
Given an existing certificate, which is assumed to be from the
same issuer (caller to validate), generate a new signed cert
with the same extensions, and a new expiration period determined
by the auto-renewal-cert-ttl time.

Note that the issuer and subject identifier extensions need to be
regenerated for signing to occur properly.

Tests are added to demonstrate the behavior of the function.
