### PR TITLE
Merge branch '7.x' 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -172,7 +172,7 @@
                                                [puppetlabs/jruby-utils]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9]]
-                      :plugins [[puppetlabs/lein-ezbake "2.4.2"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.5.0"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [puppetlabs/trapperkeeper-webserver-jetty9]]


### PR DESCRIPTION
* 7.x:
  (maint) update submodule versions and agent pin
  ([PE-36184](https://tickets.puppetlabs.com/browse/PE-36184)) Update ezbake to 2.5.0 in prep for logback 1.3.x bump
  (maint) update submodule versions and agent pin
  ([PE-36479](https://tickets.puppetlabs.com/browse/PE-36479)) remove use of clj-yaml