### PR TITLE
(PE-35705) extract certificate from renewal request

### DIFF
--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -59,6 +59,7 @@
    :auto-renewal-cert-ttl            "60d"
    :ca-name                          "test ca"
    :ca-ttl                           1
+   :allow-header-cert-info           false
    :cadir                            (str cadir)
    :cacrl                            (str cadir "/ca_crl.pem")
    :cacert                           (str cadir "/ca_crt.pem")


### PR DESCRIPTION
This commit updates the handle-cert-renewal function to extract certificates present in the request. Certificates can be included either as a ssl-client-cert property in the request, or as an x-client-cert field in the request header.

Imports for certificate-authority-core and certificate-authority-int-test were alphabetized as well.