### PR TITLE
(maint) merge 7.x to main

### DIFF
--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -21,10 +21,10 @@ step "Upgrade nss to version that is hopefully compatible with jdk version puppe
     nss_package_name="nss"
   end
   if nss_package_name
-    if master['platform'] != 'el-8-x86_64'
-      master.upgrade_package(nss_package_name)
-    else
+    if master['platform'] == 'el-8-x86_64' || master['platform'] == 'el-9-x86_64'
       master.install_package(nss_package_name)
+    else
+      master.upgrade_package(nss_package_name)
     end
   else
     logger.warn("Don't know what nss package to use for #{variant} so not installing one")

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -140,9 +140,12 @@
    ca-settings :- ca/CaSettings]
   (let [response (ca/delete-certificate-request! ca-settings subject)
         outcomes->codes {:success 204 :not-found 404 :error 500}]
-    (-> (rr/response (:message response))
-        (rr/status ((response :outcome) outcomes->codes))
-        (rr/content-type "text/plain"))))
+    (if (not= (response :outcome) :success) 
+      (-> (rr/response (:message response)) 
+          (rr/status ((response :outcome) outcomes->codes))
+          (rr/content-type "text/plain"))
+      (-> (rr/response (:message response))
+          (rr/status ((response :outcome) outcomes->codes))))))
 
 (schema/defn handle-get-ca-expirations
   [ca-settings :- ca/CaSettings]

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -327,7 +327,6 @@
               (is (false? (fs/exists? expected-path)))
               (is (= 204 (:status response)))
               (is (re-matches msg-matcher (:body response)))
-              (is (= "text/plain" (get-in response [:headers "Content-Type"])))
               (is (logged? msg-matcher :debug)))
             (finally
               (fs/delete expected-path))))))


### PR DESCRIPTION
* 7.x:
  (maint) update submodule versions and agent pin
  (maint) Add nss install exception for el-9
  (maint) Update ezbake to 2.5.3
  (maint) update submodule versions and agent pin
  (maint) update submodule versions and agent pin
  Set clj-parent=5.5.0
  (maint) update submodule versions and agent pin
  ([PE-36076](https://tickets.puppetlabs.com/browse/PE-36076)) Remove content type from certificate reject
  (maint) update submodule versions and agent pin
  (maint) update submodule versions and agent pin
  (maint) update submodule versions and agent pin
  (maint) update submodule versions and agent pin
  (maint) update submodule versions and agent pin