### PR TITLE
(maint) remove metrics dependency in self-referential inclusion

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -175,7 +175,7 @@
                                                [puppetlabs/jruby-utils]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [com.puppetlabs/trapperkeeper-webserver-jetty10]
-                                               [puppetlabs/trapperkeeper-metrics "2.0.1"]]
+                                               [puppetlabs/trapperkeeper-metrics]]
                       :plugins [[puppetlabs/lein-ezbake "2.5.5"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]


### PR DESCRIPTION
The metrics version being included in the `ezbake->dependencies` was
pulling in a older version of metrics. The version of metrics is now
managed at the clj-parent level, so this removes the pin.