### PR TITLE
(maint) Use postgres 14 for acceptance tests in puppetdb

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -38,6 +38,7 @@ node default {
   class { 'puppetdb':
     manage_firewall     => false,
     manage_package_repo => #{manage_package_repo},
+    postgres_version    => '14',
   }
 
   class { 'puppetdb::master::config':


### PR DESCRIPTION
Postgres 11 is deprecated, use postgres 14 for acceptance test setup when installing puppetdb via puppetlabs-puppetdb module.