### PR TITLE
(SERVER-3390): Fix smoke acceptance test suite for puppetserver in 7.x stream

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -41,7 +41,7 @@ teardown do
   on(master, "rm -rf #{git_repo_parentdir}", :accept_all_exit_codes => true)
   on(master, "rm -rf #{git_local_repo}", :accept_all_exit_codes => true)
   on(master, 'rm -rf /home/git/.ssh/authorized_keys', :accept_all_exit_codes => true)
- 
+
   #remove code_* scripts.
   on(master, 'rm -rf /opt/puppetlabs/server/apps/puppetserver/code-id-command_script.sh')
   on(master, 'rm -rf /opt/puppetlabs/server/apps/puppetserver/code_content_script.sh')
@@ -59,7 +59,7 @@ step 'SETUP: Generate a new ssh key for the root user account to use with the gi
   gittest_key=on(master, "awk '{print $2}' /root/.ssh/gittest_rsa.pub").stdout.chomp
 
 step 'SETUP: Install and configure git server' do
-  on(master, 'puppet module install puppetlabs-git') 
+  on(master, 'puppet module install puppetlabs-git')
   git_config=<<-GIT
     user { 'git':
       ensure => present,
@@ -124,7 +124,7 @@ step 'SETUP: Install and configure r10k, and perform the initial commit' do
   on master, "puppet config set server #{fqdn}"
   # For puppet 7 with ruby 2.7 we need to pin back to a ruby 2 compatable gem
   on master, '/opt/puppetlabs/puppet/bin/gem install faraday -v 2.8.1'
-  on master, '/opt/puppetlabs/puppet/bin/gem install r10k'
+  on master, '/opt/puppetlabs/puppet/bin/gem install r10k --no-document'
   on master, "cd #{git_local_repo} && git checkout -b production"
   r10k_yaml=<<-R10K
 # The location to use for storing cached Git repos
@@ -186,13 +186,13 @@ PP
   create_remote_file(master, "#{git_local_repo}/site/profile/manifests/base.pp", base_pp)
   on master, "cd #{git_local_repo} && git add ."
   on master, "cd #{git_local_repo} && git commit -m 'commit to setup r10k example'"
-  on master, "cd #{git_local_repo} && git push origin production"  
+  on master, "cd #{git_local_repo} && git push origin production"
   on master, "/opt/puppetlabs/puppet/bin/r10k deploy environment -p"
 end
 
 step 'SETUP: Install the code-id-command script' do
   code_id_command_script=<<-CIC
-  #!/usr/bin/env sh  
+  #!/usr/bin/env sh
   /opt/puppetlabs/puppet/bin/r10k deploy display -p --detail $1 | grep signature | grep -oE '[0-9a-f]{40}'
   CIC
   create_remote_file(master, '/opt/puppetlabs/server/apps/puppetserver/code-id-command_script.sh', code_id_command_script)
@@ -201,7 +201,7 @@ step 'SETUP: Install the code-id-command script' do
 end
 
 step 'SETUP: Configure the code-id script' do
-  on master, 'puppet module install puppetlabs-hocon' 
+  on master, 'puppet module install puppetlabs-hocon'
   create_remote_file(master, '/tmp/config_code_id_command_script.pp', cicsetting() )
   on master, 'puppet apply /tmp/config_code_id_command_script.pp'
   reload_server


### PR DESCRIPTION
[Jenkins Pipeline for Smoke Acceptance test suite](https://jenkins-platform.delivery.puppetlabs.net/job/platform_puppetserver_integration-system_no-conditional_smoke-7.x/) is failing with following errors:

Error Snippet from [this]([url](https://jenkins-platform.delivery.puppetlabs.net/job/platform_puppetserver_integration-system_no-conditional_smoke-7.x/229/LAYOUT=ubuntu2204-64ma-64a,LDAP_TYPE=default,label=k8s-beaker/consoleFull)) pipeline

```
afraid-outpost.vmpooler-prod.puppet.net (afraid-outpost.vmpooler-prod.puppet.net) 20:25:25$ /opt/puppetlabs/puppet/bin/gem install r10k
13:25:25     ERROR:  While executing gem ... (NoMethodError)
13:25:50         undefined method `start_with' for "RDoc::Markup::Document":String
13:25:50     Did you mean?  start_with?
13:25:50     The `minitar` executable is no longer bundled with `minitar`. If you are
13:25:50     expecting this executable, make sure you also install `minitar-cli`.
13:25:50     Successfully installed minitar-0.12.1
13:25:50     Successfully installed jwt-2.9.1
13:25:50     Successfully installed erubi-1.13.0
13:25:50     Successfully installed gettext-3.4.9
13:25:50     Successfully installed fast_gettext-2.4.0
13:25:50     Successfully installed gettext-setup-1.1.0
13:25:50     Successfully installed faraday-follow_redirects-0.3.0
13:25:50     Successfully installed puppet_forge-5.0.4
13:25:50     Successfully installed log4r-1.1.10
13:25:50     Successfully installed cri-2.15.12
13:25:50     Successfully installed colored2-3.1.2
13:25:50     Successfully installed r10k-4.1.0
13:25:50     Parsing documentation for minitar-0.12.1
13:25:50     Installing ri documentation for minitar-0.12.1
```

Because of [this](https://jenkins-platform.delivery.puppetlabs.net/job/platform_puppetserver_integration-system_no-conditional_smoke-7.x/) pipeline failure, the changes pushed to `7.x` are not being merged into the `main` branch.

Following is the attached log of the tests I ran after the changes.

[smoke_acceptance_test_suite.log](https://github.com/user-attachments/files/17150930/smoke_acceptance_test_suite.log)

Lines of Interest:
Failing test starts @ line #4547
Failing step starts @ line #4713
