### PR TITLE
(maint) disable dropsonde during acceptance tests

### DIFF
--- a/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
@@ -15,7 +15,8 @@ step "Configure puppet.conf" do
     end
   end
 
-  config = { 'certificate-authority' => { 'allow-subject-alt-names' => true }}
+  config = { 'certificate-authority' => { 'allow-subject-alt-names' => true },
+             'dropsonde' => { 'enabled' => false }}
   path = '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
   modify_tk_config(master, path, config)
 end


### PR DESCRIPTION
It was discovered that the dropsonde service was running during acceptance tests, and due to the nature of the tests (many reloads in rapid succession, and lack of outward connectivity), the ruby processes could cause excessive memory use. This disables the service during acceptance tests, as we don't need to test it specifically there.