### PR TITLE
(maint) Drop `csr.version = 2` setting

### DIFF
--- a/dev-resources/regen_certs.rb
+++ b/dev-resources/regen_certs.rb
@@ -78,7 +78,6 @@ module PuppetSpec
 
       csr.public_key = key.public_key
       csr.subject = OpenSSL::X509::Name.parse(name)
-      csr.version = 2
       csr.sign(key, DEFAULT_SIGNING_DIGEST)
 
       csr


### PR DESCRIPTION
OpenSSL versions 3.4.0 and later no longer support setting a CSR version other than 1, because there are no other valid versions. Rather, it is recommended to stop specificying a CSR version altogether.

https://github.com/openssl/openssl/commit/397051a40db2d68433b842e7505e8cf3c9effb36