### PR TITLE
(maint) remove ssl-utils pin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -62,7 +62,7 @@
                  [puppetlabs/trapperkeeper-status]
                  [puppetlabs/trapperkeeper-filesystem-watcher]
                  [puppetlabs/kitchensink]
-                 [puppetlabs/ssl-utils "3.5.2"]
+                 [puppetlabs/ssl-utils]
                  [puppetlabs/ring-middleware]
                  [puppetlabs/dujour-version-check]
                  [puppetlabs/http-client]


### PR DESCRIPTION
This removes the pinned version of ssl-utils from puppetserver as the main branch is now using a newer clj-parent that contains the pinned version. The previous branch that was merged in pinned the version to avoid an infinite recursion bug.