### PR TITLE
Add path definitions and error checking to allow deployment of the dev server to defined paths

### DIFF
--- a/dev-setup
+++ b/dev-setup
@@ -2,11 +2,6 @@
 
 set -e
 
-# TODO: Ultimately it'd be nice to not hard-code these paths, because it is
-# not guaranteed to match up with the paths in puppetserver.conf or used by the
-# REPL.  That said, it doesn't seem like a great ROI to sort it out right now
-# because it will probably require introducing a new setting for the vendored gem
-# dir into puppetserver.conf.
 if [ -z "${ROOTDIR:-}" ]
 then
   ROOTDIR="${HOME}/.puppetlabs"
@@ -45,10 +40,6 @@ echo "Installing vendored gems"
 lein gem install --no-document "${gem_list[@]}"
 
 echo "Setting up puppet.conf for dev environment"
-
-# TODO: current implementation will simply overwrite puppet.conf.  Might be better
-# to add some checks at the beginning of this script, and abort the whole script
-# if it already exists.
 
 if [ -z "${MASTERHOST}" ]; then
     echo "    No value specified for environment variable 'MASTERHOST'; using 'localhost' for puppet certname."

--- a/dev-setup
+++ b/dev-setup
@@ -7,9 +7,24 @@ set -e
 # REPL.  That said, it doesn't seem like a great ROI to sort it out right now
 # because it will probably require introducing a new setting for the vendored gem
 # dir into puppetserver.conf.
-ROOTDIR="${HOME}/.puppetlabs"
-CONFDIR="${ROOTDIR}/etc/puppet"
-CODEDIR="${ROOTDIR}/etc/code"
+if [ -z "${ROOTDIR:-}" ]
+then
+  ROOTDIR="${HOME}/.puppetlabs"
+fi
+if [ -z "${CONFDIR:-}" ]
+then
+  CONFDIR="${ROOTDIR}/etc/puppet"
+fi
+if [ -z "${CODEDIR:-}" ]
+then
+  CODEDIR="${ROOTDIR}/etc/code"
+fi
+
+if ! [ -e "${CONFDIR}/puppet.conf" ] && [ -z "${FORCE:-}" ]
+then
+  echo "ERROR: ${CONFDIR}/puppet.conf already exists. Please run with FORCE=1 to overwrite" >&2
+  exit 1
+fi
 
 gem_list=()
 while read LINE


### PR DESCRIPTION
As noticed in the dev-setup script, there was a "TODO" requesting that ROOTDIR, CONFDIR and CODEDIR should be definable outside the script. Also a TODO to break when puppet.conf already exists. This change fixes those requests.