### PR TITLE
(maint) Update ezbake to 2.5.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -169,7 +169,7 @@
                                                [puppetlabs/jruby-utils]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9]]
-                      :plugins [[puppetlabs/lein-ezbake "2.5.2"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.5.3"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [puppetlabs/trapperkeeper-webserver-jetty9]]


### PR DESCRIPTION
contains a fix for el9 package builds for Puppet Platform 8