### PR TITLE
(maint) Add nss install exception for el-9

### DIFF
--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -21,10 +21,10 @@ step "Upgrade nss to version that is hopefully compatible with jdk version puppe
     nss_package_name="nss"
   end
   if nss_package_name
-    if master['platform'] != 'el-8-x86_64'
-      master.upgrade_package(nss_package_name)
-    else
+    if master['platform'] == 'el-8-x86_64' || master['platform'] == 'el-9-x86_64'
       master.install_package(nss_package_name)
+    else
+      master.upgrade_package(nss_package_name)
     end
   else
     logger.warn("Don't know what nss package to use for #{variant} so not installing one")


### PR DESCRIPTION
Adds `install_package` exception for el-9. Flipped logic since it's a little more clear.