### PR TITLE
(PE-35512) update deps and bootstrap to tkw-j10

### DIFF
--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -2,7 +2,7 @@ puppetlabs.services.request-handler.request-handler-service/request-handler-serv
 puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
 puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service/jruby-pool-manager-service
 puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
-puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.webserver.jetty10-service/jetty10-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
 puppetlabs.services.master.master-service/master-service

--- a/dev/dev_tools.clj
+++ b/dev/dev_tools.clj
@@ -1,5 +1,5 @@
 (ns dev-tools
-  (:require [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
+  (:require [puppetlabs.trapperkeeper.services.webserver.jetty10-service :refer [jetty10-service]]
 
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
             [puppetlabs.services.master.master-service :refer [master-service]]

--- a/ext/thread_test/bootstrap.cfg
+++ b/ext/thread_test/bootstrap.cfg
@@ -2,7 +2,7 @@ puppetlabs.services.request-handler.request-handler-service/request-handler-serv
 puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
 puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service/jruby-pool-manager-service
 puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
-puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.webserver.jetty10-service/jetty10-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
 puppetlabs.services.master.master-service/master-service

--- a/ezbake/system-config/services.d/bootstrap.cfg
+++ b/ezbake/system-config/services.d/bootstrap.cfg
@@ -2,7 +2,7 @@ puppetlabs.services.request-handler.request-handler-service/request-handler-serv
 puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
 puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service/jruby-pool-manager-service
 puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
-puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.webserver.jetty10-service/jetty10-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
 puppetlabs.services.master.master-service/master-service

--- a/project.clj
+++ b/project.clj
@@ -54,10 +54,10 @@
                  [puppetlabs/jruby-utils]
                  [puppetlabs/clj-shell-utils]
                  [puppetlabs/trapperkeeper]
-                 [puppetlabs/trapperkeeper-webserver-jetty9]
+                 [com.puppetlabs/trapperkeeper-webserver-jetty10]
                  [puppetlabs/trapperkeeper-authorization]
                  [puppetlabs/trapperkeeper-comidi-metrics]
-                 [puppetlabs/trapperkeeper-metrics]
+                 [puppetlabs/trapperkeeper-metrics "2.0.0"]
                  [puppetlabs/trapperkeeper-scheduler]
                  [puppetlabs/trapperkeeper-status]
                  [puppetlabs/trapperkeeper-filesystem-watcher]
@@ -117,7 +117,7 @@
 
   :profiles {:defaults {:source-paths  ["dev"]
                         :dependencies  [[org.clojure/tools.namespace]
-                                        [puppetlabs/trapperkeeper-webserver-jetty9 :classifier "test"]
+                                        [com.puppetlabs/trapperkeeper-webserver-jetty10 :classifier "test"]
                                         [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
                                         [puppetlabs/trapperkeeper-metrics :classifier "test" :scope "test"]
                                         [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
@@ -171,17 +171,17 @@
                                                [org.bouncycastle/bcpkix-jdk18on]
                                                [puppetlabs/jruby-utils]
                                                [puppetlabs/puppetserver ~ps-version]
-                                               [puppetlabs/trapperkeeper-webserver-jetty9]]
+                                               [com.puppetlabs/trapperkeeper-webserver-jetty10]]
                       :plugins [[puppetlabs/lein-ezbake "2.5.5"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
-                                      [puppetlabs/trapperkeeper-webserver-jetty9]]
+                                      [com.puppetlabs/trapperkeeper-webserver-jetty10]]
                        :aot [puppetlabs.trapperkeeper.main
                              puppetlabs.trapperkeeper.services.status.status-service
                              puppetlabs.trapperkeeper.services.metrics.metrics-service
                              puppetlabs.services.protocols.jruby-puppet
                              puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service
-                             puppetlabs.trapperkeeper.services.webserver.jetty9-service
+                             puppetlabs.trapperkeeper.services.webserver.jetty10-service
                              puppetlabs.trapperkeeper.services.webrouting.webrouting-service
                              puppetlabs.services.legacy-routes.legacy-routes-core
                              puppetlabs.services.protocols.jruby-metrics

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -7,7 +7,7 @@
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap-testutils]
-            [puppetlabs.trapperkeeper.testutils.webserver :as jetty9]
+            [puppetlabs.trapperkeeper.testutils.webserver :as jetty10]
             [puppetlabs.services.master.master-core :as master-core]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [cheshire.core :as cheshire]
@@ -615,7 +615,7 @@
                   (apply str (repeat body-length "a"))
                   expected-etag))
                (master-core/wrap-with-cache-check jruby-service))]
-      (jetty9/with-test-webserver
+      (jetty10/with-test-webserver
        app
        port
        (let [request-url (str "http://localhost:" port)

--- a/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
@@ -6,7 +6,7 @@
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap-testutils]
-            [puppetlabs.trapperkeeper.testutils.webserver :as jetty9]
+            [puppetlabs.trapperkeeper.testutils.webserver :as jetty10]
             [puppetlabs.services.master.master-core :as master-core]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [cheshire.core :as json]
@@ -485,7 +485,7 @@ Puppet::ResourceApi.register_transport(
                   (apply str (repeat body-length "a"))
                   expected-etag))
                (master-core/wrap-with-cache-check jruby-service))]
-      (jetty9/with-test-webserver
+      (jetty10/with-test-webserver
        app
        port
        (let [request-url (str "http://localhost:" port)

--- a/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -8,7 +8,7 @@
            (java.util.zip GZIPInputStream))
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
-            [puppetlabs.trapperkeeper.testutils.webserver :as jetty9]
+            [puppetlabs.trapperkeeper.testutils.webserver :as jetty10]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-puppet-testutils]
             [ring.middleware.basic-authentication :as auth]
             [schema.core :as schema]
@@ -170,7 +170,7 @@
 (use-fixtures :once http-client-scripting-container-fixture)
 
 (deftest test-ruby-http-client
-  (jetty9/with-test-webserver ring-app port
+  (jetty10/with-test-webserver ring-app port
     (with-scripting-container sc
       (with-http-client sc {}
         (let [url (str "http://localhost:" port)]
@@ -180,7 +180,7 @@
             (is (= "hi" (.runScriptlet sc (format "$c.post(URI('%s'), 'foo').body" url))))))))))
 
 (deftest http-escaped-urls-test
-  (jetty9/with-test-webserver ring-app port
+  (jetty10/with-test-webserver ring-app port
     (with-scripting-container sc
       (with-http-client sc {}
         (let [url (str "http://localhost:" port)]
@@ -190,7 +190,7 @@
             (is (= (str url "/a%20b%3Fc?foo=bar") (.runScriptlet sc "$response.url.to_s")))))))))
 
 (deftest http-basic-auth
-  (jetty9/with-test-webserver ring-app-with-auth port
+  (jetty10/with-test-webserver ring-app-with-auth port
     (with-scripting-container sc
       (with-http-client sc {}
         (let [url (str "http://localhost:" port)]
@@ -213,7 +213,7 @@
             (is (= "access denied" (.runScriptlet sc "$response.body")))))))))
 
 (deftest http-compressed-requests
-  (jetty9/with-test-webserver ring-app-decompressing-gzipped-request port
+  (jetty10/with-test-webserver ring-app-decompressing-gzipped-request port
     (with-scripting-container sc
       (with-http-client sc {}
         (let [url (str "http://localhost:" port)]
@@ -244,7 +244,7 @@
 
 (defmacro with-webserver-with-protocols
   [protocols cipher-suites & body]
-  `(jetty9/with-test-webserver-and-config ring-app port#
+  `(jetty10/with-test-webserver-and-config ring-app port#
     (merge {:ssl-host    "localhost"
             :ssl-port    10080
             :ssl-ca-cert ca-pem
@@ -304,7 +304,7 @@
 (deftest clients-persist
   (testing "client persists when making HTTP requests"
     (logutils/with-test-logging
-      (jetty9/with-test-webserver ring-app port
+      (jetty10/with-test-webserver ring-app port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [url (str "http://localhost:" port)
@@ -313,7 +313,7 @@
               (is (= client1 client2))))))))
   (testing "all instances of HttpClient have the same underlying client object"
     (logutils/with-test-logging
-      (jetty9/with-test-webserver ring-app port
+      (jetty10/with-test-webserver ring-app port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [client1 (.runScriptlet sc "$c.class.client")
@@ -324,7 +324,7 @@
 (deftest connections-closed
   (testing "connection header always set to close on get"
     (logutils/with-test-logging
-      (jetty9/with-test-webserver ring-app-connection-closed port
+      (jetty10/with-test-webserver ring-app-connection-closed port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [url (str "http://localhost:" port)]
@@ -332,7 +332,7 @@
                      (.runScriptlet sc (format "$c.get(URI('%s')).body" url))))))))))
   (testing "connection header always set to close on post"
     (logutils/with-test-logging
-      (jetty9/with-test-webserver ring-app-connection-closed port
+      (jetty10/with-test-webserver ring-app-connection-closed port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [url (str "http://localhost:" port)]
@@ -340,7 +340,7 @@
                      (.runScriptlet sc (format "$c.post(URI('%s'), 'foo').body" url))))))))))
   (testing "client's terminate function closes the client"
     (logutils/with-test-logging
-      (jetty9/with-test-webserver ring-app-connection-closed port
+      (jetty10/with-test-webserver ring-app-connection-closed port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [url (str "http://localhost:" port)]
@@ -358,7 +358,7 @@
 (deftest http-and-https
   (testing "can make http calls after https calls without a new scripting container"
     (logutils/with-test-logging
-      (jetty9/with-test-webserver ring-app-alternate port
+      (jetty10/with-test-webserver ring-app-alternate port
         (with-webserver-with-protocols nil nil
           (with-scripting-container sc
             (with-http-client sc {}
@@ -373,7 +373,7 @@
 
   (testing "can make https calls after http calls without a new scripting container"
     (logutils/with-test-logging
-      (jetty9/with-test-webserver ring-app-alternate port
+      (jetty10/with-test-webserver ring-app-alternate port
         (with-webserver-with-protocols nil nil
           (with-scripting-container sc
             (with-http-client sc {}

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -13,7 +13,7 @@
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :as metrics]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby-puppet]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
-            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9-service]
+            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10-service]
             [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-pool-manager]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as scheduler-service]
             [puppetlabs.trapperkeeper.services.status.status-service :as status-service]
@@ -46,7 +46,7 @@
    metrics/metrics-service
    scheduler-service/scheduler-service
    status-service/status-service
-   jetty9-service/jetty9-service
+   jetty10-service/jetty10-service
    webrouting-service/webrouting-service])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/unit/puppetlabs/services/puppet_profiler/puppet_profiler_service_test.clj
+++ b/test/unit/puppetlabs/services/puppet_profiler/puppet_profiler_service_test.clj
@@ -2,7 +2,7 @@
   (:import (com.puppetlabs.puppetserver PuppetProfiler))
   (:require [clojure.test :refer [deftest is testing]]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :refer [puppet-profiler-service]]
-            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9-service]
+            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10-service]
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :as metrics-service]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as scheduler-service]
             [puppetlabs.trapperkeeper.services.status.status-service :as status-service]
@@ -16,7 +16,7 @@
   (bootstrap/with-app-with-config
     app
     [puppet-profiler-service
-     jetty9-service/jetty9-service
+     jetty10-service/jetty10-service
      metrics-service/metrics-service
      scheduler-service/scheduler-service
      status-service/status-service

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -16,7 +16,7 @@
             [puppetlabs.puppetserver.bootstrap-testutils :as jruby-bootstrap]
             [puppetlabs.services.protocols.versioned-code :as vc]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
-            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9]
+            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as tk-scheduler]
             [puppetlabs.services.request-handler.request-handler-service :as handler-service]
             [puppetlabs.services.config.puppet-server-config-service :as ps-config]
@@ -325,7 +325,7 @@
                      profiler/puppet-profiler-service
                      handler-service/request-handler-service
                      ps-config/puppet-server-config-service
-                     jetty9/jetty9-service
+                     jetty10/jetty10-service
                      ca-service/certificate-authority-service
                      authorization-service/authorization-service
                      routing-service/webrouting-service


### PR DESCRIPTION
This commit updates the dependencies and service declarations for trapperkeeper-webserver to the jetty 10 version.