### PR TITLE
(maint) add license to project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,9 @@
 (defproject puppetlabs/puppetserver ps-version
   :description "Puppet Server"
 
+  :license {:name "Apache License, Version 2.0"
+              :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
+
   :min-lein-version "2.9.1"
 
   :parent-project {:coords [puppetlabs/clj-parent "5.6.7"]
@@ -126,13 +129,13 @@
              :dev-deps  {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}
              :dev [:defaults :dev-deps]
              :fips-deps {:dependencies [[org.bouncycastle/bcpkix-fips]
-                                       [org.bouncycastle/bc-fips]
-                                       [org.bouncycastle/bctls-fips]]
+                                        [org.bouncycastle/bc-fips]
+                                        [org.bouncycastle/bctls-fips]]
                          :jvm-opts ~(let [version (System/getProperty "java.specification.version")
-                                         [major minor _] (clojure.string/split version #"\.")
-                                         unsupported-ex (ex-info "Unsupported major Java version."
-                                                          {:major major
-                                                           :minor minor})]
+                                          [major minor _] (clojure.string/split version #"\.")
+                                          unsupported-ex (ex-info "Unsupported major Java version."
+                                                           {:major major
+                                                            :minor minor})]
                                       (condp = (java.lang.Integer/parseInt major)
                                         1 (if (= 8 (java.lang.Integer/parseInt minor))
                                             ["-Djava.security.properties==./dev-resources/java.security.jdk8-fips"]


### PR DESCRIPTION
As part of a recent change in clojars, it is necessary for the license to be part of the exported pom file. Puppetserver has been under the apache-2 license for ~12 years, so this isn't anything new. This adds the declaration to the project.clj so that leiningen will correctly add the license to the exported pom file.