### PR TITLE
(maint) Improve code scripts test

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -65,6 +65,7 @@ step 'SETUP: Install and configure git server' do
       ensure => present,
       # shell => '/usr/bin/git-shell',
       home => '/home/git',
+      password => '*',
       managehome => true,
       system => true,
       }


### PR DESCRIPTION
By default when Puppet creates a user the password is recorded as having a sentinel value of an exclamation mark. This special value prevents users from logging in via password - though the root user can still `su` to it locally - and by default SSHD will not allow access to these "locked" accounts.

Most of our acceptance VMs specially configure SSHD to allow access to these "locked" accounts, but not our newer Almalinux VMs.

By giving the git user an explicit password we can connect via SSH to the git user, regardless of the SSHD configuration on the VM. The star ("*") used for the git user's password is also a special sentinel value which prevents logging into the user via password, but will not be considered "locked" by SSHD.

For reference see:
https://unix.stackexchange.com/questions/193066/how-to-unlock-account-for-public-key-ssh-authorization-but-not-for-password-aut