### PR TITLE
(PE-37713) Update lein to 2.11.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
   :license {:name "Apache License, Version 2.0"
               :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :min-lein-version "2.9.1"
+  :min-lein-version "2.11.2"
 
   :parent-project {:coords [puppetlabs/clj-parent "7.3.26"]
                    :inherit [:managed-dependencies]}
@@ -176,7 +176,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [com.puppetlabs/trapperkeeper-webserver-jetty10]
                                                [puppetlabs/trapperkeeper-metrics]]
-                      :plugins [[puppetlabs/lein-ezbake "2.5.5"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.6.1"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [com.puppetlabs/trapperkeeper-webserver-jetty10]]


### PR DESCRIPTION
To complement https://github.com/puppetlabs/pe-puppet-server-extensions/pull/1548.

ezbake upgrade not necessary for this project but doesn't hurt

Testing pe-pse jenkins jobs with lein 2.11.2 right now
https://jenkins-enterprise.delivery.puppetlabs.net/job/enterprise_pe-puppet-server-extensions_packaging-os-clj_lein-ezbake-stage_main/775/