### PR TITLE
Allow getManifests(env) to recognize symbolic links for directories

### DIFF
--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -278,7 +278,7 @@ UTM
         when env.manifest == Puppet::Node::Environment::NO_MANIFEST
           []
         when File.directory?(env.manifest)
-          Dir.glob(File.join(env.manifest, '**/*.pp'))
+          Dir.glob(File.join(env.manifest, '**{,/*/}*.pp'))
         when File.exist?(env.manifest)
           [env.manifest]
         else


### PR DESCRIPTION
In the file https://github.com/puppetlabs/puppetserver/blob/main/src/ruby/puppetserver-lib/puppet/server/master.rb#L281, the `getManifests` function processes how files are found within the `manifests/` folder.

With this current behavior, we have noticed that sub-folders and individual symbolic links work without problems, but symbolic links on folders are not followed.

This pull request optimizes this behavior and allows the use of symbolic links on folders if the use case requires it.