### PR TITLE
Remove facter.jar from classpath

### DIFF
--- a/resources/ext/cli_defaults/cli-defaults.sh.erb
+++ b/resources/ext/cli_defaults/cli-defaults.sh.erb
@@ -20,4 +20,4 @@ if [[ $java_major_version -eq 17 ]]; then
 	fi
 fi
 
-CLASSPATH="${CLASSPATH}:/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter.jar:/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/jars/*"
+CLASSPATH="${CLASSPATH}:/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/jars/*"


### PR DESCRIPTION
Facter 4 was introduced in Puppet 7, so the facter.jar from Facter 3 is no longer needed.