### PR TITLE
(SERVER-3289) add ubuntu 22.04 as build target

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -170,7 +170,7 @@
                                                [puppetlabs/jruby-utils]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9]]
-                      :plugins [[puppetlabs/lein-ezbake "2.4.1"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.4.2"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [puppetlabs/trapperkeeper-webserver-jetty9]]


### PR DESCRIPTION
This updates ezbake to 2.4.2 to allow ubuntu to be a build target for puppetserver.