### PR TITLE
(maint) use version compare function from kitchensink

### DIFF
--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -2026,12 +2026,3 @@
             ;; for ease of testing, just test the first and last
             (is (= "0x0006" (first last-entry-fields)))
             (is (= "/CN=foo" (last last-entry-fields)))))))))
-
-(deftest versioncmp-test
-  (testing "should be able to sort a long set of various unordered versions"
-    (let [test-items ["1.1.6" "2.3" "1.1a" "3.0" "1.5" "1" "2.4" "1.1-4" "2.3.1" "1.2" "2.3.0" "1.1-3" "2.4b" "2.4" "2.40.2" "2.3a.1" "3.1" "0002" "1.1-5" "1.1.a" "1.06"]
-          sorted-items (sort ca/versioncmp test-items)]
-      (is (= ["0002", "1", "1.06", "1.1-3", "1.1-4", "1.1-5", "1.1.6", "1.1.a", "1.1a", "1.2", "1.5", "2.3", "2.3.0", "2.3.1", "2.3a.1", "2.4", "2.4", "2.4b", "2.40.2", "3.0", "3.1"]
-             sorted-items)))))
-
-


### PR DESCRIPTION
This removes the version compare function that was added as a stop-gap until the kitchensink version was available.  Now that it is, this removes the function, the utility routines and the tests from this repo.