### PR TITLE
(PE-37586) add revocation action tracking to revocation routine 

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -184,7 +184,8 @@
         (let [{existing-certs true
                missing-certs false} (group-by
                                      #(certificate-issued? ca-settings %)
-                                     certnames)
+                                     ;; ensure we process a unique set of certnames
+                                     (distinct certnames))
               message (when (seq missing-certs)
                         (format "The following certs do not exist and cannot be revoked: %s"
                                 (vec missing-certs)))


### PR DESCRIPTION
This adds action tracking to the certificate revocation routine.
The list of names comes in from input. The routine will throw
and exception if the certnames aren't found in the inventory
file or on disk, so it is reasonable to report removal in
any regard. This could mean that a host that is already removed
will be reported removed again, but this isn't a big issue.

Tests were added to demonstrate the behaviors.
