### PR TITLE
(PE-36185) update ezbake

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -169,7 +169,7 @@
                                                [puppetlabs/jruby-utils]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9]]
-                      :plugins [[puppetlabs/lein-ezbake "2.5.0"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.5.2"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [puppetlabs/trapperkeeper-webserver-jetty9]]


### PR DESCRIPTION
This updates ezbake to 2.5.2, which brings in support for el9 builds, and addresses an issue on the el platforms where tzdata-java was missing from some dependencies because of changes in the openjdk.