### PR TITLE
Revert "(maint) Pin faraday for ruby 2.7 compatability"

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -121,8 +121,6 @@ end
 
 step 'SETUP: Install and configure r10k, and perform the initial commit' do
   on master, "puppet config set server #{fqdn}"
-  # For puppet 7 with ruby 2.7 we need to pin back to a ruby 2 compatable gem
-  on master, '/opt/puppetlabs/puppet/bin/gem install faraday -v 2.8.1'
   on master, '/opt/puppetlabs/puppet/bin/gem install r10k'
   on master, "cd #{git_local_repo} && git checkout -b production"
   r10k_yaml=<<-R10K


### PR DESCRIPTION
This reverts commit 9168ec0babd91db185e436dedb75ac2edf5f9853.

This commit was auto merged up from 7.x. It is not needed for the main branche because this branch is puppet 8 / ruby 3 based.