### PR TITLE
(PE-36479) remove use of clj-yaml

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,6 @@
   :dependencies [[org.clojure/clojure]
 
                  [slingshot]
-                 [clj-commons/clj-yaml]
                  [org.yaml/snakeyaml]
                  [commons-lang]
                  [commons-io]

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -21,8 +21,8 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.kitchensink.file :as ks-file]
             [puppetlabs.puppetserver.ringutils :as ringutils]
+            [puppetlabs.trapperkeeper.common :refer [parse-yaml]]
             [puppetlabs.ssl-utils.core :as utils]
-            [clj-yaml.core :as yaml]
             [puppetlabs.puppetserver.shell-utils :as shell-utils]
             [puppetlabs.i18n.core :as i18n]))
 
@@ -862,7 +862,7 @@
   certificate extensions from the `extensions_requests` section."
   [csr-attributes-file :- schema/Str]
   (if (fs/file? csr-attributes-file)
-    (let [csr-attrs (yaml/parse-string (slurp csr-attributes-file))
+    (let [csr-attrs (parse-yaml (slurp csr-attributes-file))
           ext-req (:extension_requests csr-attrs)]
       (map (fn [[oid value]]
              {:oid (or (get puppet-short-names oid)
@@ -1813,7 +1813,7 @@
   shortnames"
   [custom-oid-mapping-file :- schema/Str]
   (if (fs/file? custom-oid-mapping-file)
-    (let [oid-mappings (:oid_mapping (yaml/parse-string (slurp custom-oid-mapping-file)))]
+    (let [oid-mappings (:oid_mapping (parse-yaml (slurp custom-oid-mapping-file)))]
       (into {} (for [[oid names] oid-mappings] [(name oid) (keyword (:shortname names))])))
     (log/debug (i18n/trs "No custom OID mapping configuration file found at {0}, custom OID mappings will not be loaded"
                 custom-oid-mapping-file))))

--- a/src/clj/puppetlabs/services/master/file_serving.clj
+++ b/src/clj/puppetlabs/services/master/file_serving.clj
@@ -1,12 +1,12 @@
 (ns puppetlabs.services.master.file-serving
   (:require [bidi.bidi :as bidi]
-            [clj-yaml.core :as yaml]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [digest :as digest]
             [me.raynes.fs :as fs]
             [puppetlabs.i18n.core :as i18n]
             [puppetlabs.ring-middleware.utils :as middleware-utils]
+            [puppetlabs.trapperkeeper.common :refer [parse-yaml]]
             [ring.util.response :as rr])
   (:import com.sun.security.auth.module.UnixSystem
            [java.nio.file Files FileSystems FileVisitOption FileVisitResult LinkOption Paths SimpleFileVisitor]))
@@ -150,7 +150,7 @@
   [project-dir]
   (let [config-path (str project-dir "/bolt-project.yaml")]
     (when (fs/file? config-path)
-     (yaml/parse-string (slurp config-path)))))
+     (parse-yaml (slurp config-path)))))
 
 (defn parse-modulepath
   "The modulepath for a bolt project can either be an array of paths or a string


### PR DESCRIPTION
This removes the use of clj-yaml, and replaces it with a use of snake-yaml as implemented in trapperkeeper. This is to help resolve https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1471

which can't be fully resolved due to a dependency on snakeyaml 1.3.3 by jRuby