### PR TITLE
(maint) Regenerate test CA certificates

### DIFF
--- a/dev-resources/regen_certs.rb
+++ b/dev-resources/regen_certs.rb
@@ -22,14 +22,14 @@ module PuppetSpec
       OpenSSL::PKey::RSA.new(length)
     end
 
-    def self.self_signed_ca(key, name)
+    def self.self_signed_ca(key, name, serial = rand(2**128))
       cert = OpenSSL::X509::Certificate.new
 
       cert.public_key = key.public_key
       cert.subject = OpenSSL::X509::Name.parse(name)
       cert.issuer = cert.subject
       cert.version = 2
-      cert.serial = rand(2**128)
+      cert.serial = serial
 
       not_before = just_now
       cert.not_before = not_before
@@ -46,7 +46,34 @@ module PuppetSpec
       cert
     end
 
-    def self.create_csr(key, name)
+	def self.create_crl(ca_cert, ca_key, revoked_cert, serial)
+	  crl = OpenSSL::X509::CRL.new
+
+	  crl.issuer = ca_cert.issuer
+	  crl.version = 1
+	  last_update = just_now
+	  crl.last_update = last_update
+	  crl.next_update = last_update + FIVE_YEARS
+
+	  revoked = OpenSSL::X509::Revoked.new
+	  revoked.serial = revoked_cert.serial
+	  revoked.time = just_now
+	  crl.add_revoked(revoked)
+
+	  crlnum = OpenSSL::ASN1::Integer(serial)
+	  crl.add_extension(OpenSSL::X509::Extension.new('crlNumber', crlnum))
+
+	  ef = OpenSSL::X509::ExtensionFactory.new
+	  ef.issuer_certificate = ca_cert
+	  ef.crl = crl
+	  crl.add_extension(ef.create_extension('authorityKeyIdentifier', 'keyid:always'))
+
+	  crl.sign(ca_key, DEFAULT_SIGNING_DIGEST)
+
+	  crl
+	end
+
+    def self.create_csr(name, key = PuppetSpec::SSL.create_private_key)
       csr = OpenSSL::X509::Request.new
 
       csr.public_key = key.public_key
@@ -57,14 +84,14 @@ module PuppetSpec
       csr
     end
 
-    def self.sign(ca_key, ca_cert, csr, extensions = NODE_EXTENSIONS)
+    def self.sign(ca_key, ca_cert, csr, serial = rand(2**128), extensions = NODE_EXTENSIONS)
       cert = OpenSSL::X509::Certificate.new
 
       cert.public_key = csr.public_key
       cert.subject = csr.subject
       cert.issuer = ca_cert.subject
       cert.version = 2
-      cert.serial = rand(2**128)
+      cert.serial = serial
 
       not_before = just_now
       cert.not_before = not_before
@@ -101,11 +128,13 @@ module PuppetSpec
   end
 end
 
+puts 'Regenerating certificates for puppetlabs.puppetserver.ruby.http-client-test ...'
+
 ca_key = PuppetSpec::SSL.create_private_key
 ca_cert = PuppetSpec::SSL.self_signed_ca(ca_key, "/CN=Puppet CA: swanson.hsd1.or.comcast.net")
 
 host_key = PuppetSpec::SSL.create_private_key
-host_csr = PuppetSpec::SSL.create_csr(host_key, "/CN=localhost")
+host_csr = PuppetSpec::SSL.create_csr("/CN=localhost", host_key)
 host_cert = PuppetSpec::SSL.sign(ca_key, ca_cert, host_csr)
 
 http_client_test_dir = "#{__dir__}/puppetlabs/puppetserver/ruby/http_client_test"
@@ -119,3 +148,60 @@ end
 File.open("#{http_client_test_dir}/localhost_key.pem", 'w') do |f|
   f.puts(host_key)
 end
+
+puts 'Regenerating certificates for puppetlabs.puppetserver.certificate-authority-test ...'
+
+ca_key = PuppetSpec::SSL.create_private_key
+ca_cert = PuppetSpec::SSL.self_signed_ca(ca_key, "/CN=Puppet CA: localhost", 1)
+test_agent_csr = PuppetSpec::SSL.create_csr("/CN=test-agent")
+localhost_csr = PuppetSpec::SSL.create_csr("/CN=localhost")
+localhost_cert = PuppetSpec::SSL.sign(ca_key, ca_cert, localhost_csr, 2)
+test_cert_csr = PuppetSpec::SSL.create_csr("/CN=test_cert")
+test_cert = PuppetSpec::SSL.sign(ca_key, ca_cert, test_cert_csr, 3)
+revoked_agent_csr = PuppetSpec::SSL.create_csr("/CN=revoked-agent")
+revoked_agent_cert = PuppetSpec::SSL.sign(ca_key, ca_cert, revoked_agent_csr, 4)
+ca_crl = PuppetSpec::SSL.create_crl(ca_cert, ca_key, revoked_agent_cert, 1)
+
+ca_dir = "#{__dir__}/puppetlabs/puppetserver/certificate_authority_test/master/conf/ca"
+
+File.open("#{ca_dir}/ca_key.pem", 'w') do |f|
+  f.puts(ca_key)
+end
+File.open("#{ca_dir}/ca_pub.pem", 'w') do |f|
+  f.puts(ca_key.public_key)
+end
+File.open("#{ca_dir}/ca_crt.pem", 'w') do |f|
+  f.puts(ca_cert)
+end
+File.open("#{ca_dir}/requests/test-agent.pem", 'w') do |f|
+  f.puts(test_agent_csr)
+end
+File.open("#{ca_dir}/signed/localhost.pem", 'w') do |f|
+  f.puts(localhost_cert)
+end
+File.open("#{ca_dir}/signed/test_cert.pem", 'w') do |f|
+  f.puts(test_cert)
+end
+File.open("#{ca_dir}/signed/revoked-agent.pem", 'w') do |f|
+  f.puts(revoked_agent_cert)
+end
+File.open("#{ca_dir}/ca_crl.pem", 'w') do |f|
+  f.puts(ca_crl)
+end
+File.open("#{ca_dir}/serial", 'w') do |f|
+  f.write('0005')
+end
+File.open("#{ca_dir}/infra_crl.pem", 'w') { |f| f.truncate(0) }
+File.open("#{ca_dir}/infra_serials", 'w') { |f| f.truncate(0) }
+File.open("#{ca_dir}/inventory.txt", 'w') do |f|
+  for cert in [ ca_cert, localhost_cert, test_cert, revoked_agent_cert ] do
+    serial_hex = "0x#{cert.serial.to_s(16).rjust(4, '0')}"
+    not_before = cert.not_before.strftime('%Y-%m-%dT%H:%M:%SUTC')
+    not_after = cert.not_after.strftime('%Y-%m-%dT%H:%M:%SUTC')
+    subject = cert.subject
+
+    f.puts("#{serial_hex} #{not_before} #{not_after} #{subject}")
+  end
+end
+
+puts "Done."

--- a/dev-resources/regen_certs.rb
+++ b/dev-resources/regen_certs.rb
@@ -108,12 +108,14 @@ host_key = PuppetSpec::SSL.create_private_key
 host_csr = PuppetSpec::SSL.create_csr(host_key, "/CN=localhost")
 host_cert = PuppetSpec::SSL.sign(ca_key, ca_cert, host_csr)
 
-File.open('ca.pem', 'w') do |f|
+http_client_test_dir = "#{__dir__}/puppetlabs/puppetserver/ruby/http_client_test"
+
+File.open("#{http_client_test_dir}/ca.pem", 'w') do |f|
   f.puts(ca_cert)
 end
-File.open('localhost_cert.pem', 'w') do |f|
+File.open("#{http_client_test_dir}/localhost_cert.pem", 'w') do |f|
   f.puts(host_cert)
 end
-File.open('localhost_key.pem', 'w') do |f|
+File.open("#{http_client_test_dir}/localhost_key.pem", 'w') do |f|
   f.puts(host_key)
 end

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -1125,11 +1125,11 @@
       (is (realized? caught-timeout)))))
 
 (defn verify-inventory-entry!
-  [inventory-entry serial-number not-before not-after subject]
+  [inventory-entry serial-number subject]
   (let [parts (string/split inventory-entry #" ")]
     (is (= serial-number (first parts)))
-    (is (= not-before (second parts)))
-    (is (= not-after (nth parts 2)))
+    (is (re-matches #"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}UTC" (second parts)))
+    (is (re-matches #"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}UTC" (nth parts 2)))
     (is (= subject (string/join " " (subvec parts 3))))))
 
 (deftest test-write-cert-to-inventory
@@ -1152,15 +1152,11 @@
           (verify-inventory-entry!
             (first entries)
             "0x0001"
-            "2020-08-19T20:23:52UTC"
-            "2025-08-19T20:23:52UTC"
             "/CN=Puppet CA: localhost")
 
           (verify-inventory-entry!
             (second entries)
             "0x0002"
-            "2020-08-19T20:26:02UTC"
-            "2025-08-19T20:26:02UTC"
             "/CN=localhost"))))))
 
 (deftest allow-duplicate-certs-test


### PR DESCRIPTION
In less than one year, the test CA certificates shipped as part of the testsuite will be expire.

This PR improves the `dev-resources/regen_certs.rb` script, so that it:

- Installs the regenerated certificates in the correct directories instead of the current working directory
- Regenerates test CA certificates in addition to HTTP certificates

In addition, it make a small adjustment to a CA unit test to remove hard-coded expiry dates

This change will also help with reproducibility testing where the date/time environment is made to vary.