### PR TITLE
(SERVER-3051) Pass cwd through to ShellUtils

### DIFF
--- a/spec/fixtures/puppet-server-lib/puppet/jvm/execution_spec/echo_cwd.sh
+++ b/spec/fixtures/puppet-server-lib/puppet/jvm/execution_spec/echo_cwd.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "cwd is $PWD"

--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -29,6 +29,13 @@ describe Puppet::Server::Execution do
       expect(result).to match(/hello stderr/)
     end
 
+    it "should set the current working directory" do
+      tmpdir = Dir.tmpdir
+      result = test_execute(File.join(__dir__, "../../../../spec/fixtures/puppet-server-lib/puppet/jvm/execution_spec/echo_cwd.sh"),
+                            {:cwd => tmpdir})
+      expect(result).to match(/cwd is #{Regexp.escape(tmpdir)}/)
+    end
+
     it "should return an instance of ProcessOutput for a command with args" do
       result = test_execute(["echo", "hi"])
       expect(result).to be_a Puppet::Util::Execution::ProcessOutput

--- a/src/ruby/puppetserver-lib/puppet/server/execution.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/execution.rb
@@ -34,6 +34,10 @@ class Puppet::Server::Execution
       exe_options.combine_stdout_stderr = true
     end
 
+    if options[:cwd]
+      exe_options.working_directory = options[:cwd]
+    end
+
     if args && !args.empty?
       result = ShellUtils.executeCommand(binary, args.to_java(:string), exe_options)
     else


### PR DESCRIPTION
If a `cwd` option is passed in Puppet::Util::Execution.execute, then pass it through to ShellUtils.executeCommand.