### PR TITLE
(PE-35710) add in certificate renewal behavior

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -2088,7 +2088,7 @@
   [extensions :- utils/SSLExtensionList ca-cert :- X509Certificate subject-public-key :- PublicKey]
   (replace-subject-identifier (replace-authority-identifier extensions ca-cert) subject-public-key))
 
-(schema/defn renew-certificate!
+(schema/defn renew-certificate! :- X509Certificate
   "Given a certificate and CaSettings create a new signed certificate using the public key from the certificate.
   It recreates all the extensions in the original certificate."
   [certificate :- X509Certificate


### PR DESCRIPTION
This adds in the certificate renewal behavior, assuming that the incoming certificate has been properly validated.  Tests are updated to demonstrate that newly generated certificates can be correctly renewed.