### PR TITLE
Revert "(SERVER-3379): Updated ezbake build version to support debian-12-x86_64 build for puppetserver"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -176,7 +176,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [com.puppetlabs/trapperkeeper-webserver-jetty10]
                                                [puppetlabs/trapperkeeper-metrics]]
-                      :plugins [[puppetlabs/lein-ezbake "2.6.2"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.5.5"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [com.puppetlabs/trapperkeeper-webserver-jetty10]]


### PR DESCRIPTION
This reverts commit c24578da0e8567a36d0cca9bfe9cd5071a91093c.

This particular change will get a merge up commit from a [PR #2879](https://github.com/puppetlabs/puppetserver/pull/2879) for 7.x branch. Therefore I am reverting this in main.

This will fix https://jenkins-platform.delivery.puppetlabs.net/view/puppetserver/view/all/job/platform_puppetserver_puppetserver-mergeup_7.x/148/console pipeline