### PR TITLE
(maint) change profile definitions to avoid maps in vectors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -123,24 +123,24 @@
                                         [ring/ring-mock]
                                         [beckon]
                                         [lambdaisland/uri "1.4.70"]]}
-             :dev [:defaults
-                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}]
-             :fips [:defaults
-                    {:dependencies [[org.bouncycastle/bcpkix-fips]
-                                    [org.bouncycastle/bc-fips]
-                                    [org.bouncycastle/bctls-fips]]
-                     :jvm-opts ~(let [version (System/getProperty "java.specification.version")
-                                      [major minor _] (clojure.string/split version #"\.")
-                                      unsupported-ex (ex-info "Unsupported major Java version."
-                                                       {:major major
-                                                        :minor minor})]
-                                  (condp = (java.lang.Integer/parseInt major)
-                                    1 (if (= 8 (java.lang.Integer/parseInt minor))
-                                        ["-Djava.security.properties==./dev-resources/java.security.jdk8-fips"]
-                                        (throw unsupported-ex))
-                                    11 ["-Djava.security.properties==./dev-resources/java.security.jdk11on-fips"]
-                                    17 ["-Djava.security.properties==./dev-resources/java.security.jdk11on-fips"]
-                                    (throw unsupported-ex)))}]
+             :dev-deps  {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}
+             :dev [:defaults :dev-deps]
+             :fips-deps {:dependencies [[org.bouncycastle/bcpkix-fips]
+                                       [org.bouncycastle/bc-fips]
+                                       [org.bouncycastle/bctls-fips]]
+                         :jvm-opts ~(let [version (System/getProperty "java.specification.version")
+                                         [major minor _] (clojure.string/split version #"\.")
+                                         unsupported-ex (ex-info "Unsupported major Java version."
+                                                          {:major major
+                                                           :minor minor})]
+                                      (condp = (java.lang.Integer/parseInt major)
+                                        1 (if (= 8 (java.lang.Integer/parseInt minor))
+                                            ["-Djava.security.properties==./dev-resources/java.security.jdk8-fips"]
+                                            (throw unsupported-ex))
+                                        11 ["-Djava.security.properties==./dev-resources/java.security.jdk11on-fips"]
+                                        17 ["-Djava.security.properties==./dev-resources/java.security.jdk11on-fips"]
+                                        (throw unsupported-ex)))}
+             :fips [:defaults :fips-deps]
 
              :testutils {:source-paths ["test/unit" "test/integration"]}
              :test {


### PR DESCRIPTION
The behavior of using nested maps in a vector of dependencies in `lein` has unexpected behaviors. The most predictable results come from declaring alternative profiles and using those in the vector declarations to allow multiple profiles to be used. For example, on the left of this is the result of `lein deps :tree` before this change was made, and the right is after the change is made.  Note that the `test` scope is correctly applied to everything now.

```
1c1
<  [beckon "0.1.1"]
---
>  [beckon "0.1.1" :scope "test"]
12c12
<  [lambdaisland/uri "1.4.70"]
---
>  [lambdaisland/uri "1.4.70" :scope "test"]
23c23
<  [org.bouncycastle/bcpkix-jdk18on "1.74"]
---
>  [org.bouncycastle/bcpkix-jdk18on "1.74" :scope "test"]
29c29
<  [org.clojure/tools.namespace "0.2.11"]
---
>  [org.clojure/tools.namespace "0.2.11" :scope "test"]
123c123
<  [puppetlabs/trapperkeeper-webserver-jetty9 "4.5.2" :classifier "test"]
---
>  [puppetlabs/trapperkeeper-webserver-jetty9 "4.5.2" :classifier "test" :scope "test"]
144,145c144,145
<  [ring-basic-authentication "1.1.0"]
<  [ring/ring-mock "0.4.0"]
---
>  [ring-basic-authentication "1.1.0" :scope "test"]
>  [ring/ring-mock "0.4.0" :scope "test"]

```