### PR TITLE
(PE-37477) Temporarily use puppetlabs-puppetdb branch for testing

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -24,7 +24,9 @@ step 'Install Puppet nightly repo' do
 end
 
 step 'Install PuppetDB module' do
-  on(master, puppet('module install puppetlabs-puppetdb'))
+  # While we sort out a new puppetlabs-puppetdb module release, point to a branch that allows us to take the latest puppetlabs-postgresql module
+  on(master, 'curl -L https://github.com/puppetlabs/puppetlabs-puppetdb/archive/refs/heads/bump-postgres.tar.gz --output /tmp/puppetlabs-puppetdb')
+  on(master, puppet('module install /tmp/puppetlabs-puppetdb'))
 end
 
 if master.platform.variant == 'debian'


### PR DESCRIPTION
This allows us to take up latest puppetlabs/postgresql module with gpg key updates.