### PR TITLE
(maint) update ruby version in github action to 3.1 

### DIFF
--- a/.github/workflows/pr-testing.yaml
+++ b/.github/workflows/pr-testing.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1
       - name: setup gems
         run: lein gem install --install-dir "target/jruby-gem-home" --no-document "semantic_puppet:1.0.2" "hocon:1.3.1" "text:1.3.1" "locale:2.1.2" "gettext:3.2.2" "fast_gettext:1.1.2" "concurrent-ruby:1.1.5" "deep_merge:1.0.1"
       - name: clojure tests


### PR DESCRIPTION
This updates the ruby version in the github PR action to use ruby 3.1 instead
of ruby 2.7.  The older version of ruby was causing test failures with log lines
being repeated multiple times.