### PR TITLE
(PE-37634) ensure sign-all with empty list succeeds

### DIFF
--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -1227,6 +1227,19 @@
         :ssl-key (str bootstrap/server-conf-dir "/ssl/private_keys/localhost.pem")
         :ssl-ca-cert (str bootstrap/server-conf-dir "/ca/ca_crt.pem")
         :ssl-crl-path (str bootstrap/server-conf-dir "/ssl/crl.pem")}}
+      (testing "PE-37634 PE-sign-all with no pending certs returns 200 with expected payload"
+        (let [response (http-client/post
+                         "https://localhost:8140/puppet-ca/v1/sign/all"
+                         {:ssl-cert (str bootstrap/server-conf-dir "/ca/ca_crt.pem")
+                          :ssl-key (str bootstrap/server-conf-dir "/ca/ca_key.pem")
+                          :ssl-ca-cert (str bootstrap/server-conf-dir "/ca/ca_crt.pem")
+                          :as :text
+                          :headers {"Accept" "application/json"}})]
+          (is (= 200 (:status response)))
+          (is (= {:signed []
+                  :no-csr []
+                  :signing-errors []}
+                 (json/parse-string (:body response) true)))))
       (testing "returns 200 with valid payload"
         ;; note- more extensive testing of the behavior is done with the testing in sign-multiple-certificate-signing-requests!-test
         (let [certname (ks/rand-str :alpha-lower 16)


### PR DESCRIPTION
Prior to this change, if the sign-all behavior was invoked for the CA service, an exception would be thrown because the function returns a result that wasn't expected. This adds a test that demonstrates the failure, and adds a fix to get the test to pass.