### PR TITLE
(PE-37585) add action tracking to certificate signing behaviors

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1687,6 +1687,7 @@
                                             (create-agent-extensions
                                              csr
                                              cacert))]
+    (common/record-action {:type :add :targets [subject] :meta {:type :certificate}})
     (write-cert-to-inventory! signed-cert ca-settings)
     (write-cert signed-cert (path-to-cert signeddir subject))
     (delete-certificate-request! ca-settings subject)
@@ -2514,5 +2515,6 @@
                   result))]
           ;; submit the signing activity as one entry for all the hosts.
           (when-not (empty? (:signed results))
+            (common/record-action {:type :add :targets (:signed results) :meta {:type :certificate}})
             (report-activity (:signed results) "signed"))
           results)))))


### PR DESCRIPTION
This adds action tracking to the certificate signing behaviors for both the "single sign" behavior and "bulk signing".  Renewals are intentionally ignored.

Tests are added to demonstrate the behaviors.