### PR TITLE
(PE-36386) remove use of clj-yaml in favor of snakeyaml 2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,6 @@
   :dependencies [[org.clojure/clojure]
 
                  [slingshot]
-                 [clj-commons/clj-yaml]
                  [org.yaml/snakeyaml]
                  [commons-lang]
                  [commons-io]
@@ -45,6 +44,7 @@
                  [liberator]
                  [org.apache.commons/commons-exec]
                  [io.dropwizard.metrics/metrics-core]
+                 [org.yaml/snakeyaml "2.0"]
 
                  ;; We do not currently use this dependency directly, but
                  ;; we have documentation that shows how users can use it to

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -26,7 +26,6 @@
             [puppetlabs.puppetserver.common :as common]
             [puppetlabs.puppetserver.ringutils :as ringutils]
             [puppetlabs.ssl-utils.core :as utils]
-            [clj-yaml.core :as yaml]
             [puppetlabs.puppetserver.shell-utils :as shell-utils]
             [puppetlabs.i18n.core :as i18n]))
 
@@ -1007,7 +1006,7 @@
   certificate extensions from the `extensions_requests` section."
   [csr-attributes-file :- schema/Str]
   (if (fs/file? csr-attributes-file)
-    (let [csr-attrs (yaml/parse-string (slurp csr-attributes-file))
+    (let [csr-attrs (common/parse-yaml (slurp csr-attributes-file))
           ext-req (:extension_requests csr-attrs)]
       (map (fn [[oid value]]
              {:oid (or (get puppet-short-names oid)
@@ -2068,7 +2067,7 @@
   shortnames"
   [custom-oid-mapping-file :- schema/Str]
   (if (fs/file? custom-oid-mapping-file)
-    (let [oid-mappings (:oid_mapping (yaml/parse-string (slurp custom-oid-mapping-file)))]
+    (let [oid-mappings (:oid_mapping (common/parse-yaml (slurp custom-oid-mapping-file)))]
       (into {} (for [[oid names] oid-mappings] [(name oid) (keyword (:shortname names))])))
     (log/debug (i18n/trs "No custom OID mapping configuration file found at {0}, custom OID mappings will not be loaded"
                 custom-oid-mapping-file))))

--- a/src/clj/puppetlabs/puppetserver/common.clj
+++ b/src/clj/puppetlabs/puppetserver/common.clj
@@ -3,7 +3,9 @@
             [schema.core :as schema]
             [puppetlabs.i18n.core :as i18n]
             [slingshot.slingshot :as sling])
-  (:import (java.util.concurrent TimeUnit)))
+  (:import (java.util List Map Set)
+           (java.util.concurrent TimeUnit)
+           (org.yaml.snakeyaml Yaml)))
 
 (def Environment
   "Schema for environment names. Alphanumeric and _ only."
@@ -92,3 +94,33 @@
          (sling/throw+
            {:kind :lock-acquisition-timeout
             :msg (i18n/tru "Failed to acquire lock \"{0}\" within {1} seconds" descriptor# timeout#)})))))
+
+(defprotocol JavaMap->ClojureMap
+  (java->clj [o]))
+
+(extend-protocol JavaMap->ClojureMap
+  Map
+  (java->clj [o] (let [entries (.entrySet o)]
+                   (reduce (fn [m [^String k v]]
+                             (assoc m (keyword k) (java->clj v)))
+                           {} entries)))
+
+  List
+  (java->clj [o] (vec (map java->clj o)))
+
+  Set
+  (java->clj [o] (set (map java->clj o)))
+
+  Object
+  (java->clj [o] o)
+
+  nil
+  (java->clj [_] nil))
+
+(defn parse-yaml
+  [yaml-string]
+  ;; default in snakeyaml 2.0 is to not allow
+  ;; global tags, which is the source of exploits.
+  (let [yaml (new Yaml)
+        data (.load yaml ^String yaml-string)]
+    (java->clj data)))

--- a/src/clj/puppetlabs/services/master/file_serving.clj
+++ b/src/clj/puppetlabs/services/master/file_serving.clj
@@ -1,11 +1,11 @@
 (ns puppetlabs.services.master.file-serving
   (:require [bidi.bidi :as bidi]
-            [clj-yaml.core :as yaml]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [digest :as digest]
             [me.raynes.fs :as fs]
             [puppetlabs.i18n.core :as i18n]
+            [puppetlabs.puppetserver.common :as common]
             [puppetlabs.ring-middleware.utils :as middleware-utils]
             [ring.util.response :as rr])
   (:import com.sun.security.auth.module.UnixSystem
@@ -150,7 +150,7 @@
   [project-dir]
   (let [config-path (str project-dir "/bolt-project.yaml")]
     (when (fs/file? config-path)
-     (yaml/parse-string (slurp config-path)))))
+      (common/parse-yaml (slurp config-path)))))
 
 (defn parse-modulepath
   "The modulepath for a bolt project can either be an array of paths or a string


### PR DESCRIPTION
This removes the use of clj-yaml for yaml parsing because internally it uses snakeyaml 1.33. Instead, snakeyaml 2.0 is used directly and a routine for mapping from java structures to clojure structures is added.