### PR TITLE
(PE-37350) ensure bulk signing endpoints enforce authentication gates

### DIFF
--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -139,6 +139,36 @@ authorization: {
             name: "puppetlabs cert clean"
         },
         {
+            # Allow the CA CLI to access the certificate sign endpoint
+            match-request: {
+                path: "/puppet-ca/v1/sign"
+                type: path
+                method: post
+            }
+            allow: {
+               extensions: {
+                   pp_cli_auth: "true"
+               }
+            }
+            sort-order: 500
+            name: "puppetlabs cert sign"
+        },
+        {
+            # Allow the CA CLI to access the certificate sign all endpoint
+            match-request: {
+                path: "/puppet-ca/v1/sign/all"
+                type: path
+                method: post
+            }
+            allow: {
+               extensions: {
+                   pp_cli_auth: "true"
+               }
+            }
+            sort-order: 500
+            name: "puppetlabs cert sign all"
+        },
+        {
             # Allow unauthenticated access to the status service endpoint
             match-request: {
                 path: "/status/v1/services"


### PR DESCRIPTION
This adds the /v1/sign and the /v1/sign/all endpoints to the auth.conf so that they will use the authentication gating for `pp_cli_auth`.