### PR TITLE
Reapply "(SERVER-3379): Updated ezbake build version to support debian-12-x86_64 build for puppetserver"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -176,7 +176,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [com.puppetlabs/trapperkeeper-webserver-jetty10]
                                                [puppetlabs/trapperkeeper-metrics]]
-                      :plugins [[puppetlabs/lein-ezbake "2.5.5"]]
+                      :plugins [[puppetlabs/lein-ezbake "2.6.2"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [com.puppetlabs/trapperkeeper-webserver-jetty10]]


### PR DESCRIPTION
This reverts commit 76fbf1d61d2922f89364dae428356f4fae5e3843.

Yesterday, due to some confusion, I mistakenly thought that the changes related to the ezbake build version hadn't been merged from the 7.x branch, so I created a [PR #2889](https://github.com/puppetlabs/puppetserver/pull/2889) to revert the change, which was unnecessary.

I’d like to correct my mistake this time by reapplying the change.