### PR TITLE
(SERVER-3339) Prepare for 8.5.0 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ps-version "8.4.1-SNAPSHOT")
+(def ps-version "8.5.0-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
HEAD of main has gone through all testing required for release, but this needs to be updated to release the agreed to 8.5.0 rather than 8.4.1.