### PR TITLE
(SERVER-3379): Updated ezbake build version to support debian-12-x86_64 build for puppetserver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -176,7 +176,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [com.puppetlabs/trapperkeeper-webserver-jetty10]
                                                [puppetlabs/trapperkeeper-metrics]]
-                      :plugins [[puppetlabs/lein-ezbake "2.5.5"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.6.2"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [com.puppetlabs/trapperkeeper-webserver-jetty10]]


### PR DESCRIPTION
Updated ezbake (via PR https://github.com/puppetlabs/ezbake/pull/629) build version from 2.5.5 to [2.6.2](https://repo.clojars.org/puppetlabs/lein-ezbake/2.6.2/), as this newer version includes the support for debian-12-x86_64.

This will be used to build puppetserver for debian-12-x86_64