### PR TITLE
(PE-37584) add action tracking for csr signing requests

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1802,6 +1802,7 @@
       (validate-duplicate-cert-policy! csr settings)
       (validate-subject! subject (get-csr-subject csr))
       (save-certificate-request! subject csr csrdir)
+      (common/record-action {:type :info :targets [subject] :meta {:what :csr :action :submit}})
       (when (autosign-csr? autosign subject csr-stream ruby-load-path gem-path)
         (ensure-subject-alt-names-allowed! csr allow-subject-alt-names)
         (ensure-no-authorization-extensions! csr allow-authorization-extensions)

--- a/src/clj/puppetlabs/puppetserver/common.clj
+++ b/src/clj/puppetlabs/puppetserver/common.clj
@@ -142,14 +142,14 @@
              s))
          files)))
 
-(def action-registraton-function (atom (constantly nil)))
+(def action-registration-function (atom (constantly nil)))
 
 (schema/def action-shape
-  {:type (schema/enum "add" "remove" "info" "action")
+  {:type (schema/enum :add :remove :info :action)
    :targets [schema/Str]
    :meta schema/Any})
 
 (schema/defn record-action
   [action :- action-shape]
-  (@action-registraton-function action))
+  (@action-registration-function action))
 


### PR DESCRIPTION
This adds tracking to the csr requests to report what csrs are submitted. This will be used for overall host activity tracking.

White box tests are added to demonstrate the behavior.