### PR TITLE
(maint) pin metrics in test space

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -119,7 +119,7 @@
                         :dependencies  [[org.clojure/tools.namespace]
                                         [com.puppetlabs/trapperkeeper-webserver-jetty10 :classifier "test"]
                                         [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
-                                        [puppetlabs/trapperkeeper-metrics :classifier "test" :scope "test"]
+                                        [puppetlabs/trapperkeeper-metrics "2.0.0" :classifier "test" :scope "test"]
                                         [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
                                         [ring-basic-authentication]
                                         [ring/ring-mock]


### PR DESCRIPTION
metrics 2.0.0 is needed for the dev/test space as well as the default dependencies, so this pins the version to that.