### PR TITLE
(maint) differentiate test names

### DIFF
--- a/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
+++ b/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
@@ -31,8 +31,7 @@
   (testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
 
 (deftest ^:integration request-with-ssl-cert-handled-via-tk-auth
-  (testing (str "Request with SSL certificate via trapperkeeper-authorization "
-                "handled")
+  (testing "Request with SSL certificate via trapperkeeper-authorization handled"
     (logutils/with-test-logging
       (bootstrap/with-puppetserver-running
         app
@@ -113,8 +112,7 @@
                   (ks/pprint-to-string response)))))))))
 
 (deftest ^:integration request-with-x-client-headers-handled-via-tk-auth
-  (testing (str "Request with X-Client headers via trapperkeeper-authorization "
-                "handled")
+  (testing "Request with X-Client headers via trapperkeeper-authorization handled"
     (let [extension-value "UUUU-IIIII-DDD"
           cert (:cert (ssl-simple/gen-self-signed-cert
                        "ssl-client"

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -184,8 +184,7 @@
                     (ks/pprint-to-string response))))))))))
 
 (deftest ^:integration certificate-with-ca-true-extension-refused
-  (testing (str "Validates that the server rejects a csr for signing"
-                " that has the v3 CA:TRUE extension")
+  (testing "Validates that the server rejects a csr for signing that has the v3 CA:TRUE extension"
     (let [server-conf-dir (str test-resources-dir "/ca_true_test/master/conf")
           req-dir (str server-conf-dir "/ca/requests")
           key-pair (ssl-utils/generate-key-pair)
@@ -216,8 +215,7 @@
           (fs/delete-dir req-dir))))))
 
 (deftest ^:integration double-encoded-request-not-allowed
-  (testing (str "client not able to unintentionally get access to CA endpoint "
-                "by double-encoding request uri")
+  (testing "client not able to unintentionally get access to CA endpoint by double-encoding request uri"
     ;; The following tests are intended to show that a client is not able
     ;; to unintentionally gain access to info for a different client by
     ;; double-encoding a character in the client name portion of the
@@ -497,8 +495,7 @@
 
 
 (deftest ^:integration certificate-status-returns-auth-ext-info
-  (testing (str "Validates that the certificate_status endpoint"
-                "includes authorization extensions for certs and CSRs")
+  (testing "Validates that the certificate_status endpoint includes authorization extensions for certs and CSRs"
     (let [request-dir (str bootstrap/server-conf-dir "/ca/requests")
           key-pair (ssl-utils/generate-key-pair)
           subjectDN (ssl-utils/cn "test_cert_with_auth_ext")

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -159,7 +159,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
 
-(deftest ^:integration ^:single-threaded-only admin-api-flush-jruby-pool-test
+(deftest ^:integration ^:single-threaded-only admin-api-flush-jruby-pool-single-threaded-test
   (testing "Flushing the instance pool results in all new JRuby instances"
     (bootstrap/with-puppetserver-running
       app
@@ -180,13 +180,14 @@
         (is (true? (verify-no-constants pool-context 4)))))))
 
 ;; Copies the test above, but for multithreaded mode (single jruby instance)
-(deftest ^:integration ^:multithreaded-only admin-api-flush-jruby-ref-pool-test
+(deftest ^:integration ^:multithreaded-only admin-api-flush-jruby-ref-pool-multi-threaded-test
   (testing "Flushing the reference pool results in a new JRuby instance"
     (bootstrap/with-puppetserver-running
       app
       {:jruby-puppet {:gem-path gem-path
                       :max-active-instances 4
-                      :borrow-timeout default-borrow-timeout}}
+                      :borrow-timeout default-borrow-timeout
+                      :multithreaded true}}
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
             context (tk-services/service-context jruby-service)
             pool-context (:pool-context context)]

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -603,9 +603,7 @@
 
 (deftest ^:integration
          not-modified-returned-for-environment-class-info-request-with-gzip-tag
-  (testing (str "SERVER-1153 - when the webserver gzips the response "
-                "containing environment_classes etag, the next request "
-                "roundtripping that etag returns an HTTP 304 (Not Modified)")
+  (testing "SERVER-1153 - when the webserver gzips the response containing environment_classes etag, the next request roundtripping that etag returns an HTTP 304 (Not Modified)"
     (let [expected-etag "abcd1234"
           body-length 200000
           jruby-service (reify jruby-protocol/JRubyPuppetService

--- a/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
@@ -473,9 +473,7 @@ Puppet::ResourceApi.register_transport(
 
 (deftest ^:integration
          not-modified-returned-for-environment-transports-info-request-with-gzip-tag
-  (testing (str "SERVER-1153 - when the webserver gzips the response "
-                "containing environment_transports etag, the next request "
-                "roundtripping that etag returns an HTTP 304 (Not Modified)")
+  (testing "SERVER-1153 - when the webserver gzips the response containing environment_transports etag, the next request roundtripping that etag returns an HTTP 304 (Not Modified)"
     (let [expected-etag "abcd1234"
           body-length 200000
           jruby-service (reify jruby-protocol/JRubyPuppetService

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -761,8 +761,7 @@
                (re-pattern (str "Missing:\n" path))
                (ca/initialize! settings)))))))
 
-  (testing (str "The CA private key has its permissions properly reset when "
-                ":manage-internal-file-permissions is true.")
+  (testing "The CA private key has its permissions properly reset when :manage-internal-file-permissions is true."
     (let [settings (testutils/ca-sandbox! cadir)]
       (ks-file/set-perms (:cakey settings) "rw-r--r--")
       (logutils/with-test-logging
@@ -770,8 +769,7 @@
         (is (logged? #"/ca/ca_key.pem' was found to have the wrong permissions set as 'rw-r--r--'. This has been corrected to 'rw-r-----'."))
         (is (= ca/private-key-perms (ks-file/get-perms (:cakey settings)))))))
 
-  (testing (str "The CA private key's permissions are not reset if "
-                ":manage-internal-file-permissions is false.")
+  (testing "The CA private key's permissions are not reset if :manage-internal-file-permissions is false."
     (let [perms "rw-r--r--"
           settings (assoc (testutils/ca-sandbox! cadir)
                      :manage-internal-file-permissions false)]
@@ -829,8 +827,7 @@
         (is (= (slurp hostcrl) cacrl-text)
             (str "Unexpected content for hostcrl: " hostcrl)))
 
-      (testing (str "Doesn't throw exception or create dummy file if no "
-                    "hostcrl and no cacrl to copy")
+      (testing "Doesn't throw exception or create dummy file if no hostcrl and no cacrl to copy"
         (fs/delete hostcrl)
         (let [copy (fs/copy cacrl (ks/temp-file))]
           (fs/delete cacrl)
@@ -913,8 +910,7 @@
              (ca/initialize-master-ssl! settings "master" ca-settings)))
         (fs/copy private-key-backup private-key-path)))
 
-    (testing (str "Throws an exception if the private key is present but cert "
-                  "and public key are missing")
+    (testing "Throws an exception if the private key is present but cert and public key are missing"
       (let [public-key-path (:hostpubkey settings)
             public-key-backup (fs/copy public-key-path (ks/temp-file))
             cert-path (:hostcert settings)
@@ -931,8 +927,7 @@
         (fs/copy public-key-backup public-key-path)
         (fs/copy cert-backup cert-path)))
 
-    (testing (str "Throws an exception if the public key is present but cert "
-                  "and private key are missing")
+    (testing "Throws an exception if the public key is present but cert and private key are missing"
       (let [private-key-path (:hostprivkey settings)
             private-key-backup (fs/copy private-key-path (ks/temp-file))
             cert-path (:hostcert settings)

--- a/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -84,26 +84,21 @@
                               :ssl-ca-cert  "thelocalcacert"
                               :ssl-crl-path "thehostcrl"}]
 
-    (testing (str "no call made to override default webserver settings if "
-                  "full ssl cert configuration already in webserver settings")
+    (testing "no call made to override default webserver settings if full ssl cert configuration already in webserver settings"
       (is (nil? (init-webserver-fn webserver-ssl-config))
           "Override function unexpectedly called with non-nil args"))
 
-    (testing (str "no call made to override default webserver settings if "
-                  "at least one overridable setting already in webserver "
-                  "settings")
+    (testing "no call made to override default webserver settings if at least one overridable setting already in webserver settings"
       (doseq [[setting-key setting-value] webserver-ssl-config]
         (let [map-with-one-overridable-setting {setting-key setting-value}]
           (is (nil? (init-webserver-fn map-with-one-overridable-setting))
               (str "Override function unexpectedly called with non-nil args "
                    "for " map-with-one-overridable-setting)))))
 
-    (testing (str "expected settings passed to override function when "
-                  "no overridable ones already exist in webserver settings")
+    (testing "expected settings passed to override function when no overridable ones already exist in webserver settings"
       (is (= webserver-ssl-config (init-webserver-fn {}))
           "Unexpected settings passed into the override function"))
 
-    (testing (str "expected settings passed to override function when "
-                  "no overridable ones already exist in webserver settings")
+    (testing "expected settings passed to override function when no overridable ones already exist in webserver settings"
       (is (= webserver-ssl-config (init-webserver-fn {:x-non-overridable true}))
           "Unexpected settings passed into the override function"))))

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -82,9 +82,7 @@
                                   "default value, should not be returned")))))))))
 
 (deftest config-key-conflicts
-  (testing (str
-             "Providing config values that should be read from Puppet results "
-             "in an error that mentions all offending config keys.")
+  (testing "Providing config values that should be read from Puppet results in an error that mentions all offending config keys."
     (with-test-logging
       (ks-testutils/with-no-jvm-shutdown-hooks
        (let [config (assoc required-config :cacrl "bogus" :cacert "meow")
@@ -104,8 +102,7 @@
                           :ssl-crl-path "thecacrl"
                           :port 8081
                           :default-server true}]
-    (testing (str "webserver settings not overridden when mult-webserver config is provided"
-                  "and full ssl cert configuration is available")
+    (testing "webserver settings not overridden when mult-webserver config is provided and full ssl cert configuration is available"
       (with-test-logging
        (let [config (assoc required-config :webserver
                                            {:puppet-server webserver-config})]
@@ -115,8 +112,7 @@
           config
           (is (logged? #"Not overriding webserver settings with values from core Puppet"))))))
 
-    (testing (str "webserver settings not overridden when single webserver is provided"
-                  "and full ssl cert configuration is available")
+    (testing "webserver settings not overridden when single webserver is provided and full ssl cert configuration is available"
       (let [config (assoc required-config :webserver webserver-config)]
         (with-test-logging
          (tk-testutils/with-app-with-config

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -282,8 +282,7 @@
       (is (every? (complement get-validity) invalid-path-results) (ks/pprint-to-string invalid-path-results)))))
 
 (deftest file-bucket-file-content-type-test
-  (testing (str "The 'Content-Type' header on incoming /file_bucket_file requests "
-                "is not overwritten, and simply passed through unmodified.")
+  (testing "The 'Content-Type' header on incoming /file_bucket_file requests is not overwritten, and simply passed through unmodified."
     (let [handler     (fn ([req] {:request req}))
           app         (build-ring-handler handler "1.2.3" dummy-jruby-service)
           resp        (app (-> {:request-method :put
@@ -293,11 +292,10 @@
       (is (= "application/octet-stream"
              (get-in resp [:request :content-type])))
 
-      (testing (str "Even if the client sends something insane, "
-                    "just pass it through and let the puppet code handle it.")
+      (testing "Even if the client sends something insane, just pass it through and let the puppet code handle it."
         (let [resp (app (-> {:request-method :put
-                          :content-type "something-crazy/for-content-type"
-                          :uri "/v3/file_bucket_file/bar"}
+                             :content-type "something-crazy/for-content-type"
+                             :uri "/v3/file_bucket_file/bar"}
                             (ring-mock/body "foo")))]
           (is (= "something-crazy/for-content-type"
                  (get-in resp [:request :content-type]))))))))


### PR DESCRIPTION
The single-threaded and multi-threaded versions of `admin-api-flush-jruby-pool-test` were named nearly the same
thing, which was confusing. This changes the naming to make them different, and forces the multithreaded
test to specify the multithreaded flag to guarantee the test runs in multithreaded mode regardless of the environment variable setting.