### PR TITLE
(maint) fix naming of pp_cli_auth

### DIFF
--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -307,7 +307,7 @@
       {:jruby-puppet
         {:gem-path gem-path}}
       (let [catalog (testutils/get-catalog)]
-        (is (= "{pp_auth_doodad => true, sf => Burning Finger, short => 22}"
+        (is (= "{pp_cli_auth => true, sf => Burning Finger, short => 22}"
                (get-in (first (filter #(= (get % "title") "trusted_hash")
                                       (get catalog "resources")))
                        ["parameters" "message"])))))))


### PR DESCRIPTION
With the change in https://tickets.puppetlabs.com/browse/PUP-9964 the oid that was used in the custom-trusted-oid-mapping is no longer unnamed in puppet. This updates the test to reflect the new puppet behavior.

See: https://github.com/puppetlabs/puppet/pull/9080/commits/38f24392ff01a7e0e9f390d89b46d9ff6c4257a6