### PR TITLE
(PE-36269) ensure CRLs are regenerated when nearing expiration

### DIFF
--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -104,7 +104,6 @@
    [:CaService initialize-master-ssl! retrieve-ca-cert! retrieve-ca-crl! get-auth-handler]
    [:JRubyPuppetService]
    [:AuthorizationService wrap-with-authorization-check]
-   [:SchedulerService interspaced]
    [:StatusService register-status]
    [:VersionedCodeService get-code-content current-code-id]]
   (init


### PR DESCRIPTION
In the first commit:

This alters the analytics service to explicitly stop the jobs it is running when shutting down. It also adds some simple logging to the startup / shutdown process.

Additionally, an unused dependency in the `master_service` was removed.


In the second commit:

This adds a new behavior where once a day, puppetserver will check to
see if the crls for both the main crl, and if enabled the infra-crl
are nearing expiration.  If one is, the list of expired serial numbers
is collected from the inventory file, and used to prune the CRL list.

The CRL is then regenerated with the (potentially) smaller set of serials.

If the CRLs are not nearing expiration, nothing is done.

Tests are added to demonstrate the CRL behaviors added.

Resolves #2789 