### PR TITLE
(issue) only issue GET requests for concrete files

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -439,10 +439,16 @@
     (ca/delete-certificate-request! settings subject))
 
   :exists?
-  (fn [_context]
-    (or
-      (certificate-issued? settings subject)
-      (ca/csr-exists? settings subject)))
+  (fn [context]
+    ;; if we actually want to get the certificate state, we only care if the files
+    ;; really exist, not if they are in the inventory file
+    (if (= :get (get-in context [:request :request-method]))
+      (or
+        (ca/certificate-exists? settings subject)
+        (ca/csr-exists? settings subject))
+      (or
+        (certificate-issued? settings subject)
+        (ca/csr-exists? settings subject))))
 
   :handle-conflict
   (fn [context]

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -1889,3 +1889,57 @@
                           :ssl-ca-cert (str bootstrap/server-conf-dir "/ca/ca_crt.pem")
                           :as          :text})]
           (is (= 404 (:status response))))))))
+
+(deftest issue-2851-deleted-cert-still-in-inventory
+  (let [cert-path (str bootstrap/server-conf-dir "/ssl/certs/localhost.pem")
+        key-path (str bootstrap/server-conf-dir "/ssl/private_keys/localhost.pem")
+        ca-cert-path (str bootstrap/server-conf-dir "/ca/ca_crt.pem")
+        crl-path (str bootstrap/server-conf-dir "/ssl/crl.pem")
+        test-service (tk-services/service
+                       act-proto/ActivityReportingService
+                       []
+                       (report-activity! [_this body]
+                                         (throw (Exception. "Foo"))))]
+    (testing "returns expiration dates for all CA certs and CRLs"
+      (testutils/with-stub-puppet-conf
+        (bootstrap/with-puppetserver-running-with-services
+          app
+          (concat (bootstrap/services-from-dev-bootstrap) [test-service])
+          {:jruby-puppet
+           {:gem-path [(ks/absolute-path jruby-testutils/gem-path)]}
+           :webserver
+           {:ssl-cert cert-path
+            :ssl-key key-path
+            :ssl-ca-cert ca-cert-path
+            :ssl-crl-path crl-path}}
+          (let [certname "test_cert"
+                csr (ssl-utils/generate-certificate-request
+                      (ssl-utils/generate-key-pair)
+                      (ssl-utils/cn certname))
+                csr-path (str bootstrap/server-conf-dir "/ca/requests/" certname ".pem")
+                status-url (str "https://localhost:8140/puppet-ca/v1/certificate_status/" certname)
+                request-opts {:ssl-cert cert-path
+                              :ssl-key key-path
+                              :ssl-ca-cert ca-cert-path}]
+
+            (ssl-utils/obj->pem! csr csr-path)
+            (testing "Sign the waiting CSR"
+              (logutils/with-test-logging
+                (let [response (http-client/put
+                                 status-url
+                                 (merge request-opts
+                                        {:body "{\"desired_state\": \"signed\"}"
+                                         :headers {"content-type" "application/json"}}))]
+                  (is (= 204 (:status response))))))
+            (testing "Delete the cert"
+              (logutils/with-test-logging
+                (let [response (http-client/delete
+                                 status-url
+                                 (merge request-opts
+                                        {:headers {"content-type" "application/json" "X-Authentication" "test"}}))]
+                  (is (= 204 (:status response))))))
+            (testing "getting the cert returns a 404"
+              (let [response (http-client/get status-url
+                         (merge request-opts
+                                {:headers {"content-type" "application/json" "X-Authentication" "test"}}))]
+                (is (= 404 (:status response)))))))))))


### PR DESCRIPTION
The inventory is managed in several ways in the CA, including an inventory file, which records certificates, expiration periods and serial numbers. In the case where we want to get the actual certificate status, we don't want to use the inventory file. The liberator `exists` method was checking in both the filesystem and the inventory file for the certificate in question for a `GET` request.  This alters that behavior to only check the file system under those circumstances.

A test is added to demonstrate the behavior.

Resolves https://github.com/puppetlabs/puppetserver/issues/2851