### PR TITLE
PE-35698 Add new certificate-authority parameters

### DIFF
--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -196,4 +196,10 @@ certificate-authority: {
 
     allow-subject-alt-names: false
     allow-authorization-extensions: false
+    # Disable auto renewal of certs by default.
+    allow-auto-renewal: false
+    # This value determines the lifetime of the cert if auto-renewal is enabled
+    auto-renewal-cert-ttl: "60d"
+    # Default cert expiration time. If the value is set here, it will take precedence over ca-ttl setting in puppet.conf
+    #ca-ttl: "60d"
 }

--- a/ezbake/config/conf.d/ca.conf
+++ b/ezbake/config/conf.d/ca.conf
@@ -7,4 +7,10 @@ certificate-authority: {
 
     # enable the separate CRL for Puppet infrastructure nodes
     # enable-infra-crl: false
+    # Disable auto renewal of certs by default.
+    allow-auto-renewal: false
+    # This value determines the lifetime of the cert if auto-renewal is enabled
+    auto-renewal-cert-ttl: "60d"
+    # Default cert expiration time. If the value is set here, it will take precedence over ca-ttl setting in puppet.conf
+    #ca-ttl: "60d"
 }

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -725,6 +725,12 @@
     (testing "serial"
       (is (fs/exists? (:serial settings))))
 
+    (testing "allow-auto-renewal"
+      (is (= false (:allow-auto-renewal settings))))
+
+    (testing "auto-renewal-cert-ttl"
+      (is (= "60d" (:auto-renewal-cert-ttl settings))))
+
     (testing "Does not replace files if they all exist"
       (let [files (-> (ca/settings->cadir-paths (assoc settings :enable-infra-crl false))
                       (dissoc :csrdir :signeddir :cadir)

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -55,6 +55,8 @@
    :allow-authorization-extensions   false
    :allow-duplicate-certs            false
    :allow-subject-alt-names          false
+   :allow-auto-renewal               false
+   :auto-renewal-cert-ttl            "60d"
    :ca-name                          "test ca"
    :ca-ttl                           1
    :cadir                            (str cadir)


### PR DESCRIPTION
Add three new parameters to certificate-authority. allow-auto-renewal - to toggle auto renewal of certs. auto-renewal-cert-ttl - determines the lifetime of cert. ca-ttl - default expiration time. If ca-ttl is set in certificate-authority, it will override the ca-ttl value in puppet conf.