### PR TITLE
(PE-36457) use attribute in csr for auto-reneal indication

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -76,9 +76,8 @@
    report-activity
    {:keys [body] {:keys [subject]} :route-params :as request}]
   (sling/try+
-    (let [supports-auto-renewal (ca/supports-auto-renewal? request)
-          report-activity-fn (ca/create-report-activity-fn report-activity request)]
-      (ca/process-csr-submission! subject body ca-settings report-activity-fn supports-auto-renewal)
+    (let [report-activity-fn (ca/create-report-activity-fn report-activity request)]
+      (ca/process-csr-submission! subject body ca-settings report-activity-fn)
       (rr/content-type (rr/response nil) "text/plain"))
     (catch ca/csr-validation-failure? {:keys [msg]}
       (log/error msg)

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -1144,7 +1144,7 @@
           (is (thrown+?
                [:kind :duplicate-cert
                 :msg "test-agent already has a requested certificate; ignoring certificate request"]
-               (ca/process-csr-submission! "test-agent" (csr-stream "test-agent") settings (constantly nil) false))))
+               (ca/process-csr-submission! "test-agent" (csr-stream "test-agent") settings (constantly nil)))))
 
         (testing "throws exception if certificate already exists"
           (is (thrown+?
@@ -1153,16 +1153,14 @@
                (ca/process-csr-submission! "localhost"
                                         (io/input-stream (test-pem-file "localhost-csr.pem"))
                                         settings
-                                        (constantly nil)
-                                        false)))
+                                        (constantly nil))))
           (is (thrown+?
                [:kind :duplicate-cert
                 :msg "revoked-agent already has a revoked certificate; ignoring certificate request"]
                (ca/process-csr-submission! "revoked-agent"
                                         (io/input-stream (test-pem-file "revoked-agent-csr.pem"))
                                         settings
-                                        (constantly nil)
-                                        false))))))
+                                        (constantly nil)))))))
 
     (testing "when true"
       (let [settings (assoc settings :allow-duplicate-certs true)]
@@ -1171,7 +1169,7 @@
                 csr      (ByteArrayInputStream. (.getBytes (slurp csr-path)))]
             (spit csr-path "should be overwritten")
             (logutils/with-test-logging
-              (ca/process-csr-submission! "test-agent" csr settings (constantly nil) false)
+              (ca/process-csr-submission! "test-agent" csr settings (constantly nil))
               (is (logged? #"test-agent already has a requested certificate; new certificate will overwrite it" :info))
               (is (not= "should be overwritten" (slurp csr-path))
                   "Existing CSR was not overwritten"))))
@@ -1182,7 +1180,7 @@
                 old-cert  (slurp cert-path)
                 csr       (io/input-stream (test-pem-file "localhost-csr.pem"))]
             (logutils/with-test-logging
-              (ca/process-csr-submission! "localhost" csr settings (constantly nil) false)
+              (ca/process-csr-submission! "localhost" csr settings (constantly nil))
               (is (logged? #"localhost already has a signed certificate; new certificate will overwrite it" :info))
               (is (not= old-cert (slurp cert-path)) "Existing certificate was not overwritten"))))))))
 
@@ -1209,7 +1207,7 @@
                 (let [path (ca/path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
                   (is (false? (fs/exists? path)))
-                  (is (thrown+? exception (ca/process-csr-submission! subject csr settings (constantly nil) false)))
+                  (is (thrown+? exception (ca/process-csr-submission! subject csr settings (constantly nil))))
                   (is (false? (fs/exists? path)))))))
 
           (testing "extension & key policies are not checked"
@@ -1221,21 +1219,17 @@
                 (let [path (ca/path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
                   (is (false? (fs/exists? path)))
-                  (ca/process-csr-submission! subject csr settings (constantly nil) false)
+                  (ca/process-csr-submission! subject csr settings (constantly nil))
                   (is (true? (fs/exists? path)))
                   (fs/delete path)))))
           (testing "writes indicator file when asked to"
             (let [subject "meow"
                   path (ca/path-to-cert-request (:csrdir settings) subject)
-                  path-to-indicator (ca/path-to-autosign-indication (:csrdir settings) subject)
                   csr  (io/input-stream (test-pem-file "meow-bad-extension.pem"))]
               (is (false? (fs/exists? path)))
-              (is (false? (fs/exists? path-to-indicator)))
-              (ca/process-csr-submission! subject csr settings (constantly nil) true)
+              (ca/process-csr-submission! subject csr settings (constantly nil))
               (is (true? (fs/exists? path)))
-              (is (true? (fs/exists? path-to-indicator)))
-              (fs/delete path)
-              (fs/delete path-to-indicator)))))
+              (fs/delete path)))))
 
       (testing "when autosign is true, all policies are checked, and"
         (let [settings (assoc settings :autosign true)]
@@ -1257,7 +1251,7 @@
                 (let [path (ca/path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
                   (is (false? (fs/exists? path)))
-                  (is (thrown+? expected (ca/process-csr-submission! subject csr settings (constantly nil) false)))
+                  (is (thrown+? expected (ca/process-csr-submission! subject csr settings (constantly nil))))
                   (is (false? (fs/exists? path)))))))
 
           (testing "CSR will be saved when"
@@ -1282,7 +1276,7 @@
                 (let [path (ca/path-to-cert-request (:csrdir settings) subject)
                       csr  (io/input-stream (test-pem-file csr-file))]
                   (is (false? (fs/exists? path)))
-                  (is (thrown+? expected (ca/process-csr-submission! subject csr settings (constantly nil) false)))
+                  (is (thrown+? expected (ca/process-csr-submission! subject csr settings (constantly nil))))
                   (is (true? (fs/exists? path)))
                   (fs/delete path)))))))
 
@@ -1293,13 +1287,13 @@
             (is (thrown+?
                  [:kind :duplicate-cert
                   :msg "test-agent already has a requested certificate; ignoring certificate request"]
-                 (ca/process-csr-submission! "not-test-agent" csr-with-mismatched-name settings (constantly nil) false)))))
+                 (ca/process-csr-submission! "not-test-agent" csr-with-mismatched-name settings (constantly nil))))))
         (testing "subject policies checked before extension & key policies"
           (let [csr-with-disallowed-alt-names (io/input-stream (test-pem-file "hostwithaltnames.pem"))]
             (is (thrown+?
                  [:kind :hostname-mismatch
                   :msg "Instance name \"hostwithaltnames\" does not match requested key \"foo\""]
-                 (ca/process-csr-submission! "foo" csr-with-disallowed-alt-names settings (constantly nil) false)))))))))
+                 (ca/process-csr-submission! "foo" csr-with-disallowed-alt-names settings (constantly nil))))))))))
 
 (deftest cert-signing-extension-test
   (let [issuer-keys  (utils/generate-key-pair 512)
@@ -2027,12 +2021,15 @@
             (is (= "0x0006" (first last-entry-fields)))
             (is (= "/CN=foo" (last last-entry-fields)))))))))
 (deftest supports-auto-renewal?-test
-  (testing "old versions should not support auto-renewal"
-    (is (false? (ca/supports-auto-renewal? {:headers {"x-puppet-version" "1.1.0"}})))
-    (is (false? (ca/supports-auto-renewal? {:headers {"x-puppet-version""7.1.8"}}))))
-  (testing "new versions should support auto-renewal"
-    (is (true? (ca/supports-auto-renewal? {:headers {"x-puppet-version""8.2.0"}})))
-    (is (true? (ca/supports-auto-renewal? {:headers {"x-puppet-version""9.0.0"}})))))
+  (let [keypair (utils/generate-key-pair)
+        subject (utils/cn "foo")]
+    (testing "should not support auto-renewal"
+      (is (false? (ca/supports-auto-renewal? (utils/generate-certificate-request keypair subject [] []))))
+      (is (false? (ca/supports-auto-renewal? (utils/generate-certificate-request keypair subject [] [{:oid "1.3.6.1.4.1.34380.1.3.2" :value false}]))))
+      (is (false? (ca/supports-auto-renewal? (utils/generate-certificate-request keypair subject [] [{:oid "1.3.6.1.4.1.34380.1.3.2" :value "false"}])))))
+    (testing "should support auto-renewal"
+      (is (true? (ca/supports-auto-renewal? (utils/generate-certificate-request keypair subject [] [{:oid "1.3.6.1.4.1.34380.1.3.2" :value true}]))))
+      (is (true? (ca/supports-auto-renewal? (utils/generate-certificate-request keypair subject [] [{:oid "1.3.6.1.4.1.34380.1.3.2" :value "true"}])))))))
 
 (deftest get-csr-attributes-test
   (testing "extract attribute from CSR"


### PR DESCRIPTION
This changes the mechanism used to determine if an agent should have the shorter "auto-renewal" ttl for Certificate Signing Requests, or if it should use the default ca-ttl.

The agent will include an attribute that indicates with a "true" value that it supports auto-renewal. If the attribute is missing, or is a "false" value, the indication is that it does not support auto-renewal.

Tests are updated as needed to demonstrate the new behaviors.

The code related to creating, interrogating and deleting the indicator file have been removed.