### PR TITLE
(PE-32607) change default auto-renewal ttl to 90 days

### DIFF
--- a/dev/puppetserver.conf
+++ b/dev/puppetserver.conf
@@ -199,7 +199,7 @@ certificate-authority: {
     # Disable auto renewal of certs by default.
     allow-auto-renewal: false
     # This value determines the lifetime of the cert if auto-renewal is enabled
-    auto-renewal-cert-ttl: "60d"
+    auto-renewal-cert-ttl: "90d"
     # Default cert expiration time. If the value is set here, it will take precedence over ca-ttl setting in puppet.conf
     #ca-ttl: "60d"
 }

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -241,10 +241,10 @@
   60)
 
 (def default-auto-ttl-renewal
-  "60d") ; 60 days by default
+  "90d") ; 90 days by default
 
 (def default-auto-ttl-renewal-seconds
-  (duration-str->sec default-auto-ttl-renewal)) ; 60 days by default
+  (duration-str->sec default-auto-ttl-renewal)) ; 90 days by default
 
 (schema/defn ^:always-validate initialize-ca-config
   "Adds in default ca config keys/values, which may be overwritten if a value for

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -214,10 +214,10 @@
                         (is (= 204 (:status response)))
                         (is (fs/exists? signed-cert-path))
                         (let [signed-cert (ssl-utils/pem->cert signed-cert-path)]
-                          (testing "new not-after should be 59 days (and some fraction) away"
+                          (testing "new not-after should be 89 days (and some fraction) away"
                             (let [diff (- (.getTime (.getNotAfter signed-cert)) (.getTime (Date.)))
                                   days (.convert TimeUnit/DAYS diff TimeUnit/MILLISECONDS)]
-                              (is (= 59 days)))))))))
+                              (is (= 89 days)))))))))
             (testing "signs a cert with a long ttl when the capability indicator is not present"
               (let [certname (ks/rand-str :alpha-lower 8)
                     csr (ssl-utils/generate-certificate-request
@@ -1194,10 +1194,10 @@
                 (is (true? (.before (.getNotBefore signed-cert) (.getNotBefore renewed-cert)))))
               (testing "new not-after is earlier than before"
                 (is (true? (.after (.getNotAfter signed-cert) (.getNotAfter renewed-cert)))))
-              (testing "new not-after should be 59 days (and some fraction) away"
+              (testing "new not-after should be 89 days (and some fraction) away"
                 (let [diff (- (.getTime (.getNotAfter renewed-cert)) (.getTime (Date.)))
                       days (.convert TimeUnit/DAYS diff TimeUnit/MILLISECONDS)]
-                  (is (= 59 days))))))))
+                  (is (= 89 days))))))))
 
       (testing "returns a 400 bad request response when the ssl-client-cert is not present"
         (bootstrap/with-puppetserver-running-with-mock-jrubies
@@ -1260,10 +1260,10 @@
                 (is (true? (.before (.getNotBefore signed-cert) (.getNotBefore renewed-cert)))))
               (testing "new not-after is earlier than before"
                 (is (true? (.after (.getNotAfter signed-cert) (.getNotAfter renewed-cert)))))
-              (testing "new not-after should be 59 days (and some fraction) away"
+              (testing "new not-after should be 89 days (and some fraction) away"
                 (let [diff (- (.getTime (.getNotAfter renewed-cert)) (.getTime (Date.)))
                       days (.convert TimeUnit/DAYS diff TimeUnit/MILLISECONDS)]
-                  (is (= 59 days))))))))
+                  (is (= 89 days))))))))
 
       (testing "returns a 400 bad request response when the feature is enabled,
              and a bogus cert is supplied in the header"

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -729,7 +729,7 @@
       (is (= false (:allow-auto-renewal settings))))
 
     (testing "auto-renewal-cert-ttl"
-      (is (= "60d" (:auto-renewal-cert-ttl settings))))
+      (is (= "90d" (:auto-renewal-cert-ttl settings))))
 
     (testing "Does not replace files if they all exist"
       (let [files (-> (ca/settings->cadir-paths (assoc settings :enable-infra-crl false))
@@ -2005,10 +2005,10 @@
           (is (= -1 (.compareTo (.getNotBefore signed-cert) (.getNotBefore renewed-cert)))))
         (testing "new not-after is later than before"
           (is (= -1 (.compareTo (.getNotAfter signed-cert) (.getNotAfter renewed-cert)))))
-        (testing "new not-after should be 59 days (and some faction) away"
+        (testing "new not-after should be 89 days (and some faction) away"
           (let [diff (- (.getTime (.getNotAfter renewed-cert)) (.getTime (Date.)))
                 days (.convert TimeUnit/DAYS diff TimeUnit/MILLISECONDS)]
-            (is (= 59 days))))
+            (is (= 89 days))))
         (testing "certificate should have been removed"
           (is (not (fs/exists? expected-cert-path))))
         (testing "extensions are preserved"

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -56,7 +56,7 @@
    :allow-duplicate-certs            false
    :allow-subject-alt-names          false
    :allow-auto-renewal               false
-   :auto-renewal-cert-ttl            "60d"
+   :auto-renewal-cert-ttl            "90d"
    :ca-name                          "test ca"
    :ca-ttl                           1
    :allow-header-cert-info           false

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -137,11 +137,11 @@
       (with-test-logging
         (ks-testutils/with-no-jvm-shutdown-hooks
           (let [config (-> (jruby-testutils/jruby-puppet-tk-config
-                    (jruby-testutils/jruby-puppet-config {:max-active-instances 2
-                                                          :borrow-timeout
-                                                          12}))
-                    (assoc :webserver {:port 8081
-                                       :shutdown-timeout-seconds 1}))
+                             (jruby-testutils/jruby-puppet-config {:max-active-instances 2
+                                                                   :borrow-timeout
+                                                                   12}))
+                           (assoc :webserver {:port 8081
+                                              :shutdown-timeout-seconds 1}))
                 service (tk-app/get-service app :PuppetServerConfigService)
                 service-config (get-config service)
                 merged-config (merge service-config  {:certificate-authority
@@ -149,9 +149,9 @@
                 settings (ca/config->ca-settings merged-config)
                 app (tk/boot-services-with-config
                       (service-and-deps-with-mock-jruby config)
-                       config)]
+                      config)]
             (is (= false (:allow-auto-renewal settings)))
-            (is (= 5184000 (:auto-renewal-cert-ttl settings)))
+            (is (= 7776000 (:auto-renewal-cert-ttl settings)))
             (tk-app/stop app)))))))
 
 (deftest multi-webserver-setting-override


### PR DESCRIPTION
This alters the default initial ttl for agents with auto-renewal capability to 90 days from 60 days, and changes the period of validity on renewal from 60 days to 90 days.