### PR TITLE
(PE-38408) Remove expensive Regexes from puppet profiler Java impl

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
@@ -269,7 +269,7 @@
     (do
       (.update wait-timer
         (- (System/currentTimeMillis) (:time ta))
-        (TimeUnit/MILLISECONDS))
+        TimeUnit/MILLISECONDS)
       (swap! requested-instances dissoc requested-event))
     (log/warn (trs "Unable to find request event for borrowed JRuby instance: {0}" event))))
 
@@ -281,8 +281,8 @@
     (if-let [ta (get @borrowed-instances worker-id)]
       (let [elapsed-time (- (System/currentTimeMillis) (:time ta))
             per-reason-timer (timer-for-borrow-reason metrics ta)]
-        (.update borrow-timer elapsed-time (TimeUnit/MILLISECONDS))
-        (.update per-reason-timer elapsed-time (TimeUnit/MILLISECONDS))
+        (.update borrow-timer elapsed-time TimeUnit/MILLISECONDS)
+        (.update per-reason-timer elapsed-time TimeUnit/MILLISECONDS)
         (MDC/put "jruby.borrow-time" (Long/toString elapsed-time))
         (swap! borrowed-instances dissoc worker-id))
       (log/warn (trs "JRuby instance ''{0}'' returned, but no record of when it was borrowed!" worker-id)))))
@@ -314,7 +314,7 @@
     (do
       (.update lock-wait-timer
                (- (System/currentTimeMillis) (:time lock-request))
-               (TimeUnit/MILLISECONDS))
+               TimeUnit/MILLISECONDS)
       (swap! lock-requests assoc
              lock-request-id
              {:state :acquired
@@ -330,7 +330,7 @@
     (do
       (.update lock-held-timer
                (- (System/currentTimeMillis) (:time lock-request))
-               (TimeUnit/MILLISECONDS))
+               TimeUnit/MILLISECONDS)
       (swap! lock-requests dissoc lock-request-id))
     (log/warn (trs "Lock request ''{0}'' released, but no record of when it was acquired!"
                    lock-request-id)))

--- a/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
+++ b/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
@@ -136,9 +136,11 @@ public class MetricsPuppetProfiler implements PuppetProfiler {
 
                 if (
                     ("resource".equals(secondElement) && "search".equals(thirdElemet)) ||
-		    ("facts".equals(secondElement) && "encode".equals(thirdElemet)) ||
-		    ("catalog".equals(secondElement) && "munge".equals(thirdElemet)) ||
-		    ("report".equals(secondElement) && "convert_to_wire_format_hash".equals(thirdElemet))
+		    ("payload".equals(secondElement) && "format".equals(thirdElemet)) ||
+		    // Set.of would be preferrable but 7.x still support Java 8, which does not have Set.of
+		    ("facts".equals(secondElement) && Arrays.asList("save", "find", "search", "encode").contains(thirdElemet)) ||
+		    ("catalog".equals(secondElement) && Arrays.asList("save", "munge").contains(thirdElemet)) ||
+		    ("report".equals(secondElement) && Arrays.asList("convert_to_wire_format_hash", "process").contains(thirdElemet))
 		) {
                     String key = String.join(".", secondElement, thirdElemet);
                     Timer metric = metricsByID.get(getMetricName(sliceOfArrayToList(metricId, 3)));


### PR DESCRIPTION
We have triggered a nasty performance regression in the JVM with some of our Regex usage in the MetricsPuppetProfiler. Regardless of the performance regression, our Regex usage is unnecessary and unneedlessly expensive.