### PR TITLE
(PE-36076) Remove content type from certificate reject

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -132,9 +132,12 @@
    ca-settings :- ca/CaSettings]
   (let [response (ca/delete-certificate-request! ca-settings subject)
         outcomes->codes {:success 204 :not-found 404 :error 500}]
-    (-> (rr/response (:message response))
-        (rr/status ((response :outcome) outcomes->codes))
-        (rr/content-type "text/plain"))))
+    (if (not= (response :outcome) :success) 
+      (-> (rr/response (:message response)) 
+          (rr/status ((response :outcome) outcomes->codes))
+          (rr/content-type "text/plain"))
+      (-> (rr/response (:message response))
+          (rr/status ((response :outcome) outcomes->codes))))))
 
 (schema/defn handle-get-ca-expirations
   [ca-settings :- ca/CaSettings]

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -321,7 +321,6 @@
               (is (false? (fs/exists? expected-path)))
               (is (= 204 (:status response)))
               (is (re-matches msg-matcher (:body response)))
-              (is (= "text/plain" (get-in response [:headers "Content-Type"])))
               (is (logged? msg-matcher :debug)))
             (finally
               (fs/delete expected-path))))))


### PR DESCRIPTION
Previously, when a `DELETE` request was  sent to `puppet-ca/v1/certificate_status/<nodename>` a `204` response was sent with a malformed content-type header. This commit removes the header.