### PR TITLE
(PE-37583) add action tracking routine

### DIFF
--- a/src/clj/puppetlabs/puppetserver/common.clj
+++ b/src/clj/puppetlabs/puppetserver/common.clj
@@ -141,3 +141,15 @@
              (subs s 0 (- (count s) suffix-size))
              s))
          files)))
+
+(def action-registraton-function (atom (constantly nil)))
+
+(schema/def action-shape
+  {:type (schema/enum "add" "remove" "info" "action")
+   :targets [schema/Str]
+   :meta schema/Any})
+
+(schema/defn record-action
+  [action :- action-shape]
+  (@action-registraton-function action))
+


### PR DESCRIPTION
This adds a routine, that defaults to a function that does nothing that will be used for action tracking within the CA.