### PR TITLE
(maint) enable pr testing through github actions

### DIFF
--- a/.github/workflows/pr-testing.yaml
+++ b/.github/workflows/pr-testing.yaml
@@ -1,0 +1,44 @@
+name: PR Testing
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+    paths: ['src/**','test/**','project.clj']
+
+jobs:
+  pr-testing:
+    name: PR Testing
+    strategy:
+      fail-fast: false
+      matrix:
+        javaargs: ['with-profile fips', '']
+        filter: [':singlethreaded', ':multithreaded']
+        version: ['8', '11', '17']
+        exclude:
+          - version: 8
+            filter: ':multithreaded'
+          - version: 8
+            javaargs: 'with-profile fips'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: setup java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.version }}
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+      - name: setup gems
+        run: lein gem install --install-dir "target/jruby-gem-home" --no-document "semantic_puppet:1.0.2" "hocon:1.3.1" "text:1.3.1" "locale:2.1.2" "gettext:3.2.2" "fast_gettext:1.1.2" "concurrent-ruby:1.1.5" "deep_merge:1.0.1"
+      - name: clojure tests
+        run: lein -U ${{ matrix.javaargs }} test ${{ matrix.filter }}
+        timeout-minutes: 30
+      - name: rspec tests
+        run: rake spec


### PR DESCRIPTION
This enables running the clojure tests via github actions on the matrix of versions of java, multithreaded support, and with fips.