### PR TITLE
(PE-36202) add indication that agent supports certificate renewal

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -70,13 +70,15 @@
         (rr/not-found (i18n/tru "Could not find certificate_request {0}" subject)))
       (rr/content-type "text/plain")))
 
+
 (schema/defn handle-put-certificate-request!
   [ca-settings :- ca/CaSettings
    report-activity
    {:keys [body] {:keys [subject]} :route-params :as request}]
   (sling/try+
-    (let [report-activity-fn (ca/create-report-activity-fn report-activity request)]
-      (ca/process-csr-submission! subject body ca-settings report-activity-fn)
+    (let [supports-auto-renewal (ca/supports-auto-renewal? request)
+          report-activity-fn (ca/create-report-activity-fn report-activity request)]
+      (ca/process-csr-submission! subject body ca-settings report-activity-fn supports-auto-renewal)
       (rr/content-type (rr/response nil) "text/plain"))
     (catch ca/csr-validation-failure? {:keys [msg]}
       (log/error msg)


### PR DESCRIPTION
This adds the concept of the CA determining if a given agent CSR can support renewal or not. As a stop-gap, this introspects the x-puppet-version header to check the version of the agent. If it is present, and >= 8.2.0, then it is assumed that the agent supports the feature. Also as a stop-gap, a file is written alongside of the csr to indicate that the agent supports the feature. Future work will be to use this file to choose a short ttl (assuming renewal is enabled), and clean up the temporary file as appropriate.

Additional follow-on work will include leveraging attributes/extensions present in the CSR instead of the version to indicate that the agent supports renewal.

Also as part of this work, the puppet function `versioncmp` was ported into clojure and included. Similar tests to what is found in puppet were added. See https://github.com/puppetlabs/puppet/blob/6b400f35193e5d6871fd679d6ad49776d1cb6072/lib/puppet/util/package.rb#L3