### PR TITLE
(PE-36178) Add config block for certificate renewal endpoint

### DIFF
--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -57,6 +57,18 @@ authorization: {
             name: "puppetlabs csr"
         },
         {
+            # Allow nodes to renew their certificate
+            match-request: {
+                path: "/puppet-ca/v1/certificate_renewal"
+                type: path
+                method: post
+            }
+            # this endpoint should never be unauthenticated, as it requires the cert to be provided.
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs certificate renewal"
+        },
+        {
             # Allow the CA CLI to access the certificate_status endpoint
             match-request: {
                 path: "/puppet-ca/v1/certificate_status"


### PR DESCRIPTION
This adds a configuration block that allows authenticated clients to access the certificate renewal endpoint.