### PR TITLE
(PE-36456) add a routine to extract attributes from a CSR

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -502,6 +502,10 @@
   (into (mapv (partial str "IP:") (utils/get-subject-ip-alt-names cert-or-csr))
         (mapv (partial str "DNS:") (utils/get-subject-dns-alt-names cert-or-csr))))
 
+(schema/defn get-csr-attributes :- utils/SSLMultiValueAttributeList
+  [csr :- PKCS10CertificationRequest]
+  (utils/get-attributes csr))
+
 (schema/defn authorization-extensions :- {schema/Str schema/Str}
   "Get the authorization extensions for the certificate or CSR.
   These are extensions that fall under the ppAuthCert OID arc.
@@ -1027,7 +1031,7 @@
         csr-attr-exts (create-csr-attrs-exts csr-attributes)
         base-ext-list [(utils/netscape-comment
                          netscape-comment-value)
-                       (utils/authority-key-identifier ca-cert)
+                       (utils/authority-key-identifier-options ca-cert)
                        (utils/basic-constraints-for-non-ca true)
                        (utils/ext-key-usages
                          [ssl-server-cert ssl-client-cert] true)
@@ -1391,7 +1395,7 @@
         csr-ext-list (utils/get-extensions csr)
         base-ext-list [(utils/netscape-comment
                          netscape-comment-value)
-                       (utils/authority-key-identifier
+                       (utils/authority-key-identifier-options
                          cacert)
                        (utils/basic-constraints-for-non-ca true)
                        (utils/ext-key-usages

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -207,7 +207,7 @@
         (let [response (testutils/get-static-file-content "dist/foo/files/bar.txt?code_id=foobar&environment=test")]
           (is (= 200 (:status response)))
           (is (= "test foobar dist/foo/files/bar.txt\n" (:body response)))))
-       (testing "the /static_file_content endpoint validates environment"
+      (testing "the /static_file_content endpoint validates environment"
          (doseq [[env-encoded env-decoded]
                  [["hi%23cat" "hi#cat"]
                   ["hi%20cat" "hi cat"]
@@ -221,7 +221,7 @@
              (is (= (ps-common/environment-validation-error-msg env-decoded)
                     (:body response))))))
 
-       (testing "the /static_file_content endpoint validates code-id"
+      (testing "the /static_file_content endpoint validates code-id"
          (doseq [[code-id-encoded code-id-decoded]
                  [["hi%23cat" "hi#cat"]
                   ["hi%20cat" "hi cat"]
@@ -237,7 +237,7 @@
 
 
 
-       (let [error-message "Error: A /static_file_content request requires an environment, a code-id, and a file-path"]
+      (let [error-message "Error: A /static_file_content request requires an environment, a code-id, and a file-path"]
         (testing "the /static_file_content endpoint returns an error if code_id is not provided"
           (let [response (testutils/get-static-file-content "modules/foo/files/bar.txt?environment=test")]
             (is (= 400 (:status response)))

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -2033,3 +2033,10 @@
   (testing "new versions should support auto-renewal"
     (is (true? (ca/supports-auto-renewal? {:headers {"x-puppet-version""8.2.0"}})))
     (is (true? (ca/supports-auto-renewal? {:headers {"x-puppet-version""9.0.0"}})))))
+
+(deftest get-csr-attributes-test
+  (testing "extract attribute from CSR"
+    (let [keypair (utils/generate-key-pair)
+          subject (utils/cn "foo")
+          csr  (utils/generate-certificate-request keypair subject [] [{:oid "1.3.6.1.4.1.34380.1.3.2" :value true}])]
+      (is (= [{:oid "1.3.6.1.4.1.34380.1.3.2", :values ["true"]}] (ca/get-csr-attributes csr))))))


### PR DESCRIPTION
This adds a new function to puppetserver that extracts attributes from CSRs, which will be needed to determine if an agent is capable of auto-renewal or not, rather than the current method of looking at the agent version.

This adds tests to demonstrate the behavior