### PR TITLE
(PE-35710) renew certificates when requested

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -2102,7 +2102,7 @@
   [extensions :- utils/SSLExtensionList ca-cert :- X509Certificate subject-public-key :- PublicKey]
   (replace-subject-identifier (replace-authority-identifier extensions ca-cert) subject-public-key))
 
-(schema/defn renew-certificate!
+(schema/defn renew-certificate! :- X509Certificate
   "Given a certificate and CaSettings create a new signed certificate using the public key from the certificate.
   It recreates all the extensions in the original certificate."
   [certificate :- X509Certificate


### PR DESCRIPTION
This commit uses the renew-certificate! function added in a previous commit [1] to sign a new certificate and return the new cert to the agent when a qualified request is made to the certificate_renewal endpoint.

[1]: a29054e19641ae1852615ee4cd89434939dff665