### PR TITLE
(maint) drop absolute symlinks pointing to tmpdirs

### DIFF
--- a/acceptance/suites/tests/certificate_authority/fixtures/certdir/391489c4.0
+++ b/acceptance/suites/tests/certificate_authority/fixtures/certdir/391489c4.0
@@ -1,1 +1,0 @@
-/tmp/certchain.HHLFb2ep/agent-ca/ca-agent-ca.crt

--- a/acceptance/suites/tests/certificate_authority/fixtures/certdir/391489c4.r0
+++ b/acceptance/suites/tests/certificate_authority/fixtures/certdir/391489c4.r0
@@ -1,1 +1,0 @@
-/tmp/certchain.HHLFb2ep/agent-ca/ca-agent-ca.crl

--- a/acceptance/suites/tests/certificate_authority/fixtures/certdir/39f49c14.0
+++ b/acceptance/suites/tests/certificate_authority/fixtures/certdir/39f49c14.0
@@ -1,1 +1,0 @@
-/tmp/certchain.HHLFb2ep/root/ca-root.crt

--- a/acceptance/suites/tests/certificate_authority/fixtures/certdir/39f49c14.r0
+++ b/acceptance/suites/tests/certificate_authority/fixtures/certdir/39f49c14.r0
@@ -1,1 +1,0 @@
-/tmp/certchain.HHLFb2ep/root/ca-root.crl

--- a/acceptance/suites/tests/certificate_authority/fixtures/certdir/4fe5e8ad.0
+++ b/acceptance/suites/tests/certificate_authority/fixtures/certdir/4fe5e8ad.0
@@ -1,1 +1,0 @@
-/tmp/certchain.HHLFb2ep/master-ca/ca-master-ca.crt

--- a/acceptance/suites/tests/certificate_authority/fixtures/certdir/4fe5e8ad.r0
+++ b/acceptance/suites/tests/certificate_authority/fixtures/certdir/4fe5e8ad.r0
@@ -1,1 +1,0 @@
-/tmp/certchain.HHLFb2ep/master-ca/ca-master-ca.crl


### PR DESCRIPTION
These symlinks were most likely mistakenly added as part of 3d275466ac20bf991f6a129dd5ef4e261811c00a, and serve no purpose that I could find.

They were flagged by Debian's [Lintian](https://wiki.debian.org/Lintian) tool in the distro's own [puppetserver](https://tracker.debian.org/pkg/puppetserver) package.